### PR TITLE
Config

### DIFF
--- a/pkg/pet/config/config_test.go
+++ b/pkg/pet/config/config_test.go
@@ -1,0 +1,371 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultPetConfig 测试默认Pet配置
+// 验证DefaultPetConfig返回正确默认值的配置
+func TestDefaultPetConfig(t *testing.T) {
+	cfg := DefaultPetConfig()
+
+	if len(cfg.Characters) != 1 {
+		t.Errorf("Characters length=%d, want 1", len(cfg.Characters))
+	}
+	if cfg.ActiveID != "pet_001" {
+		t.Errorf("ActiveID=%q, want %q", cfg.ActiveID, "pet_001")
+	}
+	if cfg.Voice == nil {
+		t.Error("Voice should not be nil")
+	}
+	if cfg.App == nil {
+		t.Error("App should not be nil")
+	}
+}
+
+// TestDefaultAppConfig 测试默认应用配置
+// 验证DefaultAppConfig返回正确的默认值（情绪启用、提醒启用、主动关怀启用等）
+func TestDefaultAppConfig(t *testing.T) {
+	cfg := DefaultAppConfig()
+
+	if !cfg.EmotionEnabled {
+		t.Error("EmotionEnabled should be true")
+	}
+	if !cfg.ReminderEnabled {
+		t.Error("ReminderEnabled should be true")
+	}
+	if !cfg.ProactiveCare {
+		t.Error("ProactiveCare should be true")
+	}
+	if cfg.ProactiveIntervalMinutes != 30 {
+		t.Errorf("ProactiveIntervalMinutes=%d, want 30", cfg.ProactiveIntervalMinutes)
+	}
+	if cfg.VoiceEnabled {
+		t.Error("VoiceEnabled should be false")
+	}
+	if cfg.Language != "zh-CN" {
+		t.Errorf("Language=%q, want %q", cfg.Language, "zh-CN")
+	}
+}
+
+// TestDefaultCharacterConfig 测试默认角色配置
+// 验证DefaultCharacterConfig返回正确的默认值
+func TestDefaultCharacterConfig(t *testing.T) {
+	cfg := DefaultCharacterConfig()
+
+	if cfg.ID != "pet_001" {
+		t.Errorf("ID=%q, want %q", cfg.ID, "pet_001")
+	}
+	if cfg.Name != "艾莉" {
+		t.Errorf("Name=%q, want %q", cfg.Name, "艾莉")
+	}
+	if cfg.PersonaType != "gentle" {
+		t.Errorf("PersonaType=%q, want %q", cfg.PersonaType, "gentle")
+	}
+}
+
+// TestDefaultEmotionState 测试默认情绪状态
+// 验证DefaultEmotionState返回六维情绪都为50（中性）的状态
+func TestDefaultEmotionState(t *testing.T) {
+	state := DefaultEmotionState()
+
+	if state.Joy != 50 {
+		t.Errorf("Joy=%d, want 50", state.Joy)
+	}
+	if state.Anger != 50 {
+		t.Errorf("Anger=%d, want 50", state.Anger)
+	}
+	if state.Sadness != 50 {
+		t.Errorf("Sadness=%d, want 50", state.Sadness)
+	}
+}
+
+// TestDefaultMBTI 测试默认MBTI配置
+// 验证DefaultMBTI返回四维都为50（中性）的配置
+func TestDefaultMBTI(t *testing.T) {
+	mbti := DefaultMBTI()
+
+	if mbti.IE != 50 {
+		t.Errorf("IE=%d, want 50", mbti.IE)
+	}
+	if mbti.SN != 50 {
+		t.Errorf("SN=%d, want 50", mbti.SN)
+	}
+	if mbti.TF != 50 {
+		t.Errorf("TF=%d, want 50", mbti.TF)
+	}
+	if mbti.JP != 50 {
+		t.Errorf("JP=%d, want 50", mbti.JP)
+	}
+}
+
+// TestDefaultVoiceConfig 测试默认语音配置
+// 验证DefaultVoiceConfig返回正确的默认值
+func TestDefaultVoiceConfig(t *testing.T) {
+	cfg := DefaultVoiceConfig()
+
+	if len(cfg.ModelList) != 0 {
+		t.Errorf("ModelList length=%d, want 0", len(cfg.ModelList))
+	}
+	if cfg.DefaultModel != "" {
+		t.Errorf("DefaultModel=%q, want empty", cfg.DefaultModel)
+	}
+	if cfg.ASREnabled {
+		t.Error("ASREnabled should be false")
+	}
+}
+
+// TestEmotionState_ToSixEmotions 测试情绪状态转换
+// 验证EmotionState能够正确转换为SixEmotions结构
+func TestEmotionState_ToSixEmotions(t *testing.T) {
+	state := &EmotionState{
+		Joy:      80,
+		Anger:    20,
+		Sadness:  60,
+		Disgust:  30,
+		Surprise: 70,
+		Fear:     40,
+	}
+
+	six := state.ToSixEmotions()
+	if six.Joy != 80 {
+		t.Errorf("Joy=%d, want 80", six.Joy)
+	}
+	if six.Anger != 20 {
+		t.Errorf("Anger=%d, want 20", six.Anger)
+	}
+}
+
+// TestNewConfigLoader 测试创建配置加载器
+// 验证NewConfigLoader返回有效的加载器实例
+func TestNewConfigLoader(t *testing.T) {
+	loader := NewConfigLoader("/tmp/test")
+	if loader == nil {
+		t.Fatal("NewConfigLoader returned nil")
+	}
+	if loader.WorkspacePath() != "/tmp/test" {
+		t.Errorf("WorkspacePath=%q, want %q", loader.WorkspacePath(), "/tmp/test")
+	}
+}
+
+// TestConfigLoader_Load_NotExist 测试加载不存在的配置文件
+// 验证配置文件不存在时使用默认配置
+func TestConfigLoader_Load_NotExist(t *testing.T) {
+	loader := NewConfigLoader("/nonexistent/path")
+	err := loader.Load()
+	if err != nil {
+		t.Errorf("Load failed: %v", err)
+	}
+
+	cfg := loader.GetConfig()
+	if cfg == nil {
+		t.Fatal("GetConfig returned nil after Load")
+	}
+	if cfg.ActiveID != "pet_001" {
+		t.Errorf("ActiveID=%q, want pet_001", cfg.ActiveID)
+	}
+}
+
+// TestConfigLoader_SaveAndLoad 测试配置保存和加载
+// 验证配置能够保存到文件并重新加载
+func TestConfigLoader_SaveAndLoad(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	err = loader.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	loader2 := NewConfigLoader(tmpDir)
+	err = loader2.Load()
+	if err != nil {
+		t.Fatalf("Load2 failed: %v", err)
+	}
+
+	if loader2.GetActiveID() != "pet_001" {
+		t.Errorf("ActiveID=%q, want %q", loader2.GetActiveID(), "pet_001")
+	}
+}
+
+// TestConfigLoader_GetCharacters 测试获取角色列表
+// 验证能够获取配置中的角色列表
+func TestConfigLoader_GetCharacters(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	chars := loader.GetCharacters()
+	if len(chars) == 0 {
+		t.Fatal("GetCharacters returned empty")
+	}
+	if chars[0].ID != "pet_001" {
+		t.Errorf("First character ID=%q, want pet_001", chars[0].ID)
+	}
+}
+
+// TestConfigLoader_GetVoice 测试获取语音配置
+// 验证能够获取语音配置
+func TestConfigLoader_GetVoice(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	voice := loader.GetVoice()
+	if voice == nil {
+		t.Fatal("GetVoice returned nil")
+	}
+}
+
+// TestConfigLoader_GetApp 测试获取应用配置
+// 验证能够获取应用配置
+func TestConfigLoader_GetApp(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	app := loader.GetApp()
+	if app == nil {
+		t.Fatal("GetApp returned nil")
+	}
+	if !app.EmotionEnabled {
+		t.Error("EmotionEnabled should be true")
+	}
+}
+
+// TestConfigLoader_LoadCharacterPrivateConfig_NotExist 测试加载不存在的私有配置
+// 验证不存在时返回默认私有配置
+func TestConfigLoader_LoadCharacterPrivateConfig_NotExist(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	cfg, err := loader.LoadCharacterPrivateConfig("nonexistent_id")
+	if err != nil {
+		t.Fatalf("LoadCharacterPrivateConfig failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadCharacterPrivateConfig returned nil")
+	}
+	if cfg.ID != "nonexistent_id" {
+		t.Errorf("ID=%q, want %q", cfg.ID, "nonexistent_id")
+	}
+}
+
+// TestConfigLoader_SaveCharacterPrivateConfig 测试保存角色私有配置
+// 验证私有配置能够保存到文件并重新加载
+func TestConfigLoader_SaveCharacterPrivateConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	cfg := &CharacterPrivateConfig{
+		ID: "test_char",
+		EmotionState: &EmotionState{
+			Joy: 80,
+		},
+		MBTI: &MBTIConfig{
+			IE: 30,
+		},
+	}
+
+	err = loader.SaveCharacterPrivateConfig(cfg)
+	if err != nil {
+		t.Fatalf("SaveCharacterPrivateConfig failed: %v", err)
+	}
+
+	loaded, err := loader.LoadCharacterPrivateConfig("test_char")
+	if err != nil {
+		t.Fatalf("LoadCharacterPrivateConfig failed: %v", err)
+	}
+	if loaded.EmotionState.Joy != 80 {
+		t.Errorf("Joy=%d, want 80", loaded.EmotionState.Joy)
+	}
+}
+
+// TestEnsureDefaultConfig 测试确保默认配置存在
+// 验证能够在指定目录下创建默认配置文件
+func TestEnsureDefaultConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	err = EnsureDefaultConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("EnsureDefaultConfig failed: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, PetConfigFile)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("PetConfigFile was not created")
+	}
+}
+
+// TestConfigLoader_GetVoiceModelConfig 测试获取语音模型配置
+// 验证能够根据名称获取语音模型配置
+func TestConfigLoader_GetVoiceModelConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	model := loader.GetVoiceModelConfig("nonexistent")
+	if model != nil {
+		t.Error("GetVoiceModelConfig should return nil for nonexistent model")
+	}
+}
+
+// TestConfigLoader_GetDefaultVoiceModel 测试获取默认语音模型
+// 验证当没有设置默认模型时返回nil
+func TestConfigLoader_GetDefaultVoiceModel(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	loader := NewConfigLoader(tmpDir)
+	loader.Load()
+
+	model := loader.GetDefaultVoiceModel()
+	if model != nil {
+		t.Error("GetDefaultVoiceModel should return nil when no default model is set")
+	}
+}

