### PR TITLE
Fix pet audio playback and settings window loading

### DIFF
--- a/electron-frontend/src/electron.d.ts
+++ b/electron-frontend/src/electron.d.ts
@@ -3,6 +3,7 @@ export {}
 interface BubblePayload {
   text: string | null
   emotion?: string
+  level?: string
   audio?: string
   animation?: string
   animationHints?: string[]
@@ -17,7 +18,10 @@ declare global {
       closeSettings: () => void
       sendSettingsChange: (settings: any) => void
       sendChatHistory: (history: any[]) => void
-      showBubble: (payload: BubblePayload) => void
+      showBubble: {
+        (payload: BubblePayload): void
+        (text: string | null, emotion: string, audio?: string): void
+      }
       sendConnectionAlive: () => void
       onSettingsUpdate: (callback: (settings: any) => void) => void
       onChatHistoryUpdate: (callback: (history: any[]) => void) => void

--- a/electron-frontend/src/electron.d.ts
+++ b/electron-frontend/src/electron.d.ts
@@ -1,5 +1,13 @@
 export {}
 
+interface BubblePayload {
+  text: string | null
+  emotion?: string
+  audio?: string
+  animation?: string
+  animationHints?: string[]
+}
+
 declare global {
   interface Window {
     electronAPI?: {
@@ -9,11 +17,11 @@ declare global {
       closeSettings: () => void
       sendSettingsChange: (settings: any) => void
       sendChatHistory: (history: any[]) => void
-      showBubble: (text: string | null, emotion: string, audio?: string) => void
+      showBubble: (payload: BubblePayload) => void
       sendConnectionAlive: () => void
       onSettingsUpdate: (callback: (settings: any) => void) => void
       onChatHistoryUpdate: (callback: (history: any[]) => void) => void
-      onBubbleShow: (callback: (data: { text: string | null; emotion?: string; audio?: string }) => void) => void
+      onBubbleShow: (callback: (data: BubblePayload) => void) => void
       onConnectionAlive: (callback: () => void) => void
     }
   }

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -23,8 +23,22 @@ function logToFile(message) {
 
 logToFile('Electron application started');
 
-const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173').replace(/\/+$/, '');
+const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173')
+  .trim()
+  .replace(/\/+$/, '');
 const shouldOpenDevTools = process.env.ELECTRON_OPEN_DEVTOOLS === '1';
+
+function revealWindow(win) {
+  if (!win || win.isDestroyed()) {
+    return;
+  }
+  if (win.isMinimized()) {
+    win.restore();
+  }
+  win.show();
+  win.moveTop();
+  win.focus();
+}
 
 function createPetWindow() {
   // 鑾峰彇灞忓箷鍙充笅瑙掍綅锟?
@@ -65,14 +79,16 @@ function createPetWindow() {
 }
 
 function createSettingsWindow() {
-  if (settingsWindow) {
-    settingsWindow.focus();
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    logToFile('[SETTINGS WINDOW] reusing existing window');
+    revealWindow(settingsWindow);
     return;
   }
 
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const settingsWidth = Math.round(width * 0.7);
   const settingsHeight = Math.round(height * 0.7);
+  const settingsUrl = `${rendererBaseUrl}/settings.html`;
   
   settingsWindow = new BrowserWindow({
     width: settingsWidth,
@@ -81,7 +97,8 @@ function createSettingsWindow() {
     minHeight: 400,
     show: false,
     frame: false,
-    transparent: true,
+    transparent: false,
+    backgroundColor: '#1e1e2e',
     alwaysOnTop: false,
     autoHideMenuBar: true,
     webPreferences: {
@@ -91,21 +108,48 @@ function createSettingsWindow() {
     }
   });
 
-  settingsWindow.loadURL(`${rendererBaseUrl}/settings.html`);
-
-  settingsWindow.once('ready-to-show', () => {
-    settingsWindow.show();
+  let hasBeenRevealed = false;
+  const revealSettingsWindow = () => {
+    if (!settingsWindow || settingsWindow.isDestroyed() || hasBeenRevealed) {
+      return;
+    }
+    hasBeenRevealed = true;
+    logToFile('[SETTINGS WINDOW] reveal');
+    revealWindow(settingsWindow);
     if (shouldOpenDevTools) {
       settingsWindow.webContents.openDevTools({ mode: 'detach' });
     }
+  };
+
+  logToFile(`[SETTINGS WINDOW] opening ${settingsUrl}`);
+
+  settingsWindow.once('ready-to-show', revealSettingsWindow);
+  settingsWindow.webContents.once('did-finish-load', () => {
+    logToFile('[SETTINGS WINDOW] did-finish-load');
+    revealSettingsWindow();
+  });
+  settingsWindow.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    logToFile(`[SETTINGS WINDOW CONSOLE] level=${level} source=${sourceId}:${line} message=${message}`);
+  });
+  settingsWindow.webContents.on('did-fail-load', (_event, code, desc, url) => {
+    logToFile(`[SETTINGS WINDOW] did-fail-load code=${code} desc=${desc} url=${url}`);
+  });
+  settingsWindow.webContents.on('render-process-gone', (_event, details) => {
+    logToFile(`[SETTINGS WINDOW] render-process-gone reason=${details.reason} exitCode=${details.exitCode}`);
+  });
+
+  settingsWindow.loadURL(settingsUrl).catch((error) => {
+    logToFile(`[SETTINGS WINDOW] loadURL failed: ${error}`);
   });
 
   settingsWindow.on('closed', () => {
+    logToFile('[SETTINGS WINDOW] closed');
     settingsWindow = null;
   });
 }
 
 ipcMain.on('open-settings', () => {
+  logToFile('[IPC] open-settings');
   createSettingsWindow();
 });
 

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -1,4 +1,4 @@
-﻿const { app, BrowserWindow, ipcMain, screen } = require('electron');
+const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -9,6 +9,10 @@ let settingsWindow = null;
 // 璁剧疆鐢ㄦ埛鏁版嵁鐩綍浠ヨВ鍐虫潈闄愰棶棰?
 const userDataPath = path.join(os.homedir(), '.goclaw');
 app.setPath('userData', userDataPath);
+
+if (!fs.existsSync(userDataPath)) {
+  fs.mkdirSync(userDataPath, { recursive: true });
+}
 
 // 鍒涘缓鏃ュ織鏂囦欢
 const logFilePath = path.join(userDataPath, 'logs.txt');
@@ -66,7 +70,9 @@ function createPetWindow() {
     }
   });
 
-  petWindow.loadURL(rendererBaseUrl);
+  petWindow.loadURL(rendererBaseUrl).catch((err) => {
+    logToFile(`[PET WINDOW] loadURL failed: ${String(err)}`);
+  });
   
   petWindow.once('ready-to-show', () => {
     petWindow.show();
@@ -154,8 +160,8 @@ ipcMain.on('open-settings', () => {
 });
 
 // 鎺ユ敹鏉ヨ嚜娓叉煋杩涚▼鐨勬棩蹇?
-ipcMain.on('renderer-log', (event, { level, args }) => {
-  const message = args.map(arg => {
+ipcMain.on('renderer-log', (_event, { level, args }) => {
+  const message = args.map((arg) => {
     if (typeof arg === 'object') {
       return JSON.stringify(arg);
     }
@@ -170,11 +176,13 @@ ipcMain.on('renderer-log', (event, { level, args }) => {
 });
 
 ipcMain.on('minimize-settings', () => {
-  if (settingsWindow) settingsWindow.minimize();
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.minimize();
+  }
 });
 
 ipcMain.on('maximize-settings', () => {
-  if (settingsWindow) {
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
     if (settingsWindow.isMaximized()) {
       settingsWindow.unmaximize();
     } else {
@@ -184,22 +192,24 @@ ipcMain.on('maximize-settings', () => {
 });
 
 ipcMain.on('close-settings', () => {
-  if (settingsWindow) settingsWindow.close();
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.close();
+  }
 });
 
-ipcMain.on('settings-changed', (event, settings) => {
+ipcMain.on('settings-changed', (_event, settings) => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('settings-updated', settings);
   }
 });
 
-ipcMain.on('chat-history', (event, history) => {
+ipcMain.on('chat-history', (_event, history) => {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     settingsWindow.webContents.send('chat-history-updated', history);
   }
 });
 
-ipcMain.on('show-bubble', (event, data) => {
+ipcMain.on('show-bubble', (_event, data) => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('bubble-show', data);
   }

--- a/electron-frontend/src/preload.js
+++ b/electron-frontend/src/preload.js
@@ -7,8 +7,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closeSettings: () => ipcRenderer.send('close-settings'),
   sendSettingsChange: (settings) => ipcRenderer.send('settings-changed', settings),
   sendChatHistory: (history) => ipcRenderer.send('chat-history', history),
-  showBubble: (text, emotion, audio) => {
-    ipcRenderer.send('show-bubble', { text, emotion, audio })
+  showBubble: (payload) => {
+    ipcRenderer.send('show-bubble', payload)
   },
   sendConnectionAlive: () => ipcRenderer.send('connection-alive'),
   onSettingsUpdate: (callback) => {

--- a/electron-frontend/src/preload.js
+++ b/electron-frontend/src/preload.js
@@ -7,7 +7,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closeSettings: () => ipcRenderer.send('close-settings'),
   sendSettingsChange: (settings) => ipcRenderer.send('settings-changed', settings),
   sendChatHistory: (history) => ipcRenderer.send('chat-history', history),
-  showBubble: (payload) => {
+  showBubble: (payloadOrText, emotion, audio) => {
+    const payload =
+      payloadOrText && typeof payloadOrText === 'object'
+        ? payloadOrText
+        : { text: payloadOrText ?? null, emotion, audio }
     ipcRenderer.send('show-bubble', payload)
   },
   sendConnectionAlive: () => ipcRenderer.send('connection-alive'),

--- a/electron-frontend/src/settings-main.tsx
+++ b/electron-frontend/src/settings-main.tsx
@@ -3,6 +3,67 @@ import ReactDOM from 'react-dom/client'
 import Settings from './settings'
 import './settings.css'
 
+type BoundaryState = {
+  error: Error | null
+}
+
+class SettingsErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  BoundaryState
+> {
+  state: BoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[settings] render crashed', error, info)
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            minHeight: '100vh',
+            background: '#1e1e2e',
+            color: '#f8d7da',
+            padding: '24px',
+            fontFamily:
+              "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif",
+          }}
+        >
+          <h2 style={{ marginBottom: '12px', color: '#fff' }}>Settings renderer crashed</h2>
+          <pre
+            style={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              background: 'rgba(0,0,0,0.25)',
+              padding: '16px',
+              borderRadius: '12px',
+            }}
+          >
+            {this.state.error.stack || this.state.error.message}
+          </pre>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+window.addEventListener('error', (event) => {
+  console.error('[settings] window error', event.error || event.message)
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[settings] unhandled rejection', event.reason)
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <Settings />
+  <SettingsErrorBoundary>
+    <Settings />
+  </SettingsErrorBoundary>,
 )

--- a/electron-frontend/src/settings.tsx
+++ b/electron-frontend/src/settings.tsx
@@ -95,7 +95,7 @@ interface CronJobDTO {
 }
 
 interface AudioPushData {
-  chat_id?: number
+  chat_id?: number | null
   text?: string
   is_final?: boolean
   type?: string
@@ -262,7 +262,7 @@ function mergeFinalText(streamed: string, finalChunk?: string) {
   return `${streamText}${finalText}`.trim()
 }
 
-function decodeBase64Chunk(value: string): Uint8Array {
+function decodeBase64Chunk(value: string): Uint8Array | null {
   const base64 = value
     .replace(/^data:audio\/[^;]+;base64,/, '')
     .replace(/\s+/g, '')
@@ -270,12 +270,17 @@ function decodeBase64Chunk(value: string): Uint8Array {
     return new Uint8Array()
   }
 
-  const binary = window.atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i)
+  try {
+    const binary = window.atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes
+  } catch (error) {
+    console.warn('[settings] dropped malformed audio chunk', error)
+    return null
   }
-  return bytes
 }
 
 function mergeAudioChunks(chunks: Uint8Array[]): Uint8Array {
@@ -466,19 +471,27 @@ export default function PetClawApp() {
         return
       }
 
-      const currentStream = audioStreamRef.current
-      const incomingChatId =
+      const hasExplicitChatId =
         typeof data.chat_id === 'number' && Number.isFinite(data.chat_id)
-          ? data.chat_id
-          : null
+      const incomingChatId: number | null = hasExplicitChatId ? data.chat_id! : null
 
-      if (incomingChatId !== null && currentStream.chatId !== incomingChatId) {
-        currentStream.chatId = incomingChatId
-        currentStream.chunks = []
+      let currentStream = audioStreamRef.current
+      if (hasExplicitChatId) {
+        if (currentStream.chatId !== incomingChatId) {
+          currentStream = { chatId: incomingChatId, chunks: [] }
+          audioStreamRef.current = currentStream
+        }
+      } else if (currentStream.chatId !== null) {
+        currentStream = { chatId: null, chunks: [] }
+        audioStreamRef.current = currentStream
       }
 
       if (data.text) {
         const chunkBytes = decodeBase64Chunk(data.text)
+        if (chunkBytes === null) {
+          resetAudioStream()
+          return
+        }
         if (chunkBytes.length > 0) {
           currentStream.chunks.push(chunkBytes)
         }

--- a/electron-frontend/src/settings.tsx
+++ b/electron-frontend/src/settings.tsx
@@ -94,6 +94,18 @@ interface CronJobDTO {
   state?: CronStateDTO
 }
 
+interface AudioPushData {
+  chat_id?: number
+  text?: string
+  is_final?: boolean
+  type?: string
+}
+
+interface PendingAudioStream {
+  chatId: number | null
+  chunks: Uint8Array[]
+}
+
 const API_BASE = 'http://127.0.0.1:18790'
 
 const ASSET_PREFIX =
@@ -250,6 +262,45 @@ function mergeFinalText(streamed: string, finalChunk?: string) {
   return `${streamText}${finalText}`.trim()
 }
 
+function decodeBase64Chunk(value: string): Uint8Array {
+  const base64 = value
+    .replace(/^data:audio\/[^;]+;base64,/, '')
+    .replace(/\s+/g, '')
+  if (!base64) {
+    return new Uint8Array()
+  }
+
+  const binary = window.atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+function mergeAudioChunks(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+  return merged
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return ''
+  }
+
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return window.btoa(binary)
+}
+
 export default function PetClawApp() {
   const [page, setPage] = useState<PageType>('chat')
   const [menu, setMenu] = useState<MainMenu>('chat')
@@ -280,7 +331,7 @@ export default function PetClawApp() {
   const chatRef = useRef('')
   const emotionRef = useRef('neutral')
   const msgListRef = useRef<HTMLDivElement>(null)
-  const audioRef = useRef('')
+  const audioStreamRef = useRef<PendingAudioStream>({ chatId: null, chunks: [] })
   const responseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { isListening, toggleListening } = useVoiceInput({
@@ -310,6 +361,10 @@ export default function PetClawApp() {
       clearTimeout(responseTimeoutRef.current)
       responseTimeoutRef.current = null
     }
+  }, [])
+
+  const resetAudioStream = useCallback(() => {
+    audioStreamRef.current = { chatId: null, chunks: [] }
   }, [])
 
   useEffect(() => {
@@ -401,21 +456,50 @@ export default function PetClawApp() {
     })
 
     on('audio', (raw) => {
-      const data = parseMaybeJSON<{ text?: string; is_final?: boolean }>(raw)
+      const data = parseMaybeJSON<AudioPushData>(raw)
       if (!data) {
         return
       }
+
+      if (data.type === 'error') {
+        resetAudioStream()
+        return
+      }
+
+      const currentStream = audioStreamRef.current
+      const incomingChatId =
+        typeof data.chat_id === 'number' && Number.isFinite(data.chat_id)
+          ? data.chat_id
+          : null
+
+      if (incomingChatId !== null && currentStream.chatId !== incomingChatId) {
+        currentStream.chatId = incomingChatId
+        currentStream.chunks = []
+      }
+
       if (data.text) {
-        audioRef.current += data.text
+        const chunkBytes = decodeBase64Chunk(data.text)
+        if (chunkBytes.length > 0) {
+          currentStream.chunks.push(chunkBytes)
+        }
       }
-      if (data.is_final && audioRef.current) {
-        window.electronAPI?.showBubble({
-          text: null,
-          emotion: emotionRef.current,
-          audio: audioRef.current,
-        })
-        audioRef.current = ''
+
+      if (!data.is_final) {
+        return
       }
+
+      const merged = mergeAudioChunks(currentStream.chunks)
+      resetAudioStream()
+      const audioBase64 = bytesToBase64(merged)
+      if (!audioBase64) {
+        return
+      }
+
+      window.electronAPI?.showBubble({
+        text: null,
+        emotion: emotionRef.current,
+        audio: audioBase64,
+      })
     })
 
     return () => {
@@ -424,7 +508,7 @@ export default function PetClawApp() {
       off('ai_chat')
       off('audio')
     }
-  }, [clearResponseTimeout, on, off])
+  }, [clearResponseTimeout, on, off, resetAudioStream])
 
   const sendMessage = useCallback(
     async (text?: string) => {
@@ -435,6 +519,7 @@ export default function PetClawApp() {
 
       setChatHistory((p) => [...p, { id: `u_${Date.now()}`, text: msg, time: timeText(), isUser: true }])
       setInputText('')
+      resetAudioStream()
 
       try {
         await send('chat', { text: msg })
@@ -464,7 +549,7 @@ export default function PetClawApp() {
         ])
       }
     },
-    [clearResponseTimeout, inputText, needOnboarding, send],
+    [clearResponseTimeout, inputText, needOnboarding, resetAudioStream, send],
   )
 
   const submitOnboarding = useCallback(async () => {
@@ -1014,7 +1099,7 @@ export default function PetClawApp() {
                       <div key={c.id} className="module-list-item">
                         <div>
                           <div className="module-card-title">{c.name}</div>
-                          <div className="module-card-meta">{c.schedule}</div>
+                          <div className="module-card-meta">{c.scheduleText}</div>
                           <div className="module-card-desc">{c.description}</div>
                         </div>
                         <button

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -444,6 +444,27 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
 
     setIsConnecting(true)
 
+    const scheduleReconnect = () => {
+      if (!shouldReconnectRef.current) {
+        return
+      }
+      if (reconnectAttempts.current >= maxReconnectAttempts) {
+        return
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+      const delay = Math.min(
+        1000 * Math.pow(2, reconnectAttempts.current),
+        30000,
+      )
+      console.log('[usePicoClaw] scheduling reconnect in', delay, 'ms')
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectAttempts.current += 1
+        connect()
+      }, delay)
+    }
+
     fetchTokenInfo().then((tokenInfo) => {
       console.log('[usePicoClaw] fetchTokenInfo result:', tokenInfo)
       if (!tokenInfo) {
@@ -451,6 +472,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
         setIsConnecting(false)
         setIsConnected(false)
         callbacksRef.current?.onConnectionChange?.(false)
+        scheduleReconnect()
         return
       }
 
@@ -543,17 +565,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
             return
           }
 
-          if (reconnectAttempts.current < maxReconnectAttempts) {
-            const delay = Math.min(
-              1000 * Math.pow(2, reconnectAttempts.current),
-              30000,
-            )
-            console.log('[usePicoClaw] scheduling reconnect in', delay, 'ms')
-            reconnectTimeoutRef.current = setTimeout(() => {
-              reconnectAttempts.current += 1
-              connect()
-            }, delay)
-          }
+          scheduleReconnect()
         }
 
         wsRef.current = ws

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -328,7 +328,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
             IsFinal?: boolean
           }
           handlersRef.current['audio']?.({
-            chat_id: normalized.chat_id ?? normalized.ChatID ?? 0,
+            chat_id: normalized.chat_id ?? normalized.ChatID,
             text: normalized.text ?? normalized.Text ?? '',
             type: normalized.type ?? 'audio',
             is_final:
@@ -338,7 +338,6 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
           })
         } else if (typeof rawAudioData === 'string') {
           handlersRef.current['audio']?.({
-            chat_id: 0,
             text: rawAudioData,
             type: 'audio',
             is_final: msg.is_final === true,

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -316,15 +316,34 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
       }
 
       if (msg.push_type === 'audio') {
-        let audioData = msg.data
-        if (typeof audioData === 'string') {
-          try {
-            audioData = JSON.parse(audioData)
-          } catch {
-            // keep raw string
+        const rawAudioData = decodeMaybeJSON(msg.data)
+        if (rawAudioData && typeof rawAudioData === 'object') {
+          const normalized = rawAudioData as {
+            chat_id?: number
+            ChatID?: number
+            text?: string
+            Text?: string
+            type?: string
+            is_final?: boolean
+            IsFinal?: boolean
           }
+          handlersRef.current['audio']?.({
+            chat_id: normalized.chat_id ?? normalized.ChatID ?? 0,
+            text: normalized.text ?? normalized.Text ?? '',
+            type: normalized.type ?? 'audio',
+            is_final:
+              normalized.is_final === true ||
+              normalized.IsFinal === true ||
+              msg.is_final === true,
+          })
+        } else if (typeof rawAudioData === 'string') {
+          handlersRef.current['audio']?.({
+            chat_id: 0,
+            text: rawAudioData,
+            type: 'audio',
+            is_final: msg.is_final === true,
+          })
         }
-        handlersRef.current['audio']?.(audioData)
         return
       }
 
@@ -373,7 +392,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
         })
       }
     }
-  }, [])
+  }, [decodeMaybeJSON])
 
   const handlePicoMessage = useCallback((msg: any) => {
     if (msg.type === 'session.info') {
@@ -727,18 +746,6 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
       callbacksRef.current?.onEmotionChange?.(data)
     }
 
-    handlersRef.current['audio'] = (data: any) => {
-      if (data && data.text) {
-        window.electronAPI?.showBubble({
-          text: null,
-          emotion: 'joy',
-          animation: 'happy',
-          animationHints: ['happy', 'standby', 'init.png'],
-          audio: data.text,
-        })
-      }
-    }
-
     const healthCheckInterval = setInterval(() => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         void send('health_check', {})
@@ -748,7 +755,6 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
     return () => {
       clearInterval(healthCheckInterval)
       delete handlersRef.current['heartbeat']
-      delete handlersRef.current['audio']
       disconnect()
     }
   }, [])


### PR DESCRIPTION
## Summary
- decode and reassemble streamed pet audio chunks before handing them to Electron playback
- normalize legacy audio push payloads and route bubble payloads through a typed object interface
- harden the settings window load/reveal flow and surface renderer errors instead of showing a blank shell

## Testing
- npm run build (in electron-frontend)

## Notes
- this fixes the Electron frontend path for streamed pet audio once the backend emits push_type=audio chunks
- it also fixes the settings window URL/reveal issues that could leave the desktop panel blank or hidden