### PR TITLE
ci: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  APP_NAME: picoclaw
+  BUILD_TAGS: goolm,stdjson
+  BUILD_ENTRY: ./cmd/picoclaw
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            archive_ext: tar.gz
+          - goos: darwin
+            goarch: amd64
+            archive_ext: tar.gz
+          - goos: windows
+            goarch: amd64
+            archive_ext: zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+
+          BIN="${APP_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            BIN="${BIN}.exe"
+          fi
+
+          VERSION="${GITHUB_REF_NAME}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
+            go build \
+              -trimpath \
+              -tags "${BUILD_TAGS}" \
+              -ldflags "-s -w -X github.com/sipeed/picoclaw/pkg/config.Version=${VERSION} -X github.com/sipeed/picoclaw/pkg/config.GitCommit=${SHORT_SHA} -X github.com/sipeed/picoclaw/pkg/config.BuildTime=${BUILD_TIME}" \
+              -o "dist/${BIN}" \
+              "${BUILD_ENTRY}"
+
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+
+          BASE="${APP_NAME}-${GITHUB_REF_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          BIN="${APP_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            zip "${BASE}.zip" "${BIN}.exe"
+          else
+            tar -czf "${BASE}.tar.gz" "${BIN}"
+          fi
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes
+          fi
+
+          gh release upload "${TAG}" dist/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,61 @@ jobs:
         include:
           - goos: linux
             goarch: amd64
-            archive_ext: tar.gz
+            file_os: Linux
+            file_arch: x86_64
+          - goos: linux
+            goarch: arm64
+            file_os: Linux
+            file_arch: arm64
+          - goos: linux
+            goarch: arm
+            goarm: "7"
+            file_os: Linux
+            file_arch: armv7
+          - goos: linux
+            goarch: riscv64
+            file_os: Linux
+            file_arch: riscv64
+          - goos: linux
+            goarch: loong64
+            file_os: Linux
+            file_arch: loong64
+          - goos: linux
+            goarch: mipsle
+            file_os: Linux
+            file_arch: mipsle
           - goos: darwin
             goarch: amd64
-            archive_ext: tar.gz
+            file_os: Darwin
+            file_arch: x86_64
+          - goos: darwin
+            goarch: arm64
+            file_os: Darwin
+            file_arch: arm64
           - goos: windows
             goarch: amd64
-            archive_ext: zip
+            file_os: Windows
+            file_arch: x86_64
+          - goos: windows
+            goarch: arm64
+            file_os: Windows
+            file_arch: arm64
+          - goos: freebsd
+            goarch: amd64
+            file_os: Freebsd
+            file_arch: x86_64
+          - goos: freebsd
+            goarch: arm64
+            file_os: Freebsd
+            file_arch: arm64
+          - goos: netbsd
+            goarch: amd64
+            file_os: Netbsd
+            file_arch: x86_64
+          - goos: netbsd
+            goarch: arm64
+            file_os: Netbsd
+            file_arch: arm64
 
     steps:
       - name: Checkout
@@ -43,13 +91,17 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Prepare onboard workspace
+        shell: bash
+        run: go generate ./cmd/picoclaw/internal/onboard
+
       - name: Build
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p dist
 
-          BIN="${APP_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          BIN="${APP_NAME}"
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
             BIN="${BIN}.exe"
           fi
@@ -57,8 +109,9 @@ jobs:
           VERSION="${GITHUB_REF_NAME}"
           SHORT_SHA="${GITHUB_SHA::7}"
           BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          GOARM="${{ matrix.goarm || '' }}"
 
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM="${GOARM}" CGO_ENABLED=0 \
             go build \
               -trimpath \
               -tags "${BUILD_TAGS}" \
@@ -72,8 +125,8 @@ jobs:
           set -euo pipefail
           cd dist
 
-          BASE="${APP_NAME}-${GITHUB_REF_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          BIN="${APP_NAME}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          BASE="${APP_NAME}_${{ matrix.file_os }}_${{ matrix.file_arch }}"
+          BIN="${APP_NAME}"
 
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
             zip "${BASE}.zip" "${BIN}.exe"
@@ -84,7 +137,7 @@ jobs:
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: release-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-arm{0}', matrix.goarm) || '' }}
           path: |
             dist/*.tar.gz
             dist/*.zip
@@ -108,6 +161,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          cd dist
+
+          sha256sum * > checksums.txt
 
           TAG="${GITHUB_REF_NAME}"
           if ! gh release view "${TAG}" >/dev/null 2>&1; then
@@ -116,4 +172,4 @@ jobs:
               --generate-notes
           fi
 
-          gh release upload "${TAG}" dist/* --clobber
+          gh release upload "${TAG}" * --clobber


### PR DESCRIPTION
## Description
- 新增基于 GitHub Actions 的发版工作流，触发条件为推送 `v*` 标签。
- 对 `./cmd/picoclaw` 进行 linux/darwin/windows（amd64）交叉编译。
- Linux/macOS 产物打包为 tar.gz，Windows 产物打包为 zip。
- 自动创建/更新 GitHub Release，并上传构建产物。

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes, no API changes)

## AI Code Generation
- [ ] Fully AI-generated (100% AI, 0% Human)
- [x] Mostly AI-generated (AI draft, Human verified/modified)
- [ ] Mostly Human-written (Human lead, AI assisted or none)

## Related Issue
- #105

## Technical Context (Skip for Docs)
- **Reference URL:** 采用标签触发构建 + `gh release` 上传资产的 GitHub Actions 发布流程。
- **Reasoning:** 将发版自动化从产品功能改动中独立出来，保证基于 tag 的发布可重复、可维护。

## Test Environment
- **Hardware:** PC
- **OS:** Windows 11
- **Model/Provider:** N/A
- **Channels:** N/A

## Evidence (Optional)
<details>
<summary>Click to view Logs/Screenshots</summary>

- 本地验证：`go build -tags "goolm,stdjson" ./cmd/picoclaw` 通过

</details>

## Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.