--- a/pkg/pet/config/loader.go
+++ b/pkg/pet/config/loader.go
@@ -9,26 +9,19 @@ import (
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
-const (
-	CharactersFile = "characters.json" // 角色配置文件名
-	VoiceFile      = "voice.json"      // 语音配置文件名
-)
-
 // ConfigLoader 配置加载器
-// 负责从工作区加载和管理characters.json与voice.json配置
+// 负责从工作区加载和管理pet_config.json统一配置
 type ConfigLoader struct {
-	workspacePath string            // 工作区路径
-	characters    *CharactersConfig // 角色配置
-	voice         *VoiceConfig      // 语音配置
+	config        *PetConfig // 统一配置
+	workspacePath string     // 工作区目录路径
 }
 
 // NewConfigLoader 创建配置加载器实例
-// workspacePath: 工作区目录路径，配置文件存放于此
+// workspacePath: 工作区目录路径
 func NewConfigLoader(workspacePath string) *ConfigLoader {
 	return &ConfigLoader{
+		config:        nil,
 		workspacePath: workspacePath,
-		characters:    &CharactersConfig{},
-		voice:         &VoiceConfig{},
 	}
 }
 
@@ -37,35 +30,29 @@ func (l *ConfigLoader) WorkspacePath() string {
 	return l.workspacePath
 }
 
-// Load 加载所有配置文件
-// 会加载characters.json和voice.json，如果文件不存在则返回错误
+// Load 加载统一配置文件pet_config.json
 func (l *ConfigLoader) Load() error {
-	if err := l.loadCharacters(); err != nil {
-		return fmt.Errorf("failed to load characters: %w", err)
-	}
-	if err := l.loadVoice(); err != nil {
-		return fmt.Errorf("failed to load voice: %w", err)
-	}
-	return nil
-}
-
-// loadCharacters 从characters.json加载角色配置
-func (l *ConfigLoader) loadCharacters() error {
-	path := filepath.Join(l.workspacePath, CharactersFile)
-
+	path := filepath.Join(l.workspacePath, PetConfigFile)
+	logger.Debugf("pet config: loading config from %s", path)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// 文件不存在，使用默认配置
+			l.config = DefaultPetConfig()
+			logger.Infof("pet config: no config file found, using defaults")
+			return nil
+		}
 		return fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
-	var cfg CharactersConfig
+	var cfg PetConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
 	// 至少需要一个角色
 	if len(cfg.Characters) == 0 {
-		return fmt.Errorf("no characters found in %s", path)
+		cfg.Characters = []*CharacterConfig{DefaultCharacterConfig()}
 	}
 
 	// 如果没有设置激活角色，默认激活第一个
@@ -73,79 +60,98 @@ func (l *ConfigLoader) loadCharacters() error {
 		cfg.ActiveID = cfg.Characters[0].ID
 	}
 
-	l.characters = &cfg
-	logger.Infof("pet config: loaded %d characters, active_id=%s", len(cfg.Characters), cfg.ActiveID)
+	// 确保voice和app不为nil
+	if cfg.Voice == nil {
+		cfg.Voice = DefaultVoiceConfig()
+	}
+	if cfg.App == nil {
+		cfg.App = DefaultAppConfig()
+	}
+
+	l.config = &cfg
+
+	logger.Infof("pet config: loaded config, active_id=%s, voice_enabled=%v", cfg.ActiveID, cfg.App.VoiceEnabled)
 	return nil
 }
 
