### PR TITLE
fix(pet): 恢复桌宠能动性并修复聊天面板/连接稳定性

### DIFF
--- a/electron-frontend/src/App.tsx
+++ b/electron-frontend/src/App.tsx
@@ -1,17 +1,36 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 
-type PetState = 'idle' | 'sad' | 'happy' | 'listen' | 'standby'
+type PetState = 'idle' | 'sad' | 'happy' | 'listen' | 'standby' | 'celebrate' | 'shakeHead' | 'stayOut'
+
+interface BubbleData {
+  text: string | null
+  emotion?: string
+  level?: string
+  animation?: string
+  animationHints?: string[]
+  audio?: string
+}
 
 const happyImages = ['/happy1.gif', '/happy2.gif']
 const standbyImages = ['/standby1.gif', '/standby2.gif', '/standby3.gif']
 
 const getPetImage = (state: PetState, prevImage?: string): string => {
   switch (state) {
-    case 'idle': return '/init.png'
-    case 'sad': return '/sad.gif'
-    case 'happy': return happyImages[Math.floor(Math.random() * happyImages.length)]
-    case 'listen': return '/listening.gif'
-    case 'standby':
+    case 'idle':
+      return '/init.png'
+    case 'sad':
+      return '/sad.gif'
+    case 'happy':
+      return happyImages[Math.floor(Math.random() * happyImages.length)]
+    case 'listen':
+      return '/listening.gif'
+    case 'celebrate':
+      return '/celebrate_out.gif'
+    case 'shakeHead':
+      return '/shake-head_out.gif'
+    case 'stayOut':
+      return '/stay_out.gif'
+    case 'standby': {
       let img = standbyImages[Math.floor(Math.random() * standbyImages.length)]
       if (prevImage && standbyImages.includes(prevImage) && standbyImages.length > 1) {
         while (img === prevImage) {
@@ -19,7 +38,9 @@ const getPetImage = (state: PetState, prevImage?: string): string => {
         }
       }
       return img
-    default: return '/init.png'
+    }
+    default:
+      return '/init.png'
   }
 }
 
@@ -28,12 +49,64 @@ const emotionToPetState: Record<string, PetState> = {
   happy: 'happy',
   sadness: 'sad',
   sad: 'sad',
+  anger: 'shakeHead',
+  disgust: 'shakeHead',
+  surprise: 'celebrate',
+  fear: 'stayOut',
   neutral: 'standby',
 }
 
+const levelToPetState: Record<string, PetState> = {
+  critical: 'stayOut',
+  elevated: 'standby',
+  normal: 'standby',
+}
+
+const animationToPetState: Record<string, PetState> = {
+  happy: 'happy',
+  sad: 'sad',
+  listen: 'listen',
+  standby: 'standby',
+  celebrate: 'celebrate',
+  'shake-head': 'shakeHead',
+  'stay-out': 'stayOut',
+  'init.png': 'idle',
+}
+
+const resolvePetState = (data: BubbleData): PetState => {
+  const candidates = [
+    data.animation,
+    ...(data.animationHints ?? []),
+    data.emotion ? emotionToPetState[data.emotion] : undefined,
+    data.level ? levelToPetState[data.level] : undefined,
+    'idle' as PetState,
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if (candidate in animationToPetState) {
+      return animationToPetState[candidate]
+    }
+    if (
+      candidate === 'idle' ||
+      candidate === 'sad' ||
+      candidate === 'happy' ||
+      candidate === 'listen' ||
+      candidate === 'standby' ||
+      candidate === 'celebrate' ||
+      candidate === 'shakeHead' ||
+      candidate === 'stayOut'
+    ) {
+      return candidate
+    }
+  }
+
+  return 'idle'
+}
+
 function App() {
-  const [petState, setPetState] = useState<PetState>('idle')
-  const [currentImage, setCurrentImage] = useState('/init.png')
+  const [petState, setPetState] = useState<PetState>('standby')
+  const [currentImage, setCurrentImage] = useState('/standby1.gif')
   const currentImageRef = useRef(currentImage)
   currentImageRef.current = currentImage
 
@@ -54,7 +127,7 @@ function App() {
   }, [])
 
   useEffect(() => {
-    const handleBubbleShow = (data: { text: string | null; emotion?: string; audio?: string }) => {
+    const handleBubbleShow = (data: BubbleData) => {
       if (bubbleTimerRef.current) {
         clearTimeout(bubbleTimerRef.current)
         bubbleTimerRef.current = null
@@ -64,10 +137,7 @@ function App() {
         setBubble(data.text)
       }
 
-      const targetState = data.emotion && emotionToPetState[data.emotion]
-        ? emotionToPetState[data.emotion]
-        : 'happy'
-      transitionTo(targetState)
+      transitionTo(resolvePetState(data))
 
       if (data.audio) {
         let audioUrl = data.audio
@@ -94,7 +164,6 @@ function App() {
     }
 
     window.electronAPI?.onBubbleShow(handleBubbleShow)
-
     window.electronAPI?.onSettingsUpdate(() => {})
   }, [transitionTo])
 
@@ -106,8 +175,8 @@ function App() {
     <div className="app">
       <div className="pet-container">
         <div className="controls">
-          <button className="btn" onClick={openSettings} title="设置">⚙️</button>
-          <button className="btn close" onClick={() => window.close()} title="关闭">×</button>
+          <button className="btn" onClick={openSettings} title="Settings">S</button>
+          <button className="btn close" onClick={() => window.close()} title="Close">X</button>
         </div>
 
         {bubble && <div className="bubble">{bubble}</div>}

--- a/electron-frontend/src/electron.d.ts
+++ b/electron-frontend/src/electron.d.ts
@@ -1,4 +1,11 @@
-export {}
+interface BubblePayload {
+  text: string | null
+  emotion?: string
+  level?: string
+  animation?: string
+  animationHints?: string[]
+  audio?: string
+}
 
 declare global {
   interface Window {
@@ -9,12 +16,17 @@ declare global {
       closeSettings: () => void
       sendSettingsChange: (settings: any) => void
       sendChatHistory: (history: any[]) => void
-      showBubble: (text: string | null, emotion: string, audio?: string) => void
+      showBubble: {
+        (payload: BubblePayload): void
+        (text: string | null, emotion: string, audio?: string): void
+      }
       sendConnectionAlive: () => void
       onSettingsUpdate: (callback: (settings: any) => void) => void
       onChatHistoryUpdate: (callback: (history: any[]) => void) => void
-      onBubbleShow: (callback: (data: { text: string | null; emotion?: string; audio?: string }) => void) => void
+      onBubbleShow: (callback: (data: BubblePayload) => void) => void
       onConnectionAlive: (callback: () => void) => void
     }
   }
 }
+
+export {}

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -1,4 +1,4 @@
-﻿const { app, BrowserWindow, ipcMain, screen } = require('electron');
+const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -6,11 +6,13 @@ const fs = require('fs');
 let petWindow = null;
 let settingsWindow = null;
 
-// 璁剧疆鐢ㄦ埛鏁版嵁鐩綍浠ヨВ鍐虫潈闄愰棶棰?
 const userDataPath = path.join(os.homedir(), '.goclaw');
 app.setPath('userData', userDataPath);
 
-// 鍒涘缓鏃ュ織鏂囦欢
+if (!fs.existsSync(userDataPath)) {
+  fs.mkdirSync(userDataPath, { recursive: true });
+}
+
 const logFilePath = path.join(userDataPath, 'logs.txt');
 const logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
 
@@ -23,28 +25,25 @@ function logToFile(message) {
 
 logToFile('Electron application started');
 
-const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173').replace(/\/+$/, '');
+const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173').trim().replace(/\/+$/, '');
 const shouldOpenDevTools = process.env.ELECTRON_OPEN_DEVTOOLS === '1';
 
 function createPetWindow() {
-  // 鑾峰彇灞忓箷鍙充笅瑙掍綅锟?
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-  
-  // 妗屽疇绐楀彛澶у皬
   const petWidth = 280;
   const petHeight = 380;
-  
+
   petWindow = new BrowserWindow({
     width: petWidth,
     height: petHeight,
     x: width - petWidth - 20,
     y: height - petHeight - 60,
-    frame: false,           // 鏃犺竟锟?
-    transparent: true,      // 閫忔槑鑳屾櫙
-    alwaysOnTop: true,     // 缃《
-    resizable: false,       // 涓嶅彲璋冩暣澶у皬
-    skipTaskbar: true,     // 涓嶆樉绀哄湪浠诲姟锟?
-    show: false,           // 鍔犺浇瀹屾垚鍚庢樉锟?
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    show: false,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -52,8 +51,10 @@ function createPetWindow() {
     }
   });
 
-  petWindow.loadURL(rendererBaseUrl);
-  
+  petWindow.loadURL(rendererBaseUrl).catch((err) => {
+    logToFile(`[PET WINDOW] loadURL failed: ${String(err)}`);
+  });
+
   petWindow.once('ready-to-show', () => {
     petWindow.show();
   });
@@ -65,7 +66,11 @@ function createPetWindow() {
 }
 
 function createSettingsWindow() {
-  if (settingsWindow) {
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    if (settingsWindow.isMinimized()) {
+      settingsWindow.restore();
+    }
+    settingsWindow.show();
     settingsWindow.focus();
     return;
   }
@@ -73,7 +78,7 @@ function createSettingsWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const settingsWidth = Math.round(width * 0.7);
   const settingsHeight = Math.round(height * 0.7);
-  
+
   settingsWindow = new BrowserWindow({
     width: settingsWidth,
     height: settingsHeight,
@@ -81,7 +86,8 @@ function createSettingsWindow() {
     minHeight: 400,
     show: false,
     frame: false,
-    transparent: true,
+    transparent: false,
+    backgroundColor: '#111111',
     alwaysOnTop: false,
     autoHideMenuBar: true,
     webPreferences: {
@@ -91,10 +97,24 @@ function createSettingsWindow() {
     }
   });
 
-  settingsWindow.loadURL(`${rendererBaseUrl}/settings.html`);
+  const settingsUrl = `${rendererBaseUrl}/settings.html`;
+  logToFile(`[SETTINGS WINDOW] opening ${settingsUrl}`);
+
+  settingsWindow.webContents.on('did-fail-load', (_event, code, desc, url) => {
+    logToFile(`[SETTINGS WINDOW] did-fail-load code=${code} desc=${desc} url=${url}`);
+  });
+
+  settingsWindow.webContents.on('did-finish-load', () => {
+    logToFile('[SETTINGS WINDOW] did-finish-load');
+  });
+
+  settingsWindow.loadURL(settingsUrl).catch((err) => {
+    logToFile(`[SETTINGS WINDOW] loadURL failed: ${String(err)}`);
+  });
 
   settingsWindow.once('ready-to-show', () => {
     settingsWindow.show();
+    settingsWindow.focus();
     if (shouldOpenDevTools) {
       settingsWindow.webContents.openDevTools({ mode: 'detach' });
     }
@@ -106,18 +126,18 @@ function createSettingsWindow() {
 }
 
 ipcMain.on('open-settings', () => {
+  logToFile('[IPC] open-settings');
   createSettingsWindow();
 });
 
-// 鎺ユ敹鏉ヨ嚜娓叉煋杩涚▼鐨勬棩蹇?
-ipcMain.on('renderer-log', (event, { level, args }) => {
-  const message = args.map(arg => {
+ipcMain.on('renderer-log', (_event, { level, args }) => {
+  const message = args.map((arg) => {
     if (typeof arg === 'object') {
       return JSON.stringify(arg);
     }
     return String(arg);
   }).join(' ');
-  
+
   if (level === 'error') {
     logToFile(`[RENDERER ERROR] ${message}`);
   } else {
@@ -126,11 +146,13 @@ ipcMain.on('renderer-log', (event, { level, args }) => {
 });
 
 ipcMain.on('minimize-settings', () => {
-  if (settingsWindow) settingsWindow.minimize();
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.minimize();
+  }
 });
 
 ipcMain.on('maximize-settings', () => {
-  if (settingsWindow) {
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
     if (settingsWindow.isMaximized()) {
       settingsWindow.unmaximize();
     } else {
@@ -140,22 +162,24 @@ ipcMain.on('maximize-settings', () => {
 });
 
 ipcMain.on('close-settings', () => {
-  if (settingsWindow) settingsWindow.close();
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.close();
+  }
 });
 
-ipcMain.on('settings-changed', (event, settings) => {
+ipcMain.on('settings-changed', (_event, settings) => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('settings-updated', settings);
   }
 });
 
-ipcMain.on('chat-history', (event, history) => {
+ipcMain.on('chat-history', (_event, history) => {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     settingsWindow.webContents.send('chat-history-updated', history);
   }
 });
 
-ipcMain.on('show-bubble', (event, data) => {
+ipcMain.on('show-bubble', (_event, data) => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('bubble-show', data);
   }

--- a/electron-frontend/src/preload.js
+++ b/electron-frontend/src/preload.js
@@ -7,8 +7,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closeSettings: () => ipcRenderer.send('close-settings'),
   sendSettingsChange: (settings) => ipcRenderer.send('settings-changed', settings),
   sendChatHistory: (history) => ipcRenderer.send('chat-history', history),
-  showBubble: (text, emotion, audio) => {
-    ipcRenderer.send('show-bubble', { text, emotion, audio })
+  showBubble: (payloadOrText, emotion, audio) => {
+    const payload =
+      payloadOrText && typeof payloadOrText === 'object'
+        ? payloadOrText
+        : { text: payloadOrText ?? null, emotion, audio }
+    ipcRenderer.send('show-bubble', payload)
   },
   sendConnectionAlive: () => ipcRenderer.send('connection-alive'),
   onSettingsUpdate: (callback) => {

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -426,6 +426,27 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
 
     setIsConnecting(true)
 
+    const scheduleReconnect = () => {
+      if (!shouldReconnectRef.current) {
+        return
+      }
+      if (reconnectAttempts.current >= maxReconnectAttempts) {
+        return
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+      const delay = Math.min(
+        1000 * Math.pow(2, reconnectAttempts.current),
+        30000,
+      )
+      console.log('[usePicoClaw] scheduling reconnect in', delay, 'ms')
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectAttempts.current += 1
+        connect()
+      }, delay)
+    }
+
     fetchTokenInfo().then((tokenInfo) => {
       console.log('[usePicoClaw] fetchTokenInfo result:', tokenInfo)
       if (!tokenInfo) {
@@ -433,6 +454,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
         setIsConnecting(false)
         setIsConnected(false)
         callbacksRef.current?.onConnectionChange?.(false)
+        scheduleReconnect()
         return
       }
 
@@ -525,17 +547,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
             return
           }
 
-          if (reconnectAttempts.current < maxReconnectAttempts) {
-            const delay = Math.min(
-              1000 * Math.pow(2, reconnectAttempts.current),
-              30000,
-            )
-            console.log('[usePicoClaw] scheduling reconnect in', delay, 'ms')
-            reconnectTimeoutRef.current = setTimeout(() => {
-              reconnectAttempts.current += 1
-              connect()
-            }, delay)
-          }
+          scheduleReconnect()
         }
 
         wsRef.current = ws

--- a/electron-frontend/vite.config.ts
+++ b/electron-frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         changeOrigin: true,
         ws: true,
       },
-      '/pet': {
+      '/pet/': {
         target: 'http://127.0.0.1:18790',
         changeOrigin: true,
         ws: true,

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -405,8 +405,16 @@ func (c *PetChannel) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // readLoop 读取客户端消息
 func (c *PetChannel) readLoop(pc *petConn) {
+	pingDone := make(chan struct{})
+
 	defer func() {
+		close(pingDone)
 		c.service.UnregisterSession(pc.id)
+
+		pc.writeMu.Lock()
+		pc.closed = true
+		pc.writeMu.Unlock()
+
 		pc.conn.Close()
 		c.connsMu.Lock()
 		delete(c.connections, pc.id)
@@ -427,8 +435,13 @@ func (c *PetChannel) readLoop(pc *petConn) {
 			select {
 			case <-c.ctx.Done():
 				return
+			case <-pingDone:
+				return
 			case <-ticker.C:
-				pc.conn.WriteMessage(websocket.PingMessage, nil)
+				if err := pc.writePing(); err != nil {
+					logger.Debugf("pet: ping failed, conn_id=%s, err=%v", pc.id, err)
+					return
+				}
 			}
 		}
 	}()
@@ -436,6 +449,7 @@ func (c *PetChannel) readLoop(pc *petConn) {
 	for {
 		_, rawMsg, err := pc.conn.ReadMessage()
 		if err != nil {
+			logger.Debugf("pet: readLoop exit, conn_id=%s, err=%v", pc.id, err)
 			return
 		}
 
@@ -462,11 +476,27 @@ func (pc *petConn) writeJSON(v any) error {
 	}
 	pc.writeMu.Lock()
 	defer pc.writeMu.Unlock()
+	if pc.closed {
+		return fmt.Errorf("connection closed")
+	}
+	_ = pc.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	err := pc.conn.WriteJSON(v)
 	if err != nil {
 		logger.Warnf("pet: writeJSON failed conn_id=%s, err=%v", pc.id, err)
 	}
 	return err
+}
+
+func (pc *petConn) writePing() error {
+	if pc.closed {
+		return fmt.Errorf("connection closed")
+	}
+	pc.writeMu.Lock()
+	defer pc.writeMu.Unlock()
+	if pc.closed {
+		return fmt.Errorf("connection closed")
+	}
+	return pc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(10*time.Second))
 }
 
 // generateConnID 生成连接ID

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -471,9 +471,6 @@ func (c *PetChannel) handleRequest(pc *petConn, req Request) {
 
 // writeJSON 发送JSON到客户端
 func (pc *petConn) writeJSON(v any) error {
-	if pc.closed {
-		return fmt.Errorf("connection closed")
-	}
 	pc.writeMu.Lock()
 	defer pc.writeMu.Unlock()
 	if pc.closed {
@@ -488,9 +485,6 @@ func (pc *petConn) writeJSON(v any) error {
 }
 
 func (pc *petConn) writePing() error {
-	if pc.closed {
-		return fmt.Errorf("connection closed")
-	}
 	pc.writeMu.Lock()
 	defer pc.writeMu.Unlock()
 	if pc.closed {


### PR DESCRIPTION
﻿## 变更背景
近期桌宠在会话过程中出现两个明显问题：
- 桌宠状态无法按情绪/动画提示切换，表现为“不会动”
- 聊天面板偶发无法打开，或连接在短时间内异常断开

本 PR 聚焦恢复桌宠可用性与连通性，尽量以最小改动修复关键路径。

## 主要改动
1. 恢复桌宠动作状态解析（`electron-frontend/src/App.tsx`）
- 扩展 `PetState`，补齐 `celebrate` / `shakeHead` / `stayOut` 等状态
- 新增 `resolvePetState`，按 `animation`、`animationHints`、`emotion`、`level` 解析目标动作
- 启动默认状态改为 `standby`，避免初始化后长期停留静态图

2. 修复 Electron IPC 参数兼容（`electron-frontend/src/preload.js`、`electron-frontend/src/electron.d.ts`）
- `showBubble` 同时兼容两种调用方式：
  - 新协议：`showBubble(payload)`
  - 旧协议：`showBubble(text, emotion, audio)`
- 同步 TS 类型定义，避免桥接层签名不一致

3. 修复聊天面板打开失败（`electron-frontend/src/main.js`）
- 对 `ELECTRON_RENDERER_URL` 增加 `trim()`，避免环境变量空白导致 `ERR_INVALID_URL`
- 设置窗口已存在时执行 `restore/show/focus`
- 增加设置窗口加载日志，便于定位前端窗口问题

4. 修复 pet 通道并发写导致的 WS 断开（`pkg/channels/pet/channel.go`）
- 心跳 Ping 改为走统一写锁（`writePing`），避免与 `writeJSON` 并发写冲突
- 连接关闭时标记 `closed` 并停止 ping goroutine
- 增加写超时与断开日志，降低“聊几句后断线”的概率

## 验证
- `node --check electron-frontend/src/main.js`
- `node --check electron-frontend/src/preload.js`
- `go test ./pkg/channels/pet`

## 影响范围
- 仅涉及桌宠 Electron 前端桥接/窗口逻辑与 pet WebSocket 通道写入路径
- 不修改模型配置、业务接口契约与发布流程
