### PR TITLE
fix(petclaw): restore desktop console rendering and gateway flow

### DIFF
--- a/GoClaw-OneClickStart.ps1
+++ b/GoClaw-OneClickStart.ps1
@@ -123,8 +123,10 @@ if ($Mode -eq "petclaw") {
     Write-Host "Starting PetClaw frontend in a new PowerShell window..."
     Start-Process powershell -ArgumentList @("-NoExit", "-Command", $petclawCommand) | Out-Null
 
-    Start-Sleep -Seconds 2
-    Start-Process "http://localhost:3000/onboarding"
+    if (-not $NoBrowser) {
+        Start-Sleep -Seconds 2
+        Start-Process "http://localhost:3000/onboarding"
+    }
 
     Write-Host "Done. Keep both windows open while using the app."
     exit 0

--- a/electron-frontend/package.json
+++ b/electron-frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "go-claw-electron",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "electron": "node scripts/wait-and-start.cjs",
+    "start": "concurrently -k \"npm run dev\" \"npm run electron\"",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "concurrently": "^8.2.0",
+    "electron": "^28.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/electron-frontend/scripts/wait-and-start.cjs
+++ b/electron-frontend/scripts/wait-and-start.cjs
@@ -1,0 +1,53 @@
+const { spawn } = require('child_process')
+
+const DEFAULT_RENDERER_URL = 'http://localhost:5173'
+const RENDERER_URL = (process.env.ELECTRON_RENDERER_URL || DEFAULT_RENDERER_URL).replace(/\/+$/, '')
+const MAX_WAIT = 30000
+const CHECK_INTERVAL = 500
+
+async function waitForVite() {
+  const startTime = Date.now()
+
+  console.log(`[Electron] Waiting for Vite server at ${RENDERER_URL}...`)
+
+  while (Date.now() - startTime < MAX_WAIT) {
+    try {
+      const response = await fetch(RENDERER_URL, { method: 'HEAD' })
+      if (response.ok) {
+        console.log('[Electron] Vite server is ready!')
+        return true
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise(resolve => setTimeout(resolve, CHECK_INTERVAL))
+  }
+
+  console.error(`[Electron] Timeout waiting for Vite server at ${RENDERER_URL}`)
+  return false
+}
+
+async function main() {
+  const ready = await waitForVite()
+  if (!ready) {
+    process.exit(1)
+  }
+
+  console.log('[Electron] Starting Electron...')
+
+  const electron = spawn('npx', ['electron', 'src/main.js'], {
+    stdio: 'inherit',
+    shell: true,
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ELECTRON_RENDERER_URL: RENDERER_URL
+    }
+  })
+
+  electron.on('close', (code) => {
+    process.exit(code || 0)
+  })
+}
+
+main()

--- a/electron-frontend/settings.html
+++ b/electron-frontend/settings.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>桌宠设置</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/settings-main.tsx"></script>
+  </body>
+</html>

--- a/electron-frontend/src/App.tsx
+++ b/electron-frontend/src/App.tsx
@@ -1,7 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-
-import { OnboardingWizard } from './components/OnboardingWizard'
-import { loadOnboardingState } from './lib/onboarding'
+﻿import { useState, useEffect, useCallback, useRef } from 'react'
 
 type PetState = 'idle' | 'sad' | 'happy' | 'listen' | 'standby' | 'celebrate' | 'shakeHead' | 'stayOut'
 
@@ -107,7 +104,7 @@ const resolvePetState = (data: BubbleData): PetState => {
   return 'idle'
 }
 
-function PetView() {
+function App() {
   const [petState, setPetState] = useState<PetState>('standby')
   const [currentImage, setCurrentImage] = useState('/standby1.gif')
   const currentImageRef = useRef(currentImage)
@@ -168,6 +165,7 @@ function PetView() {
 
     window.electronAPI?.onBubbleShow(handleBubbleShow)
     window.electronAPI?.onSettingsUpdate(() => {})
+    document.title = 'PetClaw'
   }, [transitionTo])
 
   const openSettings = () => {
@@ -191,35 +189,6 @@ function PetView() {
       </div>
     </div>
   )
-}
-
-function App() {
-  const [ready, setReady] = useState(false)
-  const [showOnboarding, setShowOnboarding] = useState(false)
-
-  useEffect(() => {
-    const onboardingState = loadOnboardingState()
-    setShowOnboarding(!onboardingState?.completed)
-    setReady(true)
-  }, [])
-
-  useEffect(() => {
-    if (!ready) {
-      return
-    }
-    window.electronAPI?.setOnboardingMode?.(showOnboarding)
-    document.title = showOnboarding ? '初始化向导 - PetClaw AI' : 'PetClaw'
-  }, [ready, showOnboarding])
-
-  if (!ready) {
-    return <div className="app" />
-  }
-
-  if (showOnboarding) {
-    return <OnboardingWizard onFinish={() => setShowOnboarding(false)} />
-  }
-
-  return <PetView />
 }
 
 export default App

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, screen } = require('electron');
+﻿const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -8,8 +8,6 @@ let settingsWindow = null;
 
 const PET_WIDTH = 280;
 const PET_HEIGHT = 380;
-const ONBOARDING_WIDTH = 1280;
-const ONBOARDING_HEIGHT = 860;
 
 const userDataPath = path.join(os.homedir(), '.goclaw');
 app.setPath('userData', userDataPath);
@@ -31,16 +29,26 @@ function logToFile(message) {
 logToFile('Electron application started');
 
 const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173').trim().replace(/\/+$/, '');
+const dashboardBaseUrl = (process.env.GOCLAW_DASHBOARD_URL || 'http://127.0.0.1:3000').trim().replace(/\/+$/, '');
+const launcherToken = (process.env.GOCLAW_LAUNCHER_TOKEN || process.env.PICOCLAW_LAUNCHER_TOKEN || '').trim();
 const shouldOpenDevTools = process.env.ELECTRON_OPEN_DEVTOOLS === '1';
 
-function createPetWindow() {
-  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-
-  petWindow = new BrowserWindow({
+function getPetBounds() {
+  const display = screen.getPrimaryDisplay();
+  const area = display.workArea;
+  return {
+    x: area.x + area.width - PET_WIDTH - 20,
+    y: area.y + area.height - PET_HEIGHT - 60,
     width: PET_WIDTH,
     height: PET_HEIGHT,
-    x: width - PET_WIDTH - 20,
-    y: height - PET_HEIGHT - 60,
+  };
+}
+
+function createPetWindow() {
+  const bounds = getPetBounds();
+
+  petWindow = new BrowserWindow({
+    ...bounds,
     frame: false,
     transparent: true,
     alwaysOnTop: true,
@@ -68,37 +76,54 @@ function createPetWindow() {
   });
 }
 
-function applyOnboardingMode(enabled) {
+function resetPetWindow() {
   if (!petWindow || petWindow.isDestroyed()) {
     return;
   }
 
-  const display = screen.getDisplayMatching(petWindow.getBounds());
-  const area = display.workArea;
-
-  if (enabled) {
-    const width = Math.min(ONBOARDING_WIDTH, area.width - 40);
-    const height = Math.min(ONBOARDING_HEIGHT, area.height - 40);
-    const x = area.x + Math.round((area.width - width) / 2);
-    const y = area.y + Math.round((area.height - height) / 2);
-
-    petWindow.setResizable(true);
-    petWindow.setAlwaysOnTop(false);
-    petWindow.setSkipTaskbar(false);
-    petWindow.setBounds({ x, y, width, height }, true);
-    return;
-  }
-
-  const x = area.x + area.width - PET_WIDTH - 20;
-  const y = area.y + area.height - PET_HEIGHT - 60;
   petWindow.setResizable(false);
   petWindow.setAlwaysOnTop(true);
   petWindow.setSkipTaskbar(true);
-  petWindow.setBounds({ x, y, width: PET_WIDTH, height: PET_HEIGHT }, true);
+  petWindow.setBounds(getPetBounds(), true);
 }
 
-function createSettingsWindow() {
+function withLauncherToken(rawUrl) {
+  if (!launcherToken) {
+    return rawUrl;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    if (!parsed.searchParams.has('token')) {
+      parsed.searchParams.set('token', launcherToken);
+    }
+    return parsed.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+function buildDashboardUrl(pathname = '') {
+  let resolved = dashboardBaseUrl;
+
+  if (pathname) {
+    if (/^https?:\/\//i.test(pathname)) {
+      resolved = pathname;
+    } else {
+      resolved = `${dashboardBaseUrl}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
+    }
+  }
+
+  return withLauncherToken(resolved);
+}
+
+function createSettingsWindow(targetUrl = buildDashboardUrl()) {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
+    if (targetUrl && settingsWindow.webContents.getURL() !== targetUrl) {
+      settingsWindow.loadURL(targetUrl).catch((err) => {
+        logToFile(`[SETTINGS WINDOW] reload failed: ${String(err)}`);
+      });
+    }
     if (settingsWindow.isMinimized()) {
       settingsWindow.restore();
     }
@@ -119,7 +144,7 @@ function createSettingsWindow() {
     show: false,
     frame: false,
     transparent: false,
-    backgroundColor: '#111111',
+    backgroundColor: '#f7ecdf',
     alwaysOnTop: false,
     autoHideMenuBar: true,
     webPreferences: {
@@ -129,7 +154,7 @@ function createSettingsWindow() {
     }
   });
 
-  const settingsUrl = `${rendererBaseUrl}/settings.html`;
+  const settingsUrl = targetUrl || buildDashboardUrl();
   logToFile(`[SETTINGS WINDOW] opening ${settingsUrl}`);
 
   settingsWindow.webContents.on('did-fail-load', (_event, code, desc, url) => {
@@ -159,12 +184,22 @@ function createSettingsWindow() {
 
 ipcMain.on('open-settings', () => {
   logToFile('[IPC] open-settings');
-  createSettingsWindow();
+  createSettingsWindow(buildDashboardUrl());
 });
 
-ipcMain.on('set-onboarding-mode', (_event, enabled) => {
+ipcMain.on('open-onboarding', () => {
+  logToFile('[IPC] open-onboarding');
+  createSettingsWindow(buildDashboardUrl('/onboarding?mode=rerun'));
+});
+
+ipcMain.on('set-onboarding-mode', (event, enabled) => {
   logToFile(`[IPC] set-onboarding-mode ${Boolean(enabled)}`);
-  applyOnboardingMode(Boolean(enabled));
+  const target = BrowserWindow.fromWebContents(event.sender);
+  if (target === petWindow) {
+    resetPetWindow();
+    return;
+  }
+  logToFile('[IPC] set-onboarding-mode ignored for non-pet window');
 });
 
 ipcMain.on('window-minimize', (event) => {

--- a/electron-frontend/src/preload.js
+++ b/electron-frontend/src/preload.js
@@ -1,8 +1,9 @@
-const { contextBridge, ipcRenderer } = require('electron');
+﻿const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getBackendBaseUrl: () => process.env.GOCLAW_BACKEND_URL || 'http://127.0.0.1:18800',
   getLauncherToken: () => process.env.GOCLAW_LAUNCHER_TOKEN || process.env.PICOCLAW_LAUNCHER_TOKEN || '',
+  openOnboarding: () => ipcRenderer.send('open-onboarding'),
   setOnboardingMode: (enabled) => ipcRenderer.send('set-onboarding-mode', Boolean(enabled)),
   minimizeWindow: () => ipcRenderer.send('window-minimize'),
   toggleMaximizeWindow: () => ipcRenderer.send('window-toggle-maximize'),
@@ -22,13 +23,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   sendConnectionAlive: () => ipcRenderer.send('connection-alive'),
   onSettingsUpdate: (callback) => {
-    ipcRenderer.on('settings-updated', (event, settings) => callback(settings));
+    ipcRenderer.on('settings-updated', (_event, settings) => callback(settings));
   },
   onChatHistoryUpdate: (callback) => {
-    ipcRenderer.on('chat-history-updated', (event, history) => callback(history));
+    ipcRenderer.on('chat-history-updated', (_event, history) => callback(history));
   },
   onBubbleShow: (callback) => {
-    ipcRenderer.on('bubble-show', (event, data) => callback(data));
+    ipcRenderer.on('bubble-show', (_event, data) => callback(data));
   },
   onConnectionAlive: (callback) => {
     ipcRenderer.on('connection-alive', () => callback());

--- a/electron-frontend/src/settings-main.tsx
+++ b/electron-frontend/src/settings-main.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import Settings from './settings'
+import './settings.css'
+
+type BoundaryState = {
+  error: Error | null
+}
+
+class SettingsErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  BoundaryState
+> {
+  state: BoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[settings] render crashed', error, info)
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            minHeight: '100vh',
+            background: '#1e1e2e',
+            color: '#f8d7da',
+            padding: '24px',
+            fontFamily:
+              "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif",
+          }}
+        >
+          <h2 style={{ marginBottom: '12px', color: '#fff' }}>Settings renderer crashed</h2>
+          <pre
+            style={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              background: 'rgba(0,0,0,0.25)',
+              padding: '16px',
+              borderRadius: '12px',
+            }}
+          >
+            {this.state.error.stack || this.state.error.message}
+          </pre>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+window.addEventListener('error', (event) => {
+  console.error('[settings] window error', event.error || event.message)
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[settings] unhandled rejection', event.reason)
+})
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <SettingsErrorBoundary>
+    <Settings />
+  </SettingsErrorBoundary>,
+)

--- a/electron-frontend/src/settings.css
+++ b/electron-frontend/src/settings.css
@@ -1,0 +1,1283 @@
+﻿/* ============================================
+   PetClaw AI - 娣辫壊涓婚鑱婂ぉ鐣岄潰
+   ============================================ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #1e1e2e;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  color: #e0e0e0;
+}
+
+/* ============================================
+   涓诲竷灞€
+   ============================================ */
+
+.petclaw-app {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  background: #1e1e2e;
+}
+
+/* ============================================
+   宸︿晶杈规爮
+   ============================================ */
+
+.sidebar {
+  width: 220px;
+  min-width: 220px;
+  background: #16161e;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #2a2a3a;
+  -webkit-app-region: drag;
+}
+
+.sidebar-header {
+  padding: 16px 16px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sidebar-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+}
+
+.sidebar-brand {
+  font-size: 15px;
+  font-weight: 600;
+  color: #e8e8f0;
+}
+
+.sidebar-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #999;
+  margin-left: 2px;
+}
+
+.new-chat-btn {
+  margin: 4px 12px 16px;
+  padding: 10px;
+  background: transparent;
+  border: 1px dashed #3a3a4a;
+  border-radius: 8px;
+  color: #b0b0c0;
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: all 0.2s;
+  -webkit-app-region: no-drag;
+}
+
+.new-chat-btn:hover {
+  background: #2a2a3a;
+  border-color: #4a4a5a;
+  color: #e0e0f0;
+}
+
+/* 鑿滃崟鍖?*/
+.sidebar-menu {
+  flex: 1;
+  padding: 0 8px;
+  overflow-y: auto;
+  -webkit-app-region: no-drag;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: #8888a0;
+  font-size: 13px;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+
+.menu-item:hover {
+  background: #22222e;
+  color: #c0c0d0;
+}
+
+.menu-item.active {
+  background: #2a2a3e;
+  color: #e8e8ff;
+}
+
+.menu-icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
+}
+
+.menu-label {
+  flex: 1;
+}
+
+/* 瀵硅瘽璁板綍鍖?*/
+.sidebar-section-title {
+  font-size: 11px;
+  color: #555568;
+  padding: 16px 12px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #7777a0;
+  font-size: 12px;
+  transition: all 0.15s;
+}
+
+.history-item:hover {
+  background: #22222e;
+  color: #b0b0c0;
+}
+
+.history-icon {
+  font-size: 14px;
+}
+
+.history-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.history-time {
+  font-size: 10px;
+  color: #555;
+  margin-top: 1px;
+}
+
+/* 渚ц竟鏍忓簳閮?*/
+.sidebar-footer {
+  padding: 12px;
+  border-top: 1px solid #2a2a3a;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  -webkit-app-region: no-drag;
+}
+
+.sidebar-footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.invite-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  color: #666680;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+
+.invite-btn:hover {
+  background: #22222e;
+  color: #aaa;
+}
+
+.footer-icons {
+  display: flex;
+  gap: 4px;
+}
+
+.footer-icon-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: none;
+  background: none;
+  color: #555568;
+  font-size: 15px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.footer-icon-btn:hover {
+  background: #22222e;
+  color: #aaa;
+}
+
+/* ============================================
+   鍙充晶涓诲尯鍩?
+   ============================================ */
+
+.main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #1e1e2e;
+}
+
+/* 椤堕儴鏍?*/
+.top-bar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  border-bottom: 1px solid #2a2a3a;
+  -webkit-app-region: drag;
+}
+
+.top-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  -webkit-app-region: no-drag;
+}
+
+.conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  transition: background-color 0.3s;
+}
+
+.conn-dot.connected {
+  background: #2ed573;
+  box-shadow: 0 0 6px #2ed57380;
+}
+
+.conn-dot.connecting {
+  background: #ffa502;
+  animation: pulse 1s infinite;
+}
+
+.conn-dot.disconnected {
+  background: #ff4757;
+}
+
+.conn-text {
+  font-size: 12px;
+  color: #888;
+}
+
+.top-center {
+  display: flex;
+  background: #2a2a3a;
+  border-radius: 20px;
+  padding: 3px;
+  -webkit-app-region: no-drag;
+}
+
+.tab-btn {
+  padding: 5px 20px;
+  border-radius: 18px;
+  border: none;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: #888;
+  background: transparent;
+}
+
+.tab-btn.active {
+  background: #3a3a5a;
+  color: #fff;
+}
+
+.tab-btn:hover:not(.active) {
+  color: #bbb;
+}
+
+.top-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  -webkit-app-region: no-drag;
+}
+
+.plan-text {
+  font-size: 13px;
+  color: #888;
+}
+
+.upgrade-btn {
+  padding: 5px 14px;
+  background: #e67e22;
+  border: none;
+  border-radius: 14px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.upgrade-btn:hover {
+  background: #f39c12;
+}
+
+.window-controls {
+  display: flex;
+  gap: 6px;
+  margin-left: 8px;
+}
+
+.win-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  background: #2a2a3a;
+  transition: all 0.2s;
+}
+
+.win-btn:hover {
+  background: #3a3a4a;
+  color: #ddd;
+}
+
+.win-btn.close:hover {
+  background: #e74c3c;
+  color: #fff;
+}
+
+/* ============================================
+   鑱婂ぉ鍐呭鍖?
+   ============================================ */
+
+.chat-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* 绌虹姸鎬侊紙娆㈣繋椤碉級 */
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  gap: 20px;
+}
+
+.pet-avatar {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #3a3a5a;
+  background: #2a2a3a;
+}
+
+.greeting-text {
+  font-size: 22px;
+  font-weight: 600;
+  color: #e0e0f0;
+  text-align: center;
+}
+
+.suggestion-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  max-width: 560px;
+  width: 100%;
+  margin-top: 12px;
+}
+
+.suggestion-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px 16px;
+  background: #24243a;
+  border: 1px solid #2e2e42;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.suggestion-card:hover {
+  background: #2a2a44;
+  border-color: #3a3a5a;
+}
+
+.suggestion-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.suggestion-info {
+  flex: 1;
+}
+
+.suggestion-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #e0e0f0;
+  margin-bottom: 3px;
+}
+
+.suggestion-desc {
+  font-size: 11px;
+  color: #666680;
+  line-height: 1.4;
+}
+
+/* 娑堟伅鍒楄〃 */
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.message-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.message-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.message-list::-webkit-scrollbar-thumb {
+  background: #3a3a4a;
+  border-radius: 3px;
+}
+
+.chat-msg {
+  display: flex;
+  gap: 10px;
+  max-width: 80%;
+}
+
+.chat-msg.user {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.chat-msg.ai {
+  align-self: flex-start;
+}
+
+.msg-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.msg-avatar.pet-gif {
+  background: #2a2a3a;
+  border: 1px solid #3a3a4a;
+}
+
+.msg-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.msg-bubble {
+  padding: 10px 14px;
+  border-radius: 16px;
+  font-size: 13px;
+  line-height: 1.6;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.chat-msg.user .msg-bubble {
+  background: #3a5a8a;
+  color: #e8eeff;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-msg.ai .msg-bubble {
+  background: #28283e;
+  color: #d0d0e8;
+  border-bottom-left-radius: 4px;
+}
+
+.msg-time {
+  font-size: 10px;
+  color: #555;
+  padding: 0 4px;
+}
+
+.chat-msg.user .msg-time {
+  text-align: right;
+}
+
+/* 娴佸紡杈撳嚭鎸囩ず鍣?*/
+.streaming-indicator {
+  display: flex;
+  gap: 10px;
+  align-self: flex-start;
+  max-width: 80%;
+}
+
+.streaming-bubble {
+  padding: 10px 14px;
+  background: #28283e;
+  border-radius: 16px;
+  border-bottom-left-radius: 4px;
+  color: #d0d0e8;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.typing-dots {
+  display: inline-flex;
+  gap: 3px;
+  padding: 4px 0;
+}
+
+.typing-dots span {
+  width: 6px;
+  height: 6px;
+  background: #666;
+  border-radius: 50%;
+  animation: typing 1.2s infinite;
+}
+
+.typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+.typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes typing {
+  0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-3px); }
+}
+
+/* ============================================
+   搴曢儴杈撳叆鏍?
+   ============================================ */
+
+.input-bar {
+  flex-shrink: 0;
+  padding: 12px 20px 16px;
+  border-top: 1px solid #2a2a3a;
+}
+
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #24243a;
+  border: 1px solid #2e2e42;
+  border-radius: 22px;
+  padding: 6px 6px 6px 14px;
+  transition: border-color 0.2s;
+}
+
+.input-row:focus-within {
+  border-color: #4a4a6a;
+}
+
+.input-text {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: #e0e0f0;
+  font-size: 13px;
+  padding: 4px 0;
+  min-width: 0;
+}
+
+.input-text::placeholder {
+  color: #555568;
+}
+
+.input-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.toolbar-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid #2e2e42;
+  border-radius: 14px;
+  color: #666680;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.toolbar-btn:hover {
+  background: #2a2a3a;
+  color: #aaa;
+}
+
+.input-icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: none;
+  color: #666680;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.input-icon-btn:hover {
+  color: #aaa;
+  background: #2a2a3e;
+}
+
+.input-icon-btn.listening {
+  color: #e74c3c;
+  animation: pulse 1s infinite;
+}
+
+.send-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: #3a5a8a;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.send-btn:hover {
+  background: #4a6a9a;
+}
+
+.send-btn:disabled {
+  background: #2a2a3a;
+  color: #555;
+  cursor: not-allowed;
+}
+
+/* ============================================
+   璁剧疆闈㈡澘锛堣鐩栧眰锛?
+   ============================================ */
+
+.settings-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #1e1e2e;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-panel-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #2a2a3a;
+  gap: 12px;
+}
+
+.settings-back-btn {
+  padding: 6px 12px;
+  background: #2a2a3a;
+  border: none;
+  border-radius: 8px;
+  color: #aaa;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.settings-back-btn:hover {
+  background: #3a3a4a;
+  color: #ddd;
+}
+
+.settings-panel-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e0e0f0;
+}
+
+.settings-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.setting-section {
+  margin-bottom: 28px;
+}
+
+.setting-section h3 {
+  font-size: 14px;
+  color: #aaa;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #2a2a3a;
+}
+
+.setting-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: #24243a;
+  border-radius: 10px;
+  margin-bottom: 8px;
+}
+
+.setting-item label {
+  flex: 0 0 120px;
+  font-size: 13px;
+  color: #bbb;
+}
+
+.setting-item input[type="text"],
+.setting-item input[type="password"],
+.setting-item select {
+  flex: 1;
+  padding: 8px 12px;
+  background: #1e1e2e;
+  border: 1px solid #2e2e42;
+  border-radius: 8px;
+  color: #e0e0f0;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.setting-item input:focus,
+.setting-item select:focus {
+  border-color: #4a4a6a;
+}
+
+.setting-item input[type="range"] {
+  flex: 1;
+  height: 4px;
+  -webkit-appearance: none;
+  background: #3a3a5a;
+  border-radius: 2px;
+  outline: none;
+}
+
+.setting-item input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  background: #5a7aaa;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.setting-item span {
+  flex: 0 0 50px;
+  text-align: right;
+  font-size: 12px;
+  color: #888;
+}
+
+/* 寮€鍏?*/
+.toggle-switch {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  margin-left: auto;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: #3a3a4a;
+  border-radius: 11px;
+  transition: 0.3s;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background: #fff;
+  border-radius: 50%;
+  transition: 0.3s;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: #3a5a8a;
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+  transform: translateX(18px);
+}
+
+/* 瑙掕壊鍗＄墖 */
+.char-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.char-card {
+  padding: 14px;
+  background: #24243a;
+  border: 2px solid transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.2s;
+}
+
+.char-card:hover {
+  border-color: #3a3a5a;
+}
+
+.char-card.active {
+  border-color: #5a7aaa;
+  background: #2a2a44;
+}
+
+.char-card .char-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e0e0f0;
+}
+
+.char-card .char-desc {
+  font-size: 11px;
+  color: #666;
+  margin-top: 4px;
+}
+
+/* ============================================
+   鍔ㄧ敾
+   ============================================ */
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.chat-msg {
+  animation: fadeIn 0.3s ease;
+}
+
+/* onboarding */
+.onboarding-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(9, 10, 26, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 120;
+  padding: 24px;
+}
+
+.onboarding-card {
+  width: min(640px, 100%);
+  border: 1px solid #2a2c4f;
+  border-radius: 16px;
+  background: #171935;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+  padding: 24px;
+}
+
+.onboarding-card h2 {
+  margin: 0;
+  font-size: 24px;
+  color: #f4f5ff;
+}
+
+.onboarding-card p {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  color: #aeb0d7;
+}
+
+.onboarding-form {
+  display: grid;
+  gap: 10px;
+}
+
+.onboarding-form label {
+  color: #d9dbff;
+  font-size: 14px;
+}
+
+.onboarding-form input,
+.onboarding-form select,
+.onboarding-form textarea {
+  width: 100%;
+  background: #0f1128;
+  border: 1px solid #343769;
+  border-radius: 10px;
+  color: #f4f5ff;
+  padding: 10px 12px;
+}
+
+.onboarding-form textarea {
+  resize: vertical;
+}
+
+.onboarding-error {
+  margin-top: 12px;
+  color: #ff8f8f;
+  font-size: 13px;
+}
+
+.onboarding-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+.onboarding-submit {
+  min-width: 124px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  background: #ff9f1a;
+  color: #1b1e3b;
+  font-weight: 700;
+  padding: 10px 16px;
+}
+
+.onboarding-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  background: #5b5e87;
+}
+
+/* module pages */
+.module-page {
+  flex: 1;
+  overflow: auto;
+  padding: 20px 24px;
+}
+
+.module-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+
+.module-header h2 {
+  font-size: 20px;
+  color: #e4e6ff;
+}
+
+.module-source {
+  color: #8d90be;
+  font-size: 12px;
+}
+
+.module-error {
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: #ff8f8f;
+}
+
+.module-loading {
+  color: #b8bbe1;
+  font-size: 13px;
+}
+
+.module-block {
+  margin-bottom: 16px;
+}
+
+.module-block h3 {
+  margin-bottom: 10px;
+  color: #d9dcff;
+  font-size: 14px;
+}
+
+.module-summary {
+  font-size: 12px;
+  color: #969ac8;
+  margin-bottom: 10px;
+}
+
+.module-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.module-card {
+  background: #24243a;
+  border: 1px solid #2f3150;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.module-card-title {
+  color: #f0f2ff;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.module-card-meta {
+  color: #8f93c2;
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.module-card-desc {
+  color: #c5c8eb;
+  font-size: 12px;
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.module-list {
+  display: grid;
+  gap: 8px;
+}
+
+.module-list-item {
+  background: #24243a;
+  border: 1px solid #2f3150;
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.switch-btn {
+  min-width: 70px;
+  height: 32px;
+  border-radius: 16px;
+  border: 1px solid #3a3c60;
+  background: #1c1f38;
+  color: #9fa3ce;
+  cursor: pointer;
+}
+
+.switch-btn.on {
+  background: #355f98;
+  border-color: #4f7dbd;
+  color: #fff;
+}
+
+.switch-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.cron-create-card {
+  background: linear-gradient(135deg, rgba(53, 95, 152, 0.16), rgba(36, 36, 58, 0.92));
+}
+
+.cron-form-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.cron-input,
+.cron-textarea {
+  width: 100%;
+  background: #1d1f34;
+  border: 1px solid #323655;
+  border-radius: 10px;
+  color: #eef0ff;
+  font-size: 13px;
+  padding: 10px 12px;
+  outline: none;
+}
+
+.cron-input:focus,
+.cron-textarea:focus {
+  border-color: #4f7dbd;
+}
+
+.cron-textarea {
+  resize: vertical;
+  min-height: 70px;
+  margin-top: 10px;
+}
+
+.cron-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.cron-submit-btn {
+  min-width: 110px;
+  border: 1px solid #4f7dbd;
+  border-radius: 10px;
+  background: #355f98;
+  color: #f2f6ff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 14px;
+  cursor: pointer;
+}
+
+.cron-submit-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.cron-empty {
+  border: 1px dashed #3a3d62;
+  border-radius: 12px;
+  padding: 16px;
+  color: #a7acd7;
+  text-align: center;
+}
+
+.cron-list-item {
+  align-items: center;
+}
+
+.cron-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.danger-btn {
+  min-width: 64px;
+  height: 32px;
+  border-radius: 16px;
+  border: 1px solid #6c3a53;
+  background: #2a1a2a;
+  color: #f6bacf;
+  cursor: pointer;
+}
+
+.danger-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.module-price {
+  color: #ffbd59;
+  font-size: 20px;
+  font-weight: 700;
+  margin-top: 8px;
+}
+
+@media (max-width: 900px) {
+  .cron-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================
+   婊氬姩鏉＄編鍖?
+   ============================================ */
+
+.sidebar-menu::-webkit-scrollbar,
+.settings-panel-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sidebar-menu::-webkit-scrollbar-track,
+.settings-panel-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-menu::-webkit-scrollbar-thumb,
+.settings-panel-body::-webkit-scrollbar-thumb {
+  background: #3a3a4a;
+  border-radius: 2px;
+}
+

--- a/electron-frontend/src/settings.tsx
+++ b/electron-frontend/src/settings.tsx
@@ -1,0 +1,1204 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { usePicoClaw } from './usePicoClaw'
+import { useVoiceInput } from './useVoiceInput'
+import './settings.css'
+
+type PageType = 'chat' | 'settings'
+type MainMenu = 'chat' | 'skills' | 'cron' | 'channels' | 'pricing'
+type ToolStatus = 'enabled' | 'disabled' | 'blocked'
+
+interface ChatMessage {
+  id: string
+  text: string
+  time: string
+  isUser?: boolean
+  emotion?: string
+  action?: string
+}
+
+interface InitStatus {
+  need_config: boolean
+  has_character: boolean
+  character?: {
+    pet_name: string
+    pet_persona: string
+    pet_persona_type: string
+  }
+  emotion_state?: { emotion: string }
+}
+
+interface SkillItem {
+  name: string
+  source: string
+  description: string
+  installed_version?: string
+}
+
+interface ToolItem {
+  name: string
+  category: string
+  description: string
+  status: ToolStatus
+  reason_code?: string
+}
+
+interface ChannelItem {
+  key: string
+  label: string
+  configKey: string
+  variant?: string
+  enabled: boolean
+  secrets: number
+  source: 'live' | 'mock'
+}
+
+interface CronItem {
+  id: string
+  name: string
+  scheduleText: string
+  enabled: boolean
+  description: string
+  nextRunText: string
+  lastResultText: string
+  source: 'live' | 'mock'
+}
+
+interface CronScheduleDTO {
+  kind: string
+  atMs?: number
+  everyMs?: number
+  expr?: string
+  tz?: string
+}
+
+interface CronPayloadDTO {
+  message: string
+  channel?: string
+  to?: string
+  command?: string
+}
+
+interface CronStateDTO {
+  nextRunAtMs?: number
+  lastRunAtMs?: number
+  lastStatus?: string
+  lastError?: string
+}
+
+interface CronJobDTO {
+  id: string
+  name: string
+  enabled: boolean
+  schedule: CronScheduleDTO
+  payload: CronPayloadDTO
+  state?: CronStateDTO
+}
+
+interface AudioPushData {
+  chat_id?: number | null
+  text?: string
+  is_final?: boolean
+  type?: string
+}
+
+interface PendingAudioStream {
+  chatId: number | null
+  chunks: Uint8Array[]
+}
+
+const API_BASE = 'http://127.0.0.1:18790'
+
+const ASSET_PREFIX =
+  typeof window !== 'undefined' &&
+  (window.location.protocol === 'http:' || window.location.protocol === 'https:')
+    ? '/'
+    : './'
+
+function assetPath(name: string) {
+  return `${ASSET_PREFIX}${name.replace(/^\/+/, '')}`
+}
+
+const FORCE_TEST_ONBOARDING = (() => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    const byQuery = new URLSearchParams(window.location.search).get('onboarding') === '1'
+    const byStorage = window.localStorage.getItem('clawpet.forceOnboarding') === '1'
+    return byQuery || byStorage
+  } catch {
+    return false
+  }
+})()
+const ONBOARDING_DONE_KEY = 'clawpet.onboardingDone'
+
+const ALLOWED_PERSONA_TYPES = new Set(['gentle', 'playful', 'cool'])
+const MIN_PET_NAME_LENGTH = 2
+const MAX_PET_NAME_LENGTH = 24
+const MIN_PERSONA_LENGTH = 8
+const MAX_PERSONA_LENGTH = 300
+
+const CHARACTERS = [
+  { id: 'lively', name: '活泼', desc: '元气满满' },
+  { id: 'healing', name: '治愈', desc: '温暖贴心' },
+  { id: 'cool', name: '高冷', desc: '克制理性' },
+]
+
+const MOCK_SKILLS: SkillItem[] = [
+  { name: 'daily-care', source: 'workspace', description: 'Daily companion reminders.' },
+  { name: 'frontend-helper', source: 'builtin', description: 'UI copy and edge-case checklist.' },
+]
+
+const MOCK_TOOLS: ToolItem[] = [
+  { name: 'exec', category: 'filesystem', description: 'Run shell commands.', status: 'enabled' },
+  { name: 'read_file', category: 'filesystem', description: 'Read workspace files.', status: 'enabled' },
+  { name: 'web_search', category: 'web', description: 'Search web content.', status: 'disabled' },
+]
+
+const MOCK_CHANNELS: ChannelItem[] = [
+  { key: 'pico', label: 'Pico', configKey: 'pico', enabled: true, secrets: 1, source: 'mock' },
+  { key: 'pet', label: 'Pet', configKey: 'pet', enabled: true, secrets: 0, source: 'mock' },
+]
+
+const MOCK_CRON: CronItem[] = [
+  {
+    id: '1',
+    name: '早安问候',
+    scheduleText: 'cron · 0 8 * * *',
+    enabled: true,
+    description: '每天 08:00 发送早安消息',
+    nextRunText: '明天 08:00',
+    lastResultText: '最近执行：ok',
+    source: 'mock',
+  },
+  {
+    id: '2',
+    name: '学习打卡',
+    scheduleText: 'cron · 0 21 * * 1-5',
+    enabled: false,
+    description: '工作日 21:00 提醒打卡',
+    nextRunText: '已暂停',
+    lastResultText: '最近执行：- ',
+    source: 'mock',
+  },
+]
+
+const PRICING = [
+  { name: '免费版', price: '¥0', detail: '基础聊天、基础记忆' },
+  { name: '专业版', price: '¥29/月', detail: '无限聊天、工具管理、定时任务' },
+  { name: '团队版', price: '¥99/月/人', detail: '多人协作、权限管理、专属支持' },
+]
+
+const SUGGESTIONS = [
+  { icon: '💬', title: '聊聊心情', desc: '和桌宠分享你的感受', text: '今天过得怎么样？' },
+  { icon: '📋', title: '今日任务', desc: '帮你安排待办事项', text: '帮我整理一下今天的任务' },
+  { icon: '🎭', title: '性格调整', desc: '进入设置页', action: 'settings' as const },
+  { icon: '🧠', title: '记忆回顾', desc: '看看桌宠记住了什么', text: '你还记得我之前说过什么吗？' },
+]
+
+const emotionToGif: Record<string, string[]> = {
+  joy: ['happy1.gif', 'happy2.gif'],
+  happy: ['happy1.gif', 'happy2.gif'],
+  sadness: ['sad.gif'],
+  anger: ['shake-head_out.gif'],
+  surprise: ['celebrate_out.gif'],
+  neutral: ['standby1.gif', 'standby2.gif', 'standby3.gif'],
+}
+
+function getEmotionGif(emotion: string) {
+  const gifs = emotionToGif[emotion] || emotionToGif.neutral
+  return gifs[Math.floor(Math.random() * gifs.length)]
+}
+
+function timeText() {
+  return new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+}
+
+function titleCase(v: string) {
+  return v.split('_').join(' ').replace(/\b\w/g, (m: string) => m.toUpperCase())
+}
+
+async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init)
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`)
+  }
+  return (await res.json()) as T
+}
+
+function parseMaybeJSON<T>(raw: unknown): T | null {
+  if (raw == null) {
+    return null
+  }
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return null
+    }
+  }
+  return raw as T
+}
+
+function mergeFinalText(streamed: string, finalChunk?: string) {
+  const streamText = streamed || ''
+  const finalText = finalChunk || ''
+
+  if (!streamText) {
+    return finalText.trim()
+  }
+  if (!finalText) {
+    return streamText.trim()
+  }
+  if (streamText === finalText) {
+    return finalText.trim()
+  }
+  if (streamText.includes(finalText)) {
+    return streamText.trim()
+  }
+  if (finalText.includes(streamText)) {
+    return finalText.trim()
+  }
+  return `${streamText}${finalText}`.trim()
+}
+
+function decodeBase64Chunk(value: string): Uint8Array | null {
+  const base64 = value
+    .replace(/^data:audio\/[^;]+;base64,/, '')
+    .replace(/\s+/g, '')
+  if (!base64) {
+    return new Uint8Array()
+  }
+
+  try {
+    const binary = window.atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i)
+    }
+    return bytes
+  } catch (error) {
+    console.warn('[settings] dropped malformed audio chunk', error)
+    return null
+  }
+}
+
+function mergeAudioChunks(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+  return merged
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return ''
+  }
+
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return window.btoa(binary)
+}
+
+export default function PetClawApp() {
+  const [page, setPage] = useState<PageType>('chat')
+  const [menu, setMenu] = useState<MainMenu>('chat')
+  const [inputText, setInputText] = useState('')
+  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
+  const [streamingText, setStreamingText] = useState('')
+  const [petGif, setPetGif] = useState('/standby1.gif')
+  const [connStatus, setConnStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting')
+  const [needOnboarding, setNeedOnboarding] = useState(FORCE_TEST_ONBOARDING)
+  const [onboardingSubmitting, setOnboardingSubmitting] = useState(false)
+  const [onboardingError, setOnboardingError] = useState('')
+  const [petName, setPetName] = useState('ClawPet')
+  const [petPersona, setPetPersona] = useState('温柔体贴，善于倾听。')
+  const [petPersonaType, setPetPersonaType] = useState('gentle')
+  const [conversationHistory, setConversationHistory] = useState<{ id: string; name: string; time: string }[]>([])
+
+  const [skills, setSkills] = useState<SkillItem[]>(MOCK_SKILLS)
+  const [tools, setTools] = useState<ToolItem[]>(MOCK_TOOLS)
+  const [channels, setChannels] = useState<ChannelItem[]>(MOCK_CHANNELS)
+  const [cronItems, setCronItems] = useState<CronItem[]>(MOCK_CRON)
+  const [skillsSource, setSkillsSource] = useState<'live' | 'mock'>('mock')
+  const [toolsSource, setToolsSource] = useState<'live' | 'mock'>('mock')
+  const [channelsSource, setChannelsSource] = useState<'live' | 'mock'>('mock')
+  const [moduleLoading, setModuleLoading] = useState(false)
+  const [moduleError, setModuleError] = useState('')
+  const [settingsCharacter, setSettingsCharacter] = useState('lively')
+
+  const chatRef = useRef('')
+  const emotionRef = useRef('neutral')
+  const msgListRef = useRef<HTMLDivElement>(null)
+  const audioStreamRef = useRef<PendingAudioStream>({ chatId: null, chunks: [] })
+  const responseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const { isListening, toggleListening } = useVoiceInput({
+    onResult: (txt) => setInputText((v) => `${v}${txt}`),
+  })
+
+  const { send, on, off, isConnected, isConnecting } = usePicoClaw(API_BASE, {
+    onConnectionChange: (ok) => {
+      if (ok) {
+        window.electronAPI?.sendConnectionAlive?.()
+      }
+    },
+  })
+
+  useEffect(() => {
+    setConnStatus(isConnected ? 'connected' : isConnecting ? 'connecting' : 'disconnected')
+  }, [isConnected, isConnecting])
+
+  useEffect(() => {
+    if (msgListRef.current) {
+      msgListRef.current.scrollTop = msgListRef.current.scrollHeight
+    }
+  }, [chatHistory, streamingText])
+
+  const clearResponseTimeout = useCallback(() => {
+    if (responseTimeoutRef.current) {
+      clearTimeout(responseTimeoutRef.current)
+      responseTimeoutRef.current = null
+    }
+  }, [])
+
+  const resetAudioStream = useCallback(() => {
+    audioStreamRef.current = { chatId: null, chunks: [] }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      clearResponseTimeout()
+    }
+  }, [clearResponseTimeout])
+
+  useEffect(() => {
+    on('init_status', (raw) => {
+      const data = parseMaybeJSON<InitStatus>(raw)
+      if (!data) {
+        return
+      }
+
+      if (data.character) {
+        setPetName(data.character.pet_name || 'ClawPet')
+        setPetPersona(data.character.pet_persona || '温柔体贴，善于倾听。')
+        setPetPersonaType(data.character.pet_persona_type || 'gentle')
+      }
+
+      if (!FORCE_TEST_ONBOARDING) {
+        let showOnboarding = Boolean(data.need_config)
+        if (!showOnboarding) {
+          try {
+            showOnboarding = window.localStorage.getItem(ONBOARDING_DONE_KEY) !== '1'
+          } catch {
+            showOnboarding = false
+          }
+        }
+        setNeedOnboarding(showOnboarding)
+      }
+
+      if (data.emotion_state?.emotion) {
+        emotionRef.current = data.emotion_state.emotion
+        setPetGif(getEmotionGif(data.emotion_state.emotion))
+      }
+    })
+
+    on('emotion_change', (raw) => {
+      const data = parseMaybeJSON<{ emotion?: string }>(raw)
+      if (!data?.emotion) {
+        return
+      }
+      emotionRef.current = data.emotion
+      setPetGif(getEmotionGif(data.emotion))
+    })
+
+    on('ai_chat', (raw) => {
+      const data = parseMaybeJSON<{
+        text?: string
+        emotion?: string
+        action?: string
+        is_final?: boolean
+      }>(raw)
+      if (!data) {
+        return
+      }
+      clearResponseTimeout()
+
+      if (data.is_final) {
+        const text = mergeFinalText(chatRef.current, data.text)
+        chatRef.current = ''
+        setStreamingText('')
+        if (text) {
+          setChatHistory((p) => [
+            ...p,
+            {
+              id: `ai_${Date.now()}`,
+              text,
+              time: timeText(),
+              emotion: emotionRef.current,
+              action: data.action,
+            },
+          ])
+        }
+        return
+      }
+
+      if (!data.text) {
+        return
+      }
+
+      if (data.emotion) {
+        emotionRef.current = data.emotion
+      }
+      chatRef.current += data.text
+      setStreamingText(chatRef.current)
+    })
+
+    on('audio', (raw) => {
+      const data = parseMaybeJSON<AudioPushData>(raw)
+      if (!data) {
+        return
+      }
+
+      if (data.type === 'error') {
+        resetAudioStream()
+        return
+      }
+
+      const hasExplicitChatId =
+        typeof data.chat_id === 'number' && Number.isFinite(data.chat_id)
+      const incomingChatId: number | null = hasExplicitChatId ? data.chat_id! : null
+
+      let currentStream = audioStreamRef.current
+      if (hasExplicitChatId) {
+        if (currentStream.chatId !== incomingChatId) {
+          currentStream = { chatId: incomingChatId, chunks: [] }
+          audioStreamRef.current = currentStream
+        }
+      } else if (currentStream.chatId !== null) {
+        currentStream = { chatId: null, chunks: [] }
+        audioStreamRef.current = currentStream
+      }
+
+      if (data.text) {
+        const chunkBytes = decodeBase64Chunk(data.text)
+        if (chunkBytes === null) {
+          resetAudioStream()
+          return
+        }
+        if (chunkBytes.length > 0) {
+          currentStream.chunks.push(chunkBytes)
+        }
+      }
+
+      if (!data.is_final) {
+        return
+      }
+
+      const merged = mergeAudioChunks(currentStream.chunks)
+      resetAudioStream()
+      const audioBase64 = bytesToBase64(merged)
+      if (!audioBase64) {
+        return
+      }
+
+      window.electronAPI?.showBubble({
+        text: null,
+        emotion: emotionRef.current,
+        audio: audioBase64,
+      })
+    })
+
+    return () => {
+      off('init_status')
+      off('emotion_change')
+      off('ai_chat')
+      off('audio')
+    }
+  }, [clearResponseTimeout, on, off, resetAudioStream])
+
+  const sendMessage = useCallback(
+    async (text?: string) => {
+      const msg = (text || inputText).trim()
+      if (!msg || needOnboarding) {
+        return
+      }
+
+      setChatHistory((p) => [...p, { id: `u_${Date.now()}`, text: msg, time: timeText(), isUser: true }])
+      setInputText('')
+      resetAudioStream()
+
+      try {
+        await send('chat', { text: msg })
+        clearResponseTimeout()
+        responseTimeoutRef.current = setTimeout(() => {
+          setChatHistory((p) => [
+            ...p,
+            {
+              id: `timeout_${Date.now()}`,
+              text: '后端暂未返回，请先检查网关 /ready 状态与模型配置。',
+              time: timeText(),
+              emotion: 'neutral',
+            },
+          ])
+        }, 12000)
+      } catch (error) {
+        clearResponseTimeout()
+        const message = error instanceof Error ? error.message : '发送失败'
+        setChatHistory((p) => [
+          ...p,
+          {
+            id: `err_${Date.now()}`,
+            text: `发送失败：${message}`,
+            time: timeText(),
+            emotion: 'neutral',
+          },
+        ])
+      }
+    },
+    [clearResponseTimeout, inputText, needOnboarding, resetAudioStream, send],
+  )
+
+  const submitOnboarding = useCallback(async () => {
+    if (onboardingSubmitting) {
+      return
+    }
+
+    const name = petName.trim()
+    const persona = petPersona.trim()
+    const personaType = (petPersonaType || 'gentle').trim()
+
+    if (!isConnected) {
+      setOnboardingError('当前未连接后端，请先启动网关后再完成引导')
+      return
+    }
+    if (!name || !persona) {
+      setOnboardingError('请填写宠物名称和性格描述')
+      return
+    }
+    if (name.length < MIN_PET_NAME_LENGTH || name.length > MAX_PET_NAME_LENGTH) {
+      setOnboardingError(`宠物名称需为 ${MIN_PET_NAME_LENGTH}-${MAX_PET_NAME_LENGTH} 个字符`)
+      return
+    }
+    if (persona.length < MIN_PERSONA_LENGTH || persona.length > MAX_PERSONA_LENGTH) {
+      setOnboardingError(`性格描述需为 ${MIN_PERSONA_LENGTH}-${MAX_PERSONA_LENGTH} 个字符`)
+      return
+    }
+    if (!ALLOWED_PERSONA_TYPES.has(personaType)) {
+      setOnboardingError('性格类型不合法，请选择 gentle / playful / cool')
+      return
+    }
+
+    setOnboardingSubmitting(true)
+    setOnboardingError('')
+
+    try {
+      await send('onboarding_config', {
+        pet_name: name,
+        pet_persona: persona,
+        pet_persona_type: personaType,
+      })
+      try {
+        window.localStorage.setItem(ONBOARDING_DONE_KEY, '1')
+      } catch {
+        // ignore localStorage failures
+      }
+      setNeedOnboarding(false)
+      const emotion = (await send('emotion_get', {})) as { emotion?: string }
+      if (emotion?.emotion) {
+        emotionRef.current = emotion.emotion
+        setPetGif(getEmotionGif(emotion.emotion))
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '提交失败，请检查后端连接'
+      setOnboardingError(message)
+    } finally {
+      setOnboardingSubmitting(false)
+    }
+  }, [isConnected, onboardingSubmitting, petName, petPersona, petPersonaType, send])
+
+  const loadSkillsAndTools = useCallback(async () => {
+    setModuleLoading(true)
+    setModuleError('')
+
+    try {
+      const [s, t] = await Promise.allSettled([
+        fetchJSON<{ skills: SkillItem[] }>(`${API_BASE}/api/skills`),
+        fetchJSON<{ tools: ToolItem[] }>(`${API_BASE}/api/tools`),
+      ])
+
+      if (s.status === 'fulfilled') {
+        setSkills(s.value.skills || [])
+        setSkillsSource('live')
+      } else {
+        setSkills(MOCK_SKILLS)
+        setSkillsSource('mock')
+      }
+
+      if (t.status === 'fulfilled') {
+        setTools(t.value.tools || [])
+        setToolsSource('live')
+      } else {
+        setTools(MOCK_TOOLS)
+        setToolsSource('mock')
+      }
+
+      if (s.status === 'rejected' && t.status === 'rejected') {
+        setModuleError('技能与工具接口不可用，已切换 mock')
+      }
+    } finally {
+      setModuleLoading(false)
+    }
+  }, [])
+
+  const loadChannels = useCallback(async () => {
+    setModuleLoading(true)
+    setModuleError('')
+
+    try {
+      const catalog = await fetchJSON<{
+        channels: { name: string; config_key: string; variant?: string }[]
+      }>(`${API_BASE}/api/channels/catalog`)
+
+      const details = await Promise.allSettled(
+        catalog.channels.map((c) =>
+          fetchJSON<{
+            config?: { enabled?: boolean }
+            configured_secrets?: string[]
+            config_key?: string
+            variant?: string
+          }>(`${API_BASE}/api/channels/${encodeURIComponent(c.name)}/config`),
+        ),
+      )
+
+      const rows = catalog.channels.map((c, i) => {
+        const d = details[i]
+        if (d.status !== 'fulfilled') {
+          return {
+            key: c.name,
+            label: titleCase(c.name),
+            configKey: c.config_key,
+            variant: c.variant,
+            enabled: false,
+            secrets: 0,
+            source: 'mock' as const,
+          }
+        }
+
+        return {
+          key: c.name,
+          label: titleCase(c.name),
+          configKey: d.value.config_key || c.config_key,
+          variant: d.value.variant || c.variant,
+          enabled: Boolean(d.value.config?.enabled),
+          secrets: d.value.configured_secrets?.length || 0,
+          source: 'live' as const,
+        }
+      })
+
+      setChannels(rows)
+      setChannelsSource(rows.some((r) => r.source === 'mock') ? 'mock' : 'live')
+    } catch {
+      setChannels(MOCK_CHANNELS)
+      setChannelsSource('mock')
+      setModuleError('频道接口不可用，已切换 mock')
+    } finally {
+      setModuleLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (page !== 'chat') {
+      return
+    }
+    if (menu === 'skills') {
+      void loadSkillsAndTools()
+    }
+    if (menu === 'channels') {
+      void loadChannels()
+    }
+  }, [menu, page, loadSkillsAndTools, loadChannels])
+
+  const toggleTool = useCallback(
+    async (name: string, enable: boolean) => {
+      const before = tools.find((t) => t.name === name)?.status || 'disabled'
+      setTools((p) => p.map((t) => (t.name === name ? { ...t, status: enable ? 'enabled' : 'disabled' } : t)))
+
+      if (toolsSource !== 'live') {
+        return
+      }
+
+      try {
+        await fetchJSON(`${API_BASE}/api/tools/${encodeURIComponent(name)}/state`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: enable }),
+        })
+      } catch {
+        setTools((p) => p.map((t) => (t.name === name ? { ...t, status: before } : t)))
+        setModuleError(`更新工具 ${name} 失败`)
+      }
+    },
+    [tools, toolsSource],
+  )
+
+  const newChat = () => {
+    if (chatHistory.length > 0) {
+      setConversationHistory((p) => [
+        {
+          id: `c_${Date.now()}`,
+          name: chatHistory[0].text.slice(0, 18),
+          time: new Date().toLocaleDateString('zh-CN'),
+        },
+        ...p,
+      ].slice(0, 8))
+    }
+    setChatHistory([])
+    setStreamingText('')
+    chatRef.current = ''
+    setMenu('chat')
+  }
+
+  const hasMessages = chatHistory.length > 0 || Boolean(streamingText)
+  const enabledTools = useMemo(() => tools.filter((t) => t.status === 'enabled').length, [tools])
+
+  return (
+    <div className="petclaw-app">
+      <div className="sidebar">
+        <div className="sidebar-header">
+          <img
+            src="/pet.svg"
+            alt="logo"
+            className="sidebar-logo"
+            onError={(e) => {
+              const target = e.currentTarget
+              if (!target.src.endsWith('/standby1.gif')) {
+                target.src = '/standby1.gif'
+              }
+            }}
+          />
+          <span className="sidebar-brand">ClawPet AI</span>
+          <span className="sidebar-badge">测试版</span>
+        </div>
+
+        <button className="new-chat-btn" onClick={newChat}>
+          + 新建聊天
+        </button>
+
+        <div className="sidebar-menu">
+          {([
+            { k: 'chat', i: '💬', n: 'ClawPet' },
+            { k: 'skills', i: '🧩', n: '技能' },
+            { k: 'cron', i: '⏰', n: '定时任务' },
+            { k: 'channels', i: '📡', n: '频道' },
+            { k: 'pricing', i: '💳', n: '价格' },
+          ] as { k: MainMenu; i: string; n: string }[]).map((m) => (
+            <button
+              key={m.k}
+              className={`menu-item ${menu === m.k ? 'active' : ''}`}
+              onClick={() => {
+                setMenu(m.k)
+                setPage('chat')
+              }}
+            >
+              <span className="menu-icon">{m.i}</span>
+              <span className="menu-label">{m.n}</span>
+            </button>
+          ))}
+
+          {conversationHistory.length > 0 && (
+            <>
+              <div className="sidebar-section-title">对话记录</div>
+              {conversationHistory.map((h) => (
+                <div key={h.id} className="history-item">
+                  <span className="history-icon">🗒️</span>
+                  <div className="history-info">
+                    <div className="history-name">{h.name}</div>
+                    <div className="history-time">{h.time}</div>
+                  </div>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+
+        <div className="sidebar-footer">
+          <button className="invite-btn">🏷 邀请码</button>
+          <div className="sidebar-footer-row">
+            <div className="footer-icons">
+              <button className="footer-icon-btn">👤</button>
+              <button className="footer-icon-btn" onClick={() => setPage('settings')}>
+                ⚙️
+              </button>
+              <button className="footer-icon-btn">🌙</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="main-area" style={{ position: 'relative' }}>
+        {FORCE_TEST_ONBOARDING && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              background: 'linear-gradient(90deg, #ff6b6b, #feca57)',
+              color: '#111',
+              padding: '8px 16px',
+              textAlign: 'center',
+              fontWeight: 700,
+              fontSize: '14px',
+              zIndex: 9999,
+              boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+            }}
+          >
+            调试模式：已强制开启引导页（onboarding）
+          </div>
+        )}
+
+        <div className="top-bar">
+          <div className="top-left">
+            <span className={`conn-dot ${connStatus}`}></span>
+            <span className="conn-text">
+              {connStatus === 'connected'
+                ? '已连接'
+                : connStatus === 'connecting'
+                  ? '连接中'
+                  : '未连接'}
+            </span>
+          </div>
+
+          <div className="top-center">
+            <button
+              className={`tab-btn ${menu === 'chat' ? 'active' : ''}`}
+              onClick={() => {
+                setPage('chat')
+                setMenu('chat')
+              }}
+            >
+              ClawPet
+            </button>
+            <button
+              className={`tab-btn ${menu !== 'chat' ? 'active' : ''}`}
+              onClick={() => {
+                setPage('chat')
+                if (menu === 'chat') {
+                  setMenu('skills')
+                }
+              }}
+            >
+              工作
+            </button>
+          </div>
+
+          <div className="top-right">
+            <span className="plan-text">Free</span>
+            <button className="upgrade-btn">升级</button>
+            <div className="window-controls">
+              <button className="win-btn" onClick={() => window.electronAPI?.minimizeSettings()}>
+                —
+              </button>
+              <button className="win-btn" onClick={() => window.electronAPI?.maximizeSettings()}>
+                □
+              </button>
+              <button className="win-btn close" onClick={() => window.electronAPI?.closeSettings()}>
+                ×
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {needOnboarding && (
+          <div className="onboarding-overlay">
+            <div className="onboarding-card">
+              <h2>欢迎来到 ClawPet</h2>
+              <p>先完成一次宠物初始化配置，之后再开始聊天。</p>
+
+              <div className="onboarding-form">
+                <label>宠物名称</label>
+                <input value={petName} onChange={(e) => setPetName(e.target.value)} />
+
+                <label>性格类型</label>
+                <select value={petPersonaType} onChange={(e) => setPetPersonaType(e.target.value)}>
+                  <option value="gentle">gentle</option>
+                  <option value="playful">playful</option>
+                  <option value="cool">cool</option>
+                </select>
+
+                <label>性格描述</label>
+                <textarea rows={4} value={petPersona} onChange={(e) => setPetPersona(e.target.value)} />
+              </div>
+
+              {onboardingError && <div className="onboarding-error">{onboardingError}</div>}
+
+              <div className="onboarding-actions">
+                <button className="onboarding-submit" onClick={submitOnboarding} disabled={onboardingSubmitting}>
+                  {onboardingSubmitting ? '提交中...' : '完成引导'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {page === 'chat' && (
+          <div className="chat-content">
+            {menu === 'chat' && (
+              <>
+                {!hasMessages ? (
+                  <div className="empty-state">
+                    <img src={petGif} alt="pet" className="pet-avatar" />
+                    <div className="greeting-text">今天有什么可以帮你？</div>
+                    <div className="suggestion-grid">
+                      {SUGGESTIONS.map((s, i) => (
+                        <div
+                          key={i}
+                          className="suggestion-card"
+                          onClick={() => (s.action === 'settings' ? setPage('settings') : void sendMessage(s.text))}
+                        >
+                          <span className="suggestion-icon">{s.icon}</span>
+                          <div className="suggestion-info">
+                            <div className="suggestion-title">{s.title}</div>
+                            <div className="suggestion-desc">{s.desc}</div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="message-list" ref={msgListRef}>
+                    {chatHistory.map((m) => (
+                      <div key={m.id} className={`chat-msg ${m.isUser ? 'user' : 'ai'}`}>
+                        {!m.isUser && (
+                          <img
+                            src={m.emotion ? getEmotionGif(m.emotion) : petGif}
+                            alt="pet"
+                            className="msg-avatar pet-gif"
+                          />
+                        )}
+                        <div className="msg-body">
+                          <div className="msg-bubble">{m.text}</div>
+                          <span className="msg-time">
+                            {m.time}
+                            {!m.isUser && m.action ? ` · Tool: ${m.action}` : ''}
+                          </span>
+                        </div>
+                        {m.isUser && <div style={{ width: 32 }} />}
+                      </div>
+                    ))}
+
+                    {streamingText && (
+                      <div className="streaming-indicator">
+                        <img src={petGif} alt="pet" className="msg-avatar pet-gif" />
+                        <div className="streaming-bubble">{streamingText}</div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <div className="input-bar">
+                  <div className="toolbar-row">
+                    <button className="toolbar-btn">+</button>
+                    <button className="toolbar-btn">快速 ▾</button>
+                  </div>
+                  <div className="input-row">
+                    <input
+                      className="input-text"
+                      placeholder="输入消息..."
+                      value={inputText}
+                      onChange={(e) => setInputText(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault()
+                          void sendMessage()
+                        }
+                      }}
+                    />
+                    <div className="input-actions">
+                      <button className={`input-icon-btn ${isListening ? 'listening' : ''}`} onClick={toggleListening}>
+                        🎤
+                      </button>
+                      <button
+                        className="send-btn"
+                        onClick={() => void sendMessage()}
+                        disabled={!inputText.trim() || !isConnected || needOnboarding}
+                      >
+                        ➤
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {menu !== 'chat' && (
+              <div className="module-page">
+                <div className="module-header">
+                  <h2>
+                    {menu === 'skills'
+                      ? '技能与工具'
+                      : menu === 'cron'
+                        ? '定时任务'
+                        : menu === 'channels'
+                          ? '频道配置'
+                          : '价格计划'}
+                  </h2>
+                  <span className="module-source">
+                    {menu === 'skills'
+                      ? `skills:${skillsSource} tools:${toolsSource}`
+                      : menu === 'channels'
+                        ? channelsSource
+                        : 'mock'}
+                  </span>
+                </div>
+
+                {moduleError && <div className="module-error">{moduleError}</div>}
+                {moduleLoading && (menu === 'skills' || menu === 'channels') && (
+                  <div className="module-loading">加载中...</div>
+                )}
+
+                {menu === 'skills' && !moduleLoading && (
+                  <>
+                    <div className="module-block">
+                      <h3>已安装技能</h3>
+                      <div className="module-grid">
+                        {skills.map((s) => (
+                          <div key={s.name} className="module-card">
+                            <div className="module-card-title">{s.name}</div>
+                            <div className="module-card-meta">
+                              {s.source}
+                              {s.installed_version ? ` · ${s.installed_version}` : ''}
+                            </div>
+                            <div className="module-card-desc">{s.description || 'No description'}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="module-block">
+                      <h3>{`Tool 能力（已启用 ${enabledTools}/${tools.length}）`}</h3>
+                      <div className="module-list">
+                        {tools.map((t) => (
+                          <div key={t.name} className="module-list-item">
+                            <div>
+                              <div className="module-card-title">{t.name}</div>
+                              <div className="module-card-meta">{t.category}</div>
+                              <div className="module-card-desc">{t.description}</div>
+                            </div>
+                            <button
+                              className={`switch-btn ${t.status === 'enabled' ? 'on' : ''}`}
+                              disabled={t.status === 'blocked'}
+                              onClick={() => void toggleTool(t.name, t.status !== 'enabled')}
+                            >
+                              {t.status === 'blocked' ? 'blocked' : t.status === 'enabled' ? 'on' : 'off'}
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {menu === 'cron' && (
+                  <div className="module-list">
+                    {cronItems.map((c) => (
+                      <div key={c.id} className="module-list-item">
+                        <div>
+                          <div className="module-card-title">{c.name}</div>
+                          <div className="module-card-meta">{c.scheduleText}</div>
+                          <div className="module-card-desc">{c.description}</div>
+                        </div>
+                        <button
+                          className={`switch-btn ${c.enabled ? 'on' : ''}`}
+                          onClick={() =>
+                            setCronItems((p) => p.map((x) => (x.id === c.id ? { ...x, enabled: !x.enabled } : x)))
+                          }
+                        >
+                          {c.enabled ? 'on' : 'off'}
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {menu === 'channels' && !moduleLoading && (
+                  <div className="module-grid">
+                    {channels.map((c) => (
+                      <div key={`${c.key}:${c.variant || ''}`} className="module-card">
+                        <div className="module-card-title">{c.label}</div>
+                        <div className="module-card-meta">
+                          {c.configKey}
+                          {c.variant ? ` · ${c.variant}` : ''}
+                        </div>
+                        <div className="module-card-desc">
+                          {`enabled: ${String(c.enabled)}`}
+                          <br />
+                          {`configured secrets: ${c.secrets}`}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {menu === 'pricing' && (
+                  <div className="module-grid">
+                    {PRICING.map((p) => (
+                      <div key={p.name} className="module-card">
+                        <div className="module-card-title">{p.name}</div>
+                        <div className="module-price">{p.price}</div>
+                        <div className="module-card-desc">{p.detail}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {page === 'settings' && (
+          <div className="settings-overlay">
+            <div className="settings-panel-header">
+              <button className="settings-back-btn" onClick={() => setPage('chat')}>
+                ← 返回
+              </button>
+              <span className="settings-panel-title">偏好设置</span>
+            </div>
+            <div className="settings-panel-body">
+              <div className="setting-section">
+                <h3>人格切换</h3>
+                <div className="char-grid">
+                  {CHARACTERS.map((c) => (
+                    <div
+                      key={c.id}
+                      className={`char-card ${settingsCharacter === c.id ? 'active' : ''}`}
+                      onClick={() => setSettingsCharacter(c.id)}
+                    >
+                      <div className="char-name">{c.name}</div>
+                      <div className="char-desc">{c.desc}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="setting-section">
+                <h3>后端</h3>
+                <div className="setting-item">
+                  <label>Gateway</label>
+                  <input type="text" readOnly value={API_BASE || '(same-origin in dev)'} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -9,6 +9,23 @@ interface PicoTokenInfo {
   protocol?: string
 }
 
+interface PicoTokenResponse {
+  token?: string
+  ws_url?: string
+  enabled?: boolean
+  protocol?: string
+}
+
+interface HealthStatusResponse {
+  status?: string
+}
+
+interface FetchJsonResult<T> {
+  ok: boolean
+  status?: number
+  data?: T
+}
+
 type MessageHandler = (data: any) => void
 type TransportMode = 'pico' | 'legacy'
 
@@ -78,6 +95,17 @@ function joinUrl(base: string, path: string): string {
   return `${trimTrailingSlash(base)}${path}`
 }
 
+function resolveHttpBase(base: string): string {
+  const trimmed = trimTrailingSlash(base || '')
+  if (trimmed) {
+    return trimmed
+  }
+  if (typeof window !== 'undefined') {
+    return trimTrailingSlash(window.location.origin)
+  }
+  return ''
+}
+
 function unique(values: string[]): string[] {
   return Array.from(new Set(values))
 }
@@ -101,21 +129,14 @@ function buildBaseCandidates(configuredBase: string): string[] {
   return unique(candidates)
 }
 
-function isPetTokenInfo(info: PicoTokenInfo): boolean {
+function isPetTokenInfo(info: { protocol?: string; ws_url?: string }): boolean {
   if (info.protocol === 'pet') {
     return true
   }
-  return info.ws_url.includes('/pet/ws') || /:8080\/ws(\?|$)/.test(info.ws_url)
-}
-
-function hasUsableTokenInfo(info: PicoTokenInfo): boolean {
   if (!info.ws_url) {
     return false
   }
-  if (isPetTokenInfo(info)) {
-    return true
-  }
-  return Boolean(info.token)
+  return info.ws_url.includes('/pet/ws') || /:8080\/ws(\?|$)/.test(info.ws_url)
 }
 
 function isPetWsUrl(wsUrl: string): boolean {
@@ -123,6 +144,35 @@ function isPetWsUrl(wsUrl: string): boolean {
     return false
   }
   return wsUrl.includes('/pet/ws') || /:8080\/ws(\?|$)/.test(wsUrl)
+}
+
+function buildDefaultPetWsUrl(base: string): string | null {
+  const httpBase = resolveHttpBase(base)
+  if (!httpBase) {
+    return null
+  }
+  return normalizeWsUrl(joinUrl(httpBase, '/pet/ws'))
+}
+
+function normalizePetTokenInfo(
+  info: PicoTokenResponse | undefined,
+  base: string,
+): PicoTokenInfo | null {
+  if (!info || info.enabled === false) {
+    return null
+  }
+
+  const ws_url = info.ws_url?.trim() || buildDefaultPetWsUrl(base)
+  if (!ws_url || !isPetWsUrl(ws_url)) {
+    return null
+  }
+
+  return {
+    token: info.token,
+    ws_url,
+    enabled: info.enabled ?? true,
+    protocol: info.protocol || 'pet',
+  }
 }
 
 function decodeEscapedUnicode(value: string): string {
@@ -184,10 +234,10 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
     const bases = buildBaseCandidates(apiBaseRef.current)
     const tried: string[] = []
 
-    const tryFetchJSON = async (
+    const tryFetchJSON = async <T,>(
       endpoint: string,
       init?: RequestInit,
-    ): Promise<{ ok: boolean; status?: number; data?: PicoTokenInfo }> => {
+    ): Promise<FetchJsonResult<T>> => {
       tried.push(endpoint)
       try {
         const res = await fetch(endpoint, {
@@ -198,7 +248,7 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
         if (!res.ok) {
           return { ok: false, status: res.status }
         }
-        const data = (await res.json()) as PicoTokenInfo
+        const data = (await res.json()) as T
         return { ok: true, status: res.status, data }
       } catch (error) {
         log('fetch failed', { endpoint, error: String(error) })
@@ -207,28 +257,41 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
     }
 
     for (const base of bases) {
+      const healthEndpoint = joinUrl(base, '/health')
       const petTokenEndpoint = joinUrl(base, '/pet/token')
       log('fetchTokenInfo try base', {
         base,
+        healthEndpoint,
         petTokenEndpoint,
       })
 
-      const petToken = await tryFetchJSON(petTokenEndpoint)
-      if (petToken.ok && petToken.data && hasUsableTokenInfo(petToken.data)) {
-        if (!isPetWsUrl(petToken.data.ws_url)) {
-          log('fetchTokenInfo got non-pet ws_url, skip', {
-            endpoint: petTokenEndpoint,
-            ws_url: petToken.data.ws_url,
-          })
-          continue
-        }
+      const health = await tryFetchJSON<HealthStatusResponse>(healthEndpoint)
+      if (!health.ok) {
+        log('fetchTokenInfo health unavailable, skip', {
+          endpoint: healthEndpoint,
+          status: health.status,
+        })
+        continue
+      }
+
+      const petToken = await tryFetchJSON<PicoTokenResponse>(petTokenEndpoint)
+      const tokenInfo = normalizePetTokenInfo(petToken.data, base)
+      if (petToken.ok && tokenInfo) {
         log('fetchTokenInfo success (pet)', {
           base,
+          healthEndpoint,
           endpoint: petTokenEndpoint,
-          ws_url: petToken.data.ws_url,
+          ws_url: tokenInfo.ws_url,
         })
-        return petToken.data
+        return tokenInfo
       }
+
+      log('fetchTokenInfo pet channel unavailable, skip', {
+        endpoint: petTokenEndpoint,
+        status: petToken.status,
+        enabled: petToken.data?.enabled,
+        ws_url: petToken.data?.ws_url,
+      })
     }
 
     console.error('[PicoClaw] Failed to fetch pet token info from /pet/token', { tried })

--- a/electron-frontend/src/useVoiceInput.ts
+++ b/electron-frontend/src/useVoiceInput.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+interface UseVoiceInputOptions {
+  onResult?: (text: string) => void
+  onError?: (error: string) => void
+  lang?: string
+}
+
+export function useVoiceInput(options: UseVoiceInputOptions = {}) {
+  const { onResult, onError, lang = 'zh-CN' } = options
+  const [isListening, setIsListening] = useState(false)
+  const [isSupported, setIsSupported] = useState(false)
+  const [status, setStatus] = useState('idle') // idle, starting, listening, recognized, error
+  const recognitionRef = useRef<any>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    
+    if (SpeechRecognition) {
+      setStatus('idle')
+      setIsSupported(true)
+    } else {
+      setStatus('not-supported')
+      setIsSupported(false)
+    }
+
+    return () => {
+      if (recognitionRef.current) {
+        try {
+          recognitionRef.current.abort()
+        } catch (e) {}
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+    }
+  }, [])
+
+  const startListening = useCallback(() => {
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    
+    if (!SpeechRecognition) {
+      setStatus('error')
+      onError?.('浏览器不支持语音识别')
+      return
+    }
+
+    try {
+      setStatus('starting')
+      const recognition = new SpeechRecognition()
+      recognition.continuous = true
+      recognition.interimResults = true
+      recognition.lang = lang
+      recognition.maxAlternatives = 1
+
+      recognition.onresult = (event: any) => {
+        let finalTranscript = ''
+        let interimTranscript = ''
+
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const transcript = event.results[i][0].transcript
+          if (event.results[i].isFinal) {
+            finalTranscript += transcript
+          } else {
+            interimTranscript += transcript
+          }
+        }
+
+        if (finalTranscript) {
+          setStatus('recognized')
+          onResult?.(finalTranscript)
+          setTimeout(() => setStatus('idle'), 1000)
+        } else {
+          setStatus('listening')
+        }
+      }
+
+      recognition.onerror = (event: any) => {
+        setStatus('error')
+        setIsListening(false)
+        if (event.error !== 'no-speech' && event.error !== 'aborted') {
+          onError?.(event.error)
+        }
+        setTimeout(() => setStatus('idle'), 2000)
+      }
+
+      recognition.onend = () => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+          timeoutRef.current = null
+        }
+        setIsListening(false)
+        if (status === 'listening') {
+          setStatus('idle')
+        }
+      }
+
+      recognitionRef.current = recognition
+      recognition.start()
+      setIsListening(true)
+      setStatus('listening')
+      
+      timeoutRef.current = setTimeout(() => {
+        if (recognitionRef.current) {
+          recognitionRef.current.stop()
+        }
+      }, 60000)
+      
+    } catch (e: any) {
+      setStatus('error')
+      setIsListening(false)
+      onError?.(e.message || '启动失败')
+      setTimeout(() => setStatus('idle'), 2000)
+    }
+  }, [lang, onResult, onError, status])
+
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.abort()
+        setIsListening(false)
+        setStatus('idle')
+      } catch (e) {}
+    }
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  const toggleListening = useCallback(() => {
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
+    }
+  }, [isListening, startListening, stopListening])
+
+  return {
+    isListening,
+    isSupported,
+    status, // idle, starting, listening, recognized, error, not-supported
+    startListening,
+    stopListening,
+    toggleListening
+  }
+}

--- a/petclaw/app/onboarding/page.tsx
+++ b/petclaw/app/onboarding/page.tsx
@@ -1,18 +1,24 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 import { OnboardingWizard } from "@/components/onboarding-wizard"
 import { WindowControls } from "@/components/window-controls"
 
 export default function OnboardingPage() {
+  const [isElectronShell, setIsElectronShell] = useState(false)
+
+  useEffect(() => {
+    setIsElectronShell(Boolean(window.electronAPI))
+  }, [])
+
   useEffect(() => {
     document.title = "初始化向导 - PetClaw AI"
   }, [])
 
   return (
-    <div className="h-screen bg-background p-4 md:p-5">
-      <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-border/70 bg-card shadow-[0_20px_60px_-35px_rgba(120,80,20,0.45)]">
+    <div className={`h-screen bg-background ${isElectronShell ? "p-0" : "p-4 md:p-5"}`}>
+      <div className={`flex h-full flex-col overflow-hidden bg-card ${isElectronShell ? "rounded-none border-0 shadow-none" : "rounded-3xl border border-border/70 shadow-[0_20px_60px_-35px_rgba(120,80,20,0.45)]"}`}>
         <WindowControls title="初始化向导 - PetClaw AI" />
         <div className="min-h-0 flex-1">
           <OnboardingWizard

--- a/petclaw/app/page.tsx
+++ b/petclaw/app/page.tsx
@@ -34,6 +34,7 @@ export default function Home() {
   const [bootState, setBootState] = useState<"checking" | "onboarding" | "ready">("ready")
   const [uiMood, setUiMood] = useState<"low" | "medium" | "high" | "critical">("medium")
   const [readyVisible, setReadyVisible] = useState(false)
+  const [isElectronShell, setIsElectronShell] = useState(false)
 
   const applyMoodFromOnboardingState = () => {
     const state = loadOnboardingState()
@@ -44,6 +45,10 @@ export default function Home() {
     }
     setUiMood("medium")
   }
+
+  useEffect(() => {
+    setIsElectronShell(Boolean(window.electronAPI))
+  }, [])
 
   useEffect(() => {
     try {
@@ -145,7 +150,7 @@ export default function Home() {
 
   if (bootState === "onboarding") {
     return (
-      <div className="h-screen bg-transparent p-4 md:p-5">
+      <div className={`h-screen bg-transparent ${isElectronShell ? "p-0" : "p-4 md:p-5"}`}>
         <OnboardingWizard
           onFinish={() => {
             const url = new URL(window.location.href)
@@ -167,8 +172,8 @@ export default function Home() {
   } as const
 
   return (
-    <div className={`h-screen bg-transparent p-4 transition-all duration-500 ease-out md:p-5 ${readyVisible ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"}`}>
-      <div className={`flex h-full flex-col overflow-hidden rounded-3xl transition-[background-color,border-color,box-shadow] duration-700 ease-out ${shellByMood[uiMood]}`}>
+    <div className={`h-screen bg-transparent transition-all duration-500 ease-out ${isElectronShell ? "p-0" : "p-4 md:p-5"} ${readyVisible ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0"}`}>
+      <div className={`flex h-full flex-col overflow-hidden transition-[background-color,border-color,box-shadow,border-radius] duration-700 ease-out ${isElectronShell ? "rounded-none border-0 shadow-none" : "rounded-3xl"} ${shellByMood[uiMood]}`}>
         <WindowControls title={`${activeNav} - PetClaw AI`} />
         <div className="flex min-h-0 flex-1" data-electron-no-drag="true">
           <Sidebar activeNav={activeNav} setActiveNav={setActiveNav} />

--- a/petclaw/lib/api/bootstrap.ts
+++ b/petclaw/lib/api/bootstrap.ts
@@ -1,4 +1,10 @@
-import { API_ENDPOINTS, getApiBaseUrl, withLauncherAuthRequest } from './config'
+import {
+  API_ENDPOINTS,
+  DIRECT_PET_TOKEN_PATH,
+  getApiBaseUrl,
+  getDirectGatewayBaseUrl,
+  withLauncherAuthRequest,
+} from './config'
 import { ensureLauncherAuthSession, fetchWithAuthRetry } from './auth-bootstrap'
 
 interface GatewayStatusResponse {
@@ -53,6 +59,35 @@ async function getGatewayStatus(): Promise<GatewayStatusResponse> {
     throw new Error(`gateway status failed: ${res.status}`)
   }
   return (await res.json()) as GatewayStatusResponse
+}
+
+async function isDirectGatewayHealthy(): Promise<boolean> {
+  try {
+    const res = await fetch(`${getDirectGatewayBaseUrl()}/health`)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+async function isDirectPetChannelReady(): Promise<boolean> {
+  try {
+    const res = await fetch(`${getDirectGatewayBaseUrl()}${DIRECT_PET_TOKEN_PATH}`)
+    if (!res.ok) {
+      return false
+    }
+    const data = (await res.json()) as { enabled?: boolean; ws_url?: string }
+    return Boolean(data.enabled && data.ws_url)
+  } catch {
+    return false
+  }
+}
+
+async function isDirectGatewayReady(): Promise<boolean> {
+  if (!(await isDirectGatewayHealthy())) {
+    return false
+  }
+  return isDirectPetChannelReady()
 }
 
 async function startGateway(): Promise<void> {
@@ -232,6 +267,10 @@ async function ensureDefaultModelIfNeeded(startReason?: string): Promise<void> {
 }
 
 export async function ensureBackendReadyForChat(): Promise<BackendBootstrapResult> {
+  if (await isDirectGatewayReady()) {
+    return { ok: true }
+  }
+
   const authed = await ensureLauncherAuthSession()
   if (!authed) {
     return { ok: false, reason: 'dashboard auth missing' }
@@ -243,6 +282,10 @@ export async function ensureBackendReadyForChat(): Promise<BackendBootstrapResul
     return wsReady
       ? { ok: true }
       : { ok: false, reason: 'websocket proxy unavailable (gateway not ready)' }
+  }
+
+  if (await isDirectGatewayReady()) {
+    return { ok: true }
   }
 
   await ensureDefaultModelIfNeeded(status.gateway_start_reason)

--- a/petclaw/lib/api/client.ts
+++ b/petclaw/lib/api/client.ts
@@ -1,6 +1,7 @@
 import {
   API_ENDPOINTS,
   getApiBaseUrl,
+  getDirectGatewayBaseUrl,
   getAuthRequestCredentials,
   withLauncherAuthHeader,
 } from './config'
@@ -57,6 +58,18 @@ async function request<T>(
   return JSON.parse(text)
 }
 
+async function fetchDirectGatewayHealth(): Promise<{ uptime?: string } | null> {
+  try {
+    const res = await fetch(`${getDirectGatewayBaseUrl()}/health`)
+    if (!res.ok) {
+      return null
+    }
+    return (await res.json()) as { uptime?: string }
+  } catch {
+    return null
+  }
+}
+
 // 认证 API
 export const authApi = {
   login: (token: string) =>
@@ -78,13 +91,52 @@ export const authApi = {
 // 网关 API
 export const gatewayApi = {
   status: async () => {
-    const raw = await request<{
-      gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'
-      pid?: number
-      gateway_restart_required?: boolean
-      gateway_start_allowed?: boolean
-      gateway_start_reason?: string
-    }>(API_ENDPOINTS.GATEWAY.STATUS)
+    let raw:
+      | {
+          gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'
+          pid?: number
+          gateway_restart_required?: boolean
+          gateway_start_allowed?: boolean
+          gateway_start_reason?: string
+        }
+      | null = null
+
+    try {
+      raw = await request<{
+        gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'
+        pid?: number
+        gateway_restart_required?: boolean
+        gateway_start_allowed?: boolean
+        gateway_start_reason?: string
+      }>(API_ENDPOINTS.GATEWAY.STATUS)
+    } catch (error) {
+      const direct = await fetchDirectGatewayHealth()
+      if (!direct) {
+        throw error
+      }
+      return {
+        running: true,
+        state: 'running' as const,
+        pid: undefined,
+        restartRequired: false,
+        startAllowed: false,
+        startReason: 'direct gateway fallback',
+        uptime: direct.uptime,
+      }
+    }
+
+    const direct = await fetchDirectGatewayHealth()
+    if (direct && raw.gateway_status !== 'running') {
+      return {
+        running: true,
+        state: 'running' as const,
+        pid: raw.pid,
+        restartRequired: Boolean(raw.gateway_restart_required),
+        startAllowed: raw.gateway_start_allowed,
+        startReason: raw.gateway_start_reason || 'direct gateway fallback',
+        uptime: direct.uptime,
+      }
+    }
 
     const state = raw.gateway_status === 'error' ? 'stopped' : (raw.gateway_status || 'stopped')
     return {
@@ -94,6 +146,7 @@ export const gatewayApi = {
       restartRequired: Boolean(raw.gateway_restart_required),
       startAllowed: raw.gateway_start_allowed,
       startReason: raw.gateway_start_reason,
+      uptime: direct?.uptime,
     }
   },
 

--- a/petclaw/lib/api/config.ts
+++ b/petclaw/lib/api/config.ts
@@ -1,4 +1,7 @@
 const LOCAL_DEFAULT_ORIGIN = 'http://127.0.0.1:18800'
+const LOCAL_DIRECT_GATEWAY_ORIGIN = process.env.NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL || 'http://127.0.0.1:18790'
+export const DIRECT_PET_TOKEN_PATH = '/pet/token'
+export const DIRECT_PET_WS_PATH = '/pet/ws'
 
 export const API_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_API_URL || ''
 export const WS_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_WS_URL || ''
@@ -27,6 +30,10 @@ export function getApiBaseUrl(): string {
   }
 
   return LOCAL_DEFAULT_ORIGIN
+}
+
+export function getDirectGatewayBaseUrl(): string {
+  return LOCAL_DIRECT_GATEWAY_ORIGIN
 }
 
 export function getWsBaseUrl(): string {

--- a/petclaw/lib/api/websocket.ts
+++ b/petclaw/lib/api/websocket.ts
@@ -1,6 +1,9 @@
 import {
   API_ENDPOINTS,
+  DIRECT_PET_TOKEN_PATH,
+  DIRECT_PET_WS_PATH,
   getApiBaseUrl,
+  getDirectGatewayBaseUrl,
   getAuthRequestCredentials,
   getWsBaseUrl,
   withLauncherAuthHeader,
@@ -48,6 +51,13 @@ interface TokenResponse {
   ws_url?: string
 }
 
+interface TokenCandidate {
+  baseUrl: string
+  tokenPath: string
+  wsPath: string
+  useLauncherAuth: boolean
+}
+
 type WSMode = 'pet'
 type OutboundRequest = PetRequest
 
@@ -81,6 +91,9 @@ export class PicoClawWebSocket {
   private msgIdCounter = 0
   private lastConnectUrl = ''
   private manualClose = false
+  private activeAssistantMessageId: string | null = null
+  private activeAssistantContent = ''
+  private activeAssistantTimestamp = 0
   private openHandlers: {
     settle: () => void
     fail: (err: Error) => void
@@ -118,10 +131,10 @@ export class PicoClawWebSocket {
         if (!this.sessionId) {
           this.sessionId = this.generateSessionId()
         }
-        const { token, wsPath, mode } = await this.resolveTokenAndPath()
+        const { token, wsPath, wsBaseUrl, mode } = await this.resolveTokenAndPath()
         this.wsMode = mode
         const query = `session=${encodeURIComponent(this.sessionId)}&session_id=${encodeURIComponent(this.sessionId)}`
-        const url = `${getWsBaseUrl()}${wsPath}?${query}`
+        const url = `${wsBaseUrl}${wsPath}?${query}`
         this.connectWebSocket(url, token, mode)
       } catch (err) {
         this.openHandlers = null
@@ -130,37 +143,64 @@ export class PicoClawWebSocket {
     })
   }
 
-  private async resolveTokenAndPath(): Promise<{ token: string; wsPath: string; mode: WSMode }> {
-    const endpoint = { tokenPath: API_ENDPOINTS.PET.TOKEN, wsPath: API_ENDPOINTS.CHAT.WS }
+  private async resolveTokenAndPath(): Promise<{ token: string; wsPath: string; wsBaseUrl: string; mode: WSMode }> {
+    const candidates: TokenCandidate[] = [
+      {
+        baseUrl: getDirectGatewayBaseUrl(),
+        tokenPath: DIRECT_PET_TOKEN_PATH,
+        wsPath: DIRECT_PET_WS_PATH,
+        useLauncherAuth: false,
+      },
+      {
+        baseUrl: getApiBaseUrl(),
+        tokenPath: API_ENDPOINTS.PET.TOKEN,
+        wsPath: API_ENDPOINTS.CHAT.WS,
+        useLauncherAuth: true,
+      },
+    ]
 
-    const res = await fetch(`${getApiBaseUrl()}${endpoint.tokenPath}`, {
-      method: 'GET',
-      headers: withLauncherAuthHeader(),
-      credentials: getAuthRequestCredentials(`${getApiBaseUrl()}${endpoint.tokenPath}`),
-    })
+    let lastError = 'PET channel not available'
 
-    if (res.status === 404) {
-      throw new Error('PET channel not available')
+    for (const candidate of candidates) {
+      const input = `${candidate.baseUrl}${candidate.tokenPath}`
+      const res = await fetch(input, {
+        method: 'GET',
+        headers: candidate.useLauncherAuth ? withLauncherAuthHeader() : undefined,
+        credentials: candidate.useLauncherAuth ? getAuthRequestCredentials(input) : 'omit',
+      }).catch(() => null)
+
+      if (!res) {
+        lastError = `Token endpoint failed (${candidate.tokenPath}): network error`
+        continue
+      }
+
+      if (res.status === 404) {
+        lastError = 'PET channel not available'
+        continue
+      }
+
+      if (!res.ok) {
+        lastError = `Token endpoint failed (${candidate.tokenPath}): HTTP ${res.status}`
+        continue
+      }
+
+      const data = (await res.json()) as TokenResponse
+      if (!data.enabled) {
+        lastError = `Channel not enabled (${candidate.tokenPath})`
+        continue
+      }
+
+      const wsPathFromToken = this.normalizeWsPath(data.ws_url)
+      const wsBaseUrl = this.normalizeWsBaseUrl(data.ws_url, candidate.baseUrl)
+      return {
+        token: data.token || '',
+        wsPath: wsPathFromToken || candidate.wsPath,
+        wsBaseUrl,
+        mode: 'pet',
+      }
     }
 
-    if (!res.ok) {
-      throw new Error(`Token endpoint failed (${endpoint.tokenPath}): HTTP ${res.status}`)
-    }
-
-    const data = (await res.json()) as TokenResponse
-    if (!data.enabled) {
-      throw new Error(`Channel not enabled (${endpoint.tokenPath})`)
-    }
-    const wsPathFromToken = this.normalizeWsPath(data.ws_url)
-    const wsPath = wsPathFromToken || endpoint.wsPath
-    const mode: WSMode = 'pet'
-    const token = data.token || ''
-
-    return {
-      token,
-      wsPath,
-      mode,
-    }
+    throw new Error(lastError)
   }
 
   private normalizeWsPath(raw?: string): string {
@@ -180,6 +220,23 @@ export class PicoClawWebSocket {
     }
 
     return value.startsWith('/') ? value : `/${value}`
+  }
+
+  private normalizeWsBaseUrl(raw: string | undefined, fallbackBaseUrl: string): string {
+    if (raw && raw.trim()) {
+      try {
+        const parsed = new URL(raw)
+        return `${parsed.protocol}//${parsed.host}`
+      } catch {
+        // ignore and use fallback
+      }
+    }
+
+    if (fallbackBaseUrl === getApiBaseUrl()) {
+      return getWsBaseUrl()
+    }
+
+    return fallbackBaseUrl.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:')
   }
 
   private connectWebSocket(url: string, token: string, mode: WSMode): void {
@@ -267,16 +324,35 @@ export class PicoClawWebSocket {
   }
 
   private handleAIChatPush(data: Record<string, unknown>): void {
-    const chatId = (data.chat_id as number) || 0
     const contentType = (data.type as string) || 'text'
     const text = (data.text as string) || ''
+    const timestamp = Date.now()
 
-    if (contentType === 'text' || contentType === '') {
+    if (contentType === 'tool') {
       const chatMsg: ChatMessage = {
-        id: `msg-${chatId}`,
+        id: `tool-${timestamp}-${Math.random().toString(36).slice(2, 8)}`,
         role: 'assistant',
         content: text,
-        timestamp: Date.now(),
+        timestamp,
+        streaming: false,
+      }
+      this.emit({ type: 'message', data: chatMsg })
+      return
+    }
+
+    if (contentType === 'text' || contentType === '') {
+      if (!this.activeAssistantMessageId) {
+        this.activeAssistantMessageId = `assistant-${timestamp}`
+        this.activeAssistantContent = ''
+        this.activeAssistantTimestamp = timestamp
+      }
+
+      this.activeAssistantContent += text
+      const chatMsg: ChatMessage = {
+        id: this.activeAssistantMessageId,
+        role: 'assistant',
+        content: this.activeAssistantContent,
+        timestamp: this.activeAssistantTimestamp || timestamp,
         streaming: true,
       }
       this.emit({ type: 'message', data: chatMsg })
@@ -284,15 +360,32 @@ export class PicoClawWebSocket {
     }
 
     if (contentType === 'final') {
+      if (text) {
+        if (!this.activeAssistantMessageId) {
+          this.activeAssistantMessageId = `assistant-${timestamp}`
+          this.activeAssistantTimestamp = timestamp
+        }
+        this.activeAssistantContent += text
+      }
+
+      const finalContent = this.activeAssistantContent || text
+      if (!this.activeAssistantMessageId) {
+        this.activeAssistantMessageId = `assistant-${timestamp}`
+        this.activeAssistantTimestamp = timestamp
+      }
+
       const chatMsg: ChatMessage = {
-        id: `msg-${chatId}`,
+        id: this.activeAssistantMessageId,
         role: 'assistant',
-        content: text,
-        timestamp: Date.now(),
+        content: finalContent,
+        timestamp: this.activeAssistantTimestamp || timestamp,
         streaming: false,
       }
       this.emit({ type: 'message', data: chatMsg })
       this.emit({ type: 'typing', data: 'false' })
+      this.activeAssistantMessageId = null
+      this.activeAssistantContent = ''
+      this.activeAssistantTimestamp = 0
     }
   }
 
@@ -323,6 +416,9 @@ export class PicoClawWebSocket {
   }
 
   send(content: string): void {
+    this.activeAssistantMessageId = null
+    this.activeAssistantContent = ''
+    this.activeAssistantTimestamp = 0
     this.sendAction(CHAT_ACTION, {
       text: content,
       session_key: this.sessionId,

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -242,20 +242,18 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 //  7. 检查情绪阈值，决定是否推送
 //  8. 从内容中移除所有标签
 func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*agent.LLMHookResponse, agent.HookDecision, error) {
-	// 防御性检查
 	if resp == nil || resp.Response == nil {
-		logger.InfoCF("pet", "PetHook.AfterLLM: 响应为空，跳过", nil)
+		logger.InfoCF("pet", "PetHook.AfterLLM: response is nil, skip", nil)
 		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
 	}
 
 	content := resp.Response.Content
 	if content == "" {
-		logger.InfoCF("pet", "PetHook.AfterLLM: 内容为空，跳过", nil)
+		logger.InfoCF("pet", "PetHook.AfterLLM: content is empty, skip", nil)
 		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
 	}
 
-	// 记录LLM原始响应
-	logger.DebugCF("pet", "PetHook.AfterLLM: 收到LLM响应", map[string]any{
+	logger.DebugCF("pet", "PetHook.AfterLLM: received LLM response", map[string]any{
 		"content_length": len(content),
 		"content_preview": func() string {
 			if len(content) > 200 {
@@ -265,30 +263,27 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 		}(),
 	})
 
-	// 1. 解析情绪标签并更新（使用增量更新）
+	currentChar := h.charManager.GetCurrent()
+
 	emotionTags := parseEmotionTags(content)
-	if len(emotionTags) > 0 {
-		logger.InfoCF("pet", "PetHook: 解析到情绪标签", map[string]any{
+	if len(emotionTags) > 0 && currentChar != nil {
+		logger.InfoCF("pet", "PetHook: parsed emotion tags", map[string]any{
 			"emotion_tags": emotionTags,
 		})
-		h.charManager.GetCurrent().GetEmotionEngine().UpdateFromLLMTagsDelta(emotionTags)
-		// 情绪状态会在 Shutdown 时通过 configManager 统一保存
+		currentChar.GetEmotionEngine().UpdateFromLLMTagsDelta(emotionTags)
 	}
 
-	// 2. 解析MBTI标签并更新
 	mbtiTags := emotion.ParseMBTITags(content)
-	if len(mbtiTags) > 0 {
-		logger.InfoCF("pet", "PetHook: 解析到MBTI标签", map[string]any{
+	if len(mbtiTags) > 0 && currentChar != nil {
+		logger.InfoCF("pet", "PetHook: parsed MBTI tags", map[string]any{
 			"mbti_tags": mbtiTags,
 		})
-		h.charManager.GetCurrent().GetEmotionEngine().UpdateMBTIFromTags(mbtiTags)
-		// MBTI 会在 Shutdown 时通过 configManager 统一保存
+		currentChar.GetEmotionEngine().UpdateMBTIFromTags(mbtiTags)
 	}
 
-	// 3. 解析动作标签并触发推送
 	actionNames := h.actionManager.ParseActionTags(content)
 	if len(actionNames) > 0 {
-		logger.InfoCF("pet", "PetHook: 解析到动作标签", map[string]any{
+		logger.InfoCF("pet", "PetHook: parsed action tags", map[string]any{
 			"action_names": actionNames,
 		})
 		actions := h.actionManager.GetByNames(actionNames)
@@ -297,53 +292,42 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 		}
 	}
 
-	// 4. 解析记忆标签并保存
 	memoryTags := parseMemoryTags(content)
-	if len(memoryTags) > 0 && h.memoryStore != nil {
-		char := h.charManager.GetCurrent()
-		if char != nil {
-			for _, tag := range memoryTags {
-				h.memoryStore.Add(char.ID, tag.Summary, tag.Type, tag.Weight)
-				logger.Infof("pet: saved memory type=%s, weight=%d, summary=%s", tag.Type, tag.Weight, tag.Summary)
-			}
+	if len(memoryTags) > 0 && h.memoryStore != nil && currentChar != nil {
+		for _, tag := range memoryTags {
+			h.memoryStore.Add(currentChar.ID, tag.Summary, tag.Type, tag.Weight)
+			logger.Infof("pet: saved memory type=%s, weight=%d, summary=%s", tag.Type, tag.Weight, tag.Summary)
 		}
 	}
 
-	// 5. 检查情绪阈值，决定是否推送
-	if shouldPush, push := h.charManager.GetCurrent().GetEmotionEngine().ShouldPush(); shouldPush {
-		logger.InfoCF("pet", "PetHook: 情绪阈值触发推送", map[string]any{
-			"emotion": push.Emotion,
-			"score":   push.Score,
-		})
-		h.pushEmotionChange(push)
+	if currentChar != nil {
+		if shouldPush, push := currentChar.GetEmotionEngine().ShouldPush(); shouldPush {
+			logger.InfoCF("pet", "PetHook: emotion threshold triggered push", map[string]any{
+				"emotion": push.Emotion,
+				"score":   push.Score,
+			})
+			h.pushEmotionChange(push)
+		}
 	}
 
-	// 5. 提取用户可见文本
-	// 首先从 [text:xxx] 标签提取纯文本
-	textTags := parseTextTags(content)
-	if len(textTags) == 0 {
-		logger.InfoCF("pet", "PetHook:LLM响应中未解析到文本标签", nil)
+	parseText := extractTextFromTags(content)
+	if parseText == "" {
+		logger.InfoCF("pet", "PetHook: no text tags found in LLM response", nil)
 		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
 	}
-	parseText := textTags[0].Text
+
 	resp.Response.Content = content
 
-	// 6. 记录对话到会话存储（用于后续压缩）
-	if h.conversationStore != nil {
-		char := h.charManager.GetCurrent()
-		if char != nil {
-			if h.lastUserMessage != "" {
-				if err := h.conversationStore.Add(char.ID, "user", h.lastUserMessage); err != nil {
-					logger.Warnf("pet: failed to add user message to conversation store: %v", err)
-				}
+	if h.conversationStore != nil && currentChar != nil {
+		if h.lastUserMessage != "" {
+			if err := h.conversationStore.Add(currentChar.ID, "user", h.lastUserMessage); err != nil {
+				logger.Warnf("pet: failed to add user message to conversation store: %v", err)
 			}
-			if parseText != "" {
-				if err := h.conversationStore.Add(char.ID, "pet", parseText); err != nil {
-					logger.Warnf("pet: failed to add pet message to conversation store: %v", err)
-				}
-			}
-			h.lastUserMessage = ""
 		}
+		if err := h.conversationStore.Add(currentChar.ID, "pet", parseText); err != nil {
+			logger.Warnf("pet: failed to add pet message to conversation store: %v", err)
+		}
+		h.lastUserMessage = ""
 	}
 
 	return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $petclawDir = Join-Path $repoRoot "petclaw"
 $electronDir = Join-Path $repoRoot "electron-frontend"
+$mainBinary = Join-Path $repoRoot "picoclaw.exe"
 
 if ([string]::IsNullOrWhiteSpace($LauncherConfigPath)) {
   $LauncherConfigPath = Join-Path $repoRoot ".goclaw-runtime\config.json"
@@ -553,7 +554,8 @@ if (-not [string]::IsNullOrWhiteSpace($resolvedLauncherBin)) {
     $escapedLauncherToken = $LauncherToken.Replace("'", "''")
     $escapedLauncherConfigPath = $LauncherConfigPath.Replace("'", "''")
     $escapedConfigDir = $configDir.Replace("'", "''")
-    $launcherCmd = "`$env:PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:PICOCLAW_HOME='$escapedConfigDir'; `$env:PICOCLAW_CONFIG='$escapedLauncherConfigPath'; & '$resolvedLauncherBin' '$escapedLauncherConfigPath'"
+    $escapedMainBinary = $mainBinary.Replace("'", "''")
+    $launcherCmd = "`$env:PICOCLAW_BINARY='$escapedMainBinary'; `$env:PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:PICOCLAW_HOME='$escapedConfigDir'; `$env:PICOCLAW_CONFIG='$escapedLauncherConfigPath'; & '$resolvedLauncherBin' -no-browser '$escapedLauncherConfigPath'"
     Start-DetachedPowerShell -Title "GoClaw - Launcher" -Command $launcherCmd
 
     if (-not (Wait-HttpReady -Url "http://127.0.0.1:18800" -TimeoutSeconds 25)) {


### PR DESCRIPTION
## Summary
- restore the desktop console flow by wiring Electron back into the PetClaw console pages
- fix desktop auth / launcher startup issues so gateway startup can find the local picoclaw binary
- stabilize PetClaw chat rendering by aggregating streamed assistant chunks into a single message
- prevent PetHook AfterLLM from panicking when LLM output does not contain expected text tags
- align the desktop path selection with the legacy pet channel flow and keep gateway / websocket fallbacks working

## What changed
- Electron desktop window routing and preload bridge updates for desktop console and onboarding flow
- PetClaw shell/onboarding layout fixes for Electron window chrome and border behavior
- PetClaw bootstrap, gateway status, websocket fallback, and direct pet-channel connection handling
- Pet hook safety fix to stop gateway crashes during streamed replies
- startup script updates to avoid unwanted browser auto-open and to pass the local picoclaw binary explicitly

## Verification
- 
pm run build in petclaw
- 
pm run build in electron-frontend
- go test ./pkg/pet -run Test -count=1
- manual gateway start/status checks through launcher APIs
- direct websocket verification against ws://127.0.0.1:18790/pet/ws confirming chat responses stream successfully