-// loadVoice 从voice.json加载语音配置
-func (l *ConfigLoader) loadVoice() error {
-	path := filepath.Join(l.workspacePath, VoiceFile)
+// Save 保存配置到pet_config.json
+func (l *ConfigLoader) Save() error {
 
-	data, err := os.ReadFile(path)
+	if l.config == nil {
+		return fmt.Errorf("config not loaded")
+	}
+
+	path := filepath.Join(l.workspacePath, PetConfigFile)
+
+	// 确保目录存在
+	if err := os.MkdirAll(l.workspacePath, 0755); err != nil {
+		return fmt.Errorf("failed to create workspace dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(l.config, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", path, err)
-	}
-
-	var cfg VoiceConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("failed to parse %s: %w", path, err)
-	}
-
-	l.voice = &cfg
-	logger.Infof("pet config: loaded voice config, default_model=%s, asr_enabled=%v", cfg.DefaultModel, cfg.ASREnabled)
-	return nil
-}
-
-// GetCharacters 返回角色配置
-func (l *ConfigLoader) GetCharacters() *CharactersConfig {
-	return l.characters
-}
-
-// GetVoice 返回语音配置
-func (l *ConfigLoader) GetVoice() *VoiceConfig {
-	return l.voice
-}
-
-// GetActiveCharacter 返回当前激活的角色配置
-func (l *ConfigLoader) GetActiveCharacter() *CharacterConfig {
-	for _, c := range l.characters.Characters {
-		if c.ID == l.characters.ActiveID {
-			return c
-		}
-	}
-	return l.characters.Characters[0]
-}
-
-// SaveCharacters 保存角色配置到文件
-func (l *ConfigLoader) SaveCharacters() error {
-	path := filepath.Join(l.workspacePath, CharactersFile)
-	return l.saveJSON(path, l.characters)
-}
-
-// SaveVoice 保存语音配置到文件
-func (l *ConfigLoader) SaveVoice() error {
-	path := filepath.Join(l.workspacePath, VoiceFile)
-	return l.saveJSON(path, l.voice)
-}
-
-// saveJSON 将数据以JSON格式保存到文件
-func (l *ConfigLoader) saveJSON(path string, v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal: %w", err)
+		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 
+	logger.Infof("pet config: saved to %s", path)
 	return nil
+}
+
+// GetConfig 返回完整配置（只读）
+func (l *ConfigLoader) GetConfig() *PetConfig {
+	if l.config == nil {
+		return nil
+	}
+	cfg := *l.config // 返回副本
+	return &cfg
+}
+
+// GetActiveID 返回当前激活的角色ID（只读）
+func (l *ConfigLoader) GetActiveID() string {
+	if l.config == nil {
+		return ""
+	}
+	return l.config.ActiveID
+}
+
+// GetCharacters 返回角色列表（只读）
+func (l *ConfigLoader) GetCharacters() []*CharacterConfig {
+	if l.config == nil || l.config.Characters == nil {
+		return []*CharacterConfig{}
+	}
+	return l.config.Characters
+}
+
+// GetVoice 返回语音配置（只读）
+func (l *ConfigLoader) GetVoice() *VoiceConfig {
+	if l.config == nil || l.config.Voice == nil {
+		return DefaultVoiceConfig()
+	}
+	cfg := *l.config.Voice
+	return &cfg
+}
+
+// GetApp 返回应用配置（只读）
+func (l *ConfigLoader) GetApp() *AppConfig {
+	if l.config == nil || l.config.App == nil {
+		return DefaultAppConfig()
+	}
+	cfg := *l.config.App
+	return &cfg
 }
 
 // GetVoiceModelConfig 根据名称获取语音模型配置
 func (l *ConfigLoader) GetVoiceModelConfig(name string) *VoiceModelConfig {
-	for _, m := range l.voice.ModelList {
+
+	if l.config == nil || l.config.Voice == nil {
+		return nil
+	}
+
+	for _, m := range l.config.Voice.ModelList {
 		if m.Name == name {
 			return m
 		}
@@ -155,40 +161,108 @@ func (l *ConfigLoader) GetVoiceModelConfig(name string) *VoiceModelConfig {
 
 // GetDefaultVoiceModel 获取默认语音模型配置
 func (l *ConfigLoader) GetDefaultVoiceModel() *VoiceModelConfig {
-	if l.voice.DefaultModel == "" {
+
+	if l.config == nil || l.config.Voice == nil || l.config.Voice.DefaultModel == "" {
 		return nil
 	}
-	return l.GetVoiceModelConfig(l.voice.DefaultModel)
+
+	for _, m := range l.config.Voice.ModelList {
+		if m.Name == l.config.Voice.DefaultModel {
+			return m
+		}
+	}
+	return nil
+}
+
+// LoadCharacterPrivateConfig 加载角色私有配置
+func (l *ConfigLoader) LoadCharacterPrivateConfig(charID string) (*CharacterPrivateConfig, error) {
+
+	charPath := filepath.Join(l.workspacePath, WorkspacePath, charID, CharacterConfigFile)
+
+	data, err := os.ReadFile(charPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultCharacterPrivateConfig(charID), nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", charPath, err)
+	}
+
+	var cfg CharacterPrivateConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", charPath, err)
+	}
+
+	return &cfg, nil
+}
+
+// SaveCharacterPrivateConfig 保存角色私有配置
+func (l *ConfigLoader) SaveCharacterPrivateConfig(cfg *CharacterPrivateConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	charDir := filepath.Join(l.workspacePath, WorkspacePath, cfg.ID)
+	if err := os.MkdirAll(charDir, 0755); err != nil {
+		return fmt.Errorf("failed to create character dir: %w", err)
+	}
+
+	charPath := filepath.Join(charDir, CharacterConfigFile)
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	if err := os.WriteFile(charPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", charPath, err)
+	}
+
+	return nil
 }
 
 // EnsureDefaultConfig 确保配置目录中存在默认配置文件
-// 如果文件不存在则创建默认配置
 func EnsureDefaultConfig(workspacePath string) error {
-	charactersPath := filepath.Join(workspacePath, CharactersFile)
-	voicePath := filepath.Join(workspacePath, VoiceFile)
+	configPath := filepath.Join(workspacePath, PetConfigFile)
 
-	// 创建默认characters.json（如果不存在）
-	if _, err := os.Stat(charactersPath); os.IsNotExist(err) {
-		defaultCfg := &CharactersConfig{
-			Characters: []*CharacterConfig{DefaultCharacterConfig()},
-			ActiveID:   "pet_001",
-		}
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		defaultCfg := DefaultPetConfig()
 		data, _ := json.MarshalIndent(defaultCfg, "", "  ")
-		if err := os.WriteFile(charactersPath, data, 0644); err != nil {
-			return fmt.Errorf("failed to create default %s: %w", charactersPath, err)
+		if err := os.WriteFile(configPath, data, 0644); err != nil {
+			return fmt.Errorf("failed to create default %s: %w", configPath, err)
 		}
-		logger.Infof("pet config: created default %s", charactersPath)
+		logger.Infof("pet config: created default %s", configPath)
 	}
 
-	// 创建默认voice.json（如果不存在）
-	if _, err := os.Stat(voicePath); os.IsNotExist(err) {
-		defaultCfg := DefaultVoiceConfig()
-		data, _ := json.MarshalIndent(defaultCfg, "", "  ")
-		if err := os.WriteFile(voicePath, data, 0644); err != nil {
-			return fmt.Errorf("failed to create default %s: %w", voicePath, err)
-		}
-		logger.Infof("pet config: created default %s", voicePath)
+	// 同时确保私有配置目录存在
+	privatePath := filepath.Join(workspacePath, "workspaces")
+	if err := os.MkdirAll(privatePath, 0755); err != nil {
+		return fmt.Errorf("failed to create workspaces dir: %w", err)
 	}
 
+	return nil
+}
+
+// SavePetConfig 保存完整的 PetConfig 到文件
+func (l *ConfigLoader) SavePetConfig(cfg *PetConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	path := filepath.Join(l.workspacePath, PetConfigFile)
+
+	// 确保目录存在
+	if err := os.MkdirAll(l.workspacePath, 0755); err != nil {
+		return fmt.Errorf("failed to create workspace dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+
+	logger.Infof("pet config: saved to %s", path)
 	return nil
 }

--- a/pkg/pet/config/manager.go
+++ b/pkg/pet/config/manager.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"github.com/sipeed/picoclaw/pkg/logger"
+	"sync"
+)
+
+type Manager struct {
+	mu sync.RWMutex
+
+	configLoader *ConfigLoader
+
+	managerPath            string
+	characters             []*CharacterConfig
+	voiceConfig            *VoiceConfig
+	appConfig              *AppConfig
+	activeID               string
+	characterPrivateConfig *CharacterPrivateConfig
+}
+
+func NewManager(managerPath string) *Manager {
+	configLoader := NewConfigLoader(managerPath)
+	err := configLoader.Load()
+	if err != nil {
+		logger.Errorf("pet config: failed to load config, err=%v", err)
+		return nil
+	}
+
+	characterPrivateConfig, err := configLoader.LoadCharacterPrivateConfig(configLoader.GetActiveID())
+	if err != nil {
+		logger.Errorf("pet config: failed to load character private config, err=%v", err)
+		return nil
+	}
+
+	return &Manager{
+		managerPath:            managerPath,
+		configLoader:           configLoader,
+		characters:             configLoader.GetCharacters(),
+		voiceConfig:            configLoader.GetVoice(),
+		appConfig:              configLoader.GetApp(),
+		activeID:               configLoader.GetActiveID(),
+		characterPrivateConfig: characterPrivateConfig,
+	}
+}
+
+// Save 保存所有配置到文件
+func (m *Manager) Save() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// 2. 构建 PetConfig
+	petCfg := &PetConfig{
+		Characters: m.characters,
+		ActiveID:   m.activeID,
+		Voice:      m.voiceConfig,
+		App:        m.appConfig,
+	}
+
+	// 3. 保存公开配置
+	return m.configLoader.SavePetConfig(petCfg)
+}
+
+// GetCharacterByID 根据ID获取角色配置
+func (m *Manager) GetCharacterByID(id string) *CharacterConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, char := range m.characters {
+		if char.ID == id {
+			return char
+		}
+	}
+	return nil
+}
+
+// GetActiveCharacter 获取当前激活角色配置
+func (m *Manager) GetActiveCharacter() *CharacterConfig {
+	return m.GetCharacterByID(m.activeID)
+}
+
+// GetCharacters 获取所有角色配置
+func (m *Manager) GetCharacters() []*CharacterConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.characters
+}
+
+// GetVoice 获取语音配置
+func (m *Manager) GetVoice() *VoiceConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.voiceConfig
+}
+
+// GetApp 获取应用配置
+func (m *Manager) GetApp() *AppConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.appConfig
+}
+
+// GetActiveID 获取当前激活角色ID
+func (m *Manager) GetActiveID() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.activeID
+}
+
+// GetCharacterPrivateConfig 获取当前激活角色的私有配置
+func (m *Manager) GetCharacterPrivateConfig() *CharacterPrivateConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.characterPrivateConfig
+}
+
+// GetManagerPath 获取配置管理器的工作空间路径
+func (m *Manager) GetManagerPath() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.managerPath
+}
+
+// SetActiveID 设置当前激活角色ID
+func (m *Manager) SetActiveID(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	err := m.configLoader.SaveCharacterPrivateConfig(m.characterPrivateConfig)
+	if err != nil {
+		logger.Errorf("pet config: failed to save character private config, err=%v", err)
+	}
+	m.activeID = id
+	characterPrivateConfig, err := m.configLoader.LoadCharacterPrivateConfig(id)
+	if err != nil {
+		logger.Errorf("pet config: failed to load character private config, err=%v", err)
+	}
+	m.characterPrivateConfig = characterPrivateConfig
+}
+
+// SetCharacterPrivateConfig 设置当前激活角色的私有配置
+func (m *Manager) SetCharacterPrivateConfig(config *CharacterPrivateConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.characterPrivateConfig = config
+}
+
+// SavePrivateConfig 保存指定角色的私有配置到 workspaces/{id}/config.json
+func (m *Manager) SavePrivateConfig(id string, cfg *CharacterPrivateConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.configLoader.SaveCharacterPrivateConfig(cfg)
+}
+
+func (m *Manager) SaveCharacterById(id string, char *CharacterConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.characters {
+		if m.characters[i].ID == id {
+			m.characters[i] = char
+			break
+		}
+	}
+}
+
+// AppendCharacter 添加角色配置
+func (m *Manager) AppendCharacter(char *CharacterConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.characters = append(m.characters, char)
+}
+
+// SetAsrEnabled 设置是否启用语音识别
+func (m *Manager) SetAsrEnabled(enabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.voiceConfig.ASREnabled = enabled
+}
+
+// AppendVoiceModel 添加语音模型
+func (m *Manager) AppendVoiceModel(model *VoiceModelConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.voiceConfig.ModelList = append(m.voiceConfig.ModelList, model)
+}
+
+// SelectVoiceModel 选择语音模型
+func (m *Manager) SelectVoiceModel(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.voiceConfig == nil {
+		return
+	}
+	for _, model := range m.voiceConfig.ModelList {
+		if model.Name == name {
+			m.voiceConfig.DefaultModel = model.Name
+			return
+		}
+	}
+	logger.Infof("pet config: voice model %s not found", name)
+}
+
+// SetAppConfig 设置应用配置
+func (m *Manager) SetAppConfig(config *AppConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.appConfig = config
+}

--- a/pkg/pet/config/types.go
+++ b/pkg/pet/config/types.go
@@ -1,22 +1,67 @@
 package config
 
-// CharactersConfig 多角色配置结构
-// 包含所有角色列表和当前激活的角色ID
+const (
+	PetConfigFile       = "pet_config.json" // 统一配置文件名
+	CharacterConfigFile = "config.json"     // 角色私有配置文件名
+	WorkspacePath       = "workspaces"      // 私有配置目录路径
+)
+
+// PetConfig Pet统一配置结构
+// 包含所有pet相关配置，统一加载和保存
+type PetConfig struct {
+	Characters []*CharacterConfig `json:"characters"` // 角色列表
+	ActiveID   string             `json:"active_id"`  // 当前激活的角色ID
+	Voice      *VoiceConfig       `json:"voice"`      // 语音配置
+	App        *AppConfig         `json:"app"`        // 应用运行时配置
+}
+
+// AppConfig 应用运行时配置
+// 控制pet应用的行为开关
+type AppConfig struct {
+	EmotionEnabled           bool   `json:"emotion_enabled"`            // 是否启用情绪表情
+	ReminderEnabled          bool   `json:"reminder_enabled"`           // 是否启用提醒
+	ProactiveCare            bool   `json:"proactive_care"`             // 是否启用主动关怀
+	ProactiveIntervalMinutes int    `json:"proactive_interval_minutes"` // 主动关怀间隔（分钟）
+	VoiceEnabled             bool   `json:"voice_enabled"`              // 是否启用语音播报
+	Language                 string `json:"language"`                   // 语言设置
+}
+
+// DefaultAppConfig 返回默认的应用配置
+func DefaultAppConfig() *AppConfig {
+	return &AppConfig{
+		EmotionEnabled:           true,
+		ReminderEnabled:          true,
+		ProactiveCare:            true,
+		ProactiveIntervalMinutes: 30,
+		VoiceEnabled:             false,
+		Language:                 "zh-CN",
+	}
+}
+
+// CharactersConfig 多角色配置结构（向后兼容）
 type CharactersConfig struct {
 	Characters []*CharacterConfig `json:"characters"` // 角色列表
 	ActiveID   string             `json:"active_id"`  // 当前激活的角色ID
 }
 
-// CharacterConfig 单个角色的配置
-// 包含角色的基本信息、情绪状态和MBTI性格配置
+// CharacterConfig 单个角色的公开配置
+// 包含角色的基本信息（私有数据在workspaces/{id}/config.json）
 type CharacterConfig struct {
-	ID           string        `json:"id"`                      // 角色唯一标识
-	Name         string        `json:"name"`                    // 角色名称
-	Persona      string        `json:"persona"`                 // 性格描述
-	PersonaType  string        `json:"persona_type"`            // 性格类型（如gentle/playful等）
-	Avatar       string        `json:"avatar"`                  // 头像/模型ID
-	EmotionState *EmotionState `json:"emotion_state,omitempty"` // 情绪状态（可选）
-	MBTI         *MBTIConfig   `json:"mbti,omitempty"`          // MBTI配置（可选）
+	ID          string `json:"id"`           // 角色唯一标识
+	Name        string `json:"name"`         // 角色名称
+	Persona     string `json:"persona"`      // 性格描述
+	PersonaType string `json:"persona_type"` // 性格类型（如gentle/playful等）
+	Avatar      string `json:"avatar"`       // 头像/模型ID
+}
+
+// CharacterPrivateConfig 角色私有配置
+// 存储在workspaces/{id}/config.json
+type CharacterPrivateConfig struct {
+	ID           string        `json:"id"`            // 角色唯一标识
+	EmotionState *EmotionState `json:"emotion_state"` // 情绪状态
+	MBTI         *MBTIConfig   `json:"mbti"`          // MBTI配置
+	LastUpdate   int64         `json:"last_update"`   // 最后更新时间（Unix时间戳）
+	Volatility   float64       `json:"volatility"`    // 情绪波动系数
 }
 
 // EmotionState 情绪状态配置
@@ -80,7 +125,6 @@ type VoiceModelConfig struct {
 }
 
 // DefaultEmotionState 返回默认的中性情绪状态
-// 所有情绪值为50（平静状态）
 func DefaultEmotionState() *EmotionState {
 	return &EmotionState{
 		Joy:      50,
@@ -93,7 +137,6 @@ func DefaultEmotionState() *EmotionState {
 }
 
 // DefaultMBTI 返回默认的MBTI配置
-// 所有维度为50（完全中性）
 func DefaultMBTI() *MBTIConfig {
 	return &MBTIConfig{
 		IE: 50,
@@ -103,15 +146,21 @@ func DefaultMBTI() *MBTIConfig {
 	}
 }
 
-// DefaultCharacterConfig 返回默认的角色配置
-// 用于新角色或配置缺失时
+// DefaultCharacterConfig 返回默认的角色公开配置
 func DefaultCharacterConfig() *CharacterConfig {
 	return &CharacterConfig{
-		ID:           "pet_001",
-		Name:         "艾莉",
-		Persona:      "温柔体贴，善于关心他人",
-		PersonaType:  "gentle",
-		Avatar:       "default",
+		ID:          "pet_001",
+		Name:        "艾莉",
+		Persona:     "温柔体贴，善于关心他人",
+		PersonaType: "gentle",
+		Avatar:      "default",
+	}
+}
+
+// DefaultCharacterPrivateConfig 返回默认的角色私有配置
+func DefaultCharacterPrivateConfig(id string) *CharacterPrivateConfig {
+	return &CharacterPrivateConfig{
+		ID:           id,
 		EmotionState: DefaultEmotionState(),
 		MBTI:         DefaultMBTI(),
 	}
@@ -123,5 +172,15 @@ func DefaultVoiceConfig() *VoiceConfig {
 		ModelList:    []*VoiceModelConfig{},
 		DefaultModel: "",
 		ASREnabled:   false,
+	}
+}
+
+// DefaultPetConfig 返回默认的统一配置
+func DefaultPetConfig() *PetConfig {
+	return &PetConfig{
+		Characters: []*CharacterConfig{DefaultCharacterConfig()},
+		ActiveID:   "pet_001",
+		Voice:      DefaultVoiceConfig(),
+		App:        DefaultAppConfig(),
 	}
 }


### PR DESCRIPTION
# PR: Pet 配置系统重构

## Summary

重构 Pet 配置系统，将原有配置拆分为**公开配置**和**私有配置**，实现配置的**统一加载和保存**。

---

## Motivation

1. **配置分散**：原有的 `characters` 配置中混合了公开信息和私有状态（emotion、MBTI）
2. **缺少统一管理**：没有一个统一的配置管理器来协调各子模块的配置访问
3. **持久化逻辑分散**：私有配置的持久化分散在不同地方

---

## Changes

### Commit

`6203f78` - refactor: 重构 Pet 配置系统，拆分为公开配置和私有配置

### Files Changed

| File | Description |
|------|-------------|
| `pkg/pet/config/types.go` | 类型定义：PetConfig、CharacterPrivateConfig、AppConfig |
| `pkg/pet/config/loader.go` | ConfigLoader：负责配置文件读写 |
| `pkg/pet/config/manager.go` | Manager：统一配置管理器（新增） |
| `pkg/pet/config/config_test.go` | 配置模块测试代码（新增） |

---

## Details

### 新增类型 (`types.go`)

```go
// 统一配置结构
type PetConfig struct {
    Characters []*CharacterConfig `json:"characters"` // 角色公开配置列表
    ActiveID   string             `json:"active_id"`  // 当前激活角色ID
    Voice      *VoiceConfig       `json:"voice"`      // 语音配置
    App        *AppConfig         `json:"app"`        // 应用运行时配置
}

// 角色私有配置（存储在 workspaces/{id}/config.json）
type CharacterPrivateConfig struct {
    ID           string        `json:"id"`
    EmotionState *EmotionState `json:"emotion_state"`
    MBTI         *MBTIConfig   `json:"mbti"`
    LastUpdate   int64         `json:"last_update"`
    Volatility   float64       `json:"volatility"`
}
```

### 存储结构

```
{workspacePath}/
├── pet_config.json          # 公开配置（角色列表、语音配置、应用设置）
└── workspaces/
    └── {character_id}/
        └── config.json       # 私有配置（情绪状态、MBTI、波动系数）
```

### Manager API (`manager.go`)

```go
func NewManager(managerPath string) *Manager

func (m *Manager) GetCharacters() []*CharacterConfig
func (m *Manager) GetActiveCharacter() *CharacterConfig
func (m *Manager) GetVoice() *VoiceConfig
func (m *Manager) GetApp() *AppConfig
func (m *Manager) GetActiveID() string
func (m *Manager) GetCharacterPrivateConfig() *CharacterPrivateConfig

func (m *Manager) SetActiveID(id string)
func (m *Manager) SetAppConfig(config *AppConfig)
func (m *Manager) Save() error
```

---

## Testing

```bash
go test ./pkg/pet/config/... -v
```

---

## Notes

- ConfigLoader 保留用于底层文件操作
- Manager 在 ConfigLoader 基础上提供线程安全的统一访问
