### PR TITLE
fix: stabilize ClawPet gateway routing and launcher startup

### DIFF
--- a/electron-frontend/src/settings.tsx
+++ b/electron-frontend/src/settings.tsx
@@ -16,6 +16,12 @@ interface ChatMessage {
   action?: string
 }
 
+interface ConversationSummary {
+  id: string
+  name: string
+  time: string
+}
+
 interface InitStatus {
   need_config: boolean
   has_character: boolean
@@ -106,7 +112,8 @@ interface PendingAudioStream {
   chunks: Uint8Array[]
 }
 
-const API_BASE = 'http://127.0.0.1:18790'
+const API_BASE =
+  window.electronAPI?.getBackendBaseUrl?.()?.trim() || 'http://127.0.0.1:18800'
 
 const ASSET_PREFIX =
   typeof window !== 'undefined' &&
@@ -131,6 +138,8 @@ const FORCE_TEST_ONBOARDING = (() => {
   }
 })()
 const ONBOARDING_DONE_KEY = 'clawpet.onboardingDone'
+const CHAT_HISTORY_STORAGE_KEY = 'clawpet.desktop.chatHistory'
+const CONVERSATION_HISTORY_STORAGE_KEY = 'clawpet.desktop.conversationHistory'
 
 const ALLOWED_PERSONA_TYPES = new Set(['gentle', 'playful', 'cool'])
 const MIN_PET_NAME_LENGTH = 2
@@ -216,6 +225,22 @@ function timeText() {
 
 function titleCase(v: string) {
   return v.split('_').join(' ').replace(/\b\w/g, (m: string) => m.toUpperCase())
+}
+
+function loadStoredJSON<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') {
+    return fallback
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) {
+      return fallback
+    }
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
 }
 
 async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
@@ -310,7 +335,9 @@ export default function PetClawApp() {
   const [page, setPage] = useState<PageType>('chat')
   const [menu, setMenu] = useState<MainMenu>('chat')
   const [inputText, setInputText] = useState('')
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
+  const [chatHistory, setChatHistory] = useState<ChatMessage[]>(() =>
+    loadStoredJSON<ChatMessage[]>(CHAT_HISTORY_STORAGE_KEY, []),
+  )
   const [streamingText, setStreamingText] = useState('')
   const [petGif, setPetGif] = useState('/standby1.gif')
   const [connStatus, setConnStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting')
@@ -320,7 +347,9 @@ export default function PetClawApp() {
   const [petName, setPetName] = useState('ClawPet')
   const [petPersona, setPetPersona] = useState('温柔体贴，善于倾听。')
   const [petPersonaType, setPetPersonaType] = useState('gentle')
-  const [conversationHistory, setConversationHistory] = useState<{ id: string; name: string; time: string }[]>([])
+  const [conversationHistory, setConversationHistory] = useState<ConversationSummary[]>(() =>
+    loadStoredJSON<ConversationSummary[]>(CONVERSATION_HISTORY_STORAGE_KEY, []),
+  )
 
   const [skills, setSkills] = useState<SkillItem[]>(MOCK_SKILLS)
   const [tools, setTools] = useState<ToolItem[]>(MOCK_TOOLS)
@@ -360,6 +389,25 @@ export default function PetClawApp() {
       msgListRef.current.scrollTop = msgListRef.current.scrollHeight
     }
   }, [chatHistory, streamingText])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(CHAT_HISTORY_STORAGE_KEY, JSON.stringify(chatHistory))
+    } catch {
+      // ignore localStorage failures
+    }
+  }, [chatHistory])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        CONVERSATION_HISTORY_STORAGE_KEY,
+        JSON.stringify(conversationHistory),
+      )
+    } catch {
+      // ignore localStorage failures
+    }
+  }, [conversationHistory])
 
   const clearResponseTimeout = useCallback(() => {
     if (responseTimeoutRef.current) {

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -281,10 +281,9 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
       // Ignore launcher discovery failures and continue with static candidates.
     }
 
-    const bases = unique([
-      discoveredGatewayBase,
-      ...buildBaseCandidates(apiBaseRef.current),
-    ].filter(Boolean))
+    const bases = discoveredGatewayBase
+      ? unique([discoveredGatewayBase, ...buildBaseCandidates(apiBaseRef.current)])
+      : buildBaseCandidates(apiBaseRef.current)
 
     for (const base of bases) {
       const healthEndpoint = joinUrl(base, '/health')

--- a/electron-frontend/src/usePicoClaw.ts
+++ b/electron-frontend/src/usePicoClaw.ts
@@ -20,6 +20,10 @@ interface HealthStatusResponse {
   status?: string
 }
 
+interface GatewayStatusResponse {
+  gateway_base_url?: string
+}
+
 interface FetchJsonResult<T> {
   ok: boolean
   status?: number
@@ -129,6 +133,14 @@ function buildBaseCandidates(configuredBase: string): string[] {
   return unique(candidates)
 }
 
+function getLauncherApiBase(): string {
+  const fromElectron = window.electronAPI?.getBackendBaseUrl?.()
+  if (fromElectron && fromElectron.trim()) {
+    return trimTrailingSlash(fromElectron.trim())
+  }
+  return 'http://127.0.0.1:18800'
+}
+
 function isPetTokenInfo(info: { protocol?: string; ws_url?: string }): boolean {
   if (info.protocol === 'pet') {
     return true
@@ -231,7 +243,8 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
   }, [apiBaseUrl])
 
   const fetchTokenInfo = useCallback(async (): Promise<PicoTokenInfo | null> => {
-    const bases = buildBaseCandidates(apiBaseRef.current)
+    const launcherApiBase = getLauncherApiBase()
+    let discoveredGatewayBase = ''
     const tried: string[] = []
 
     const tryFetchJSON = async <T,>(
@@ -255,6 +268,23 @@ export function usePicoClaw(apiBaseUrl: string, callbacks?: PicoCallbacks) {
         return { ok: false }
       }
     }
+
+    try {
+      const gatewayStatus = await tryFetchJSON<GatewayStatusResponse>(
+        joinUrl(launcherApiBase, '/api/gateway/status'),
+      )
+      const candidate = gatewayStatus.data?.gateway_base_url?.trim() || ''
+      if (gatewayStatus.ok && candidate) {
+        discoveredGatewayBase = trimTrailingSlash(candidate)
+      }
+    } catch {
+      // Ignore launcher discovery failures and continue with static candidates.
+    }
+
+    const bases = unique([
+      discoveredGatewayBase,
+      ...buildBaseCandidates(apiBaseRef.current),
+    ].filter(Boolean))
 
     for (const base of bases) {
       const healthEndpoint = joinUrl(base, '/health')

--- a/electron-frontend/vite.config.ts
+++ b/electron-frontend/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const backendTarget = process.env.GOCLAW_BACKEND_URL || 'http://127.0.0.1:18800'
+
 export default defineConfig({
   plugins: [react()],
   base: './',
@@ -9,16 +11,16 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:18790',
+        target: backendTarget,
         changeOrigin: true,
       },
       '/pico': {
-        target: 'http://127.0.0.1:18790',
+        target: backendTarget,
         changeOrigin: true,
         ws: true,
       },
       '/pet/': {
-        target: 'http://127.0.0.1:18790',
+        target: backendTarget,
         changeOrigin: true,
         ws: true,
       },

--- a/petclaw/lib/api/bootstrap.ts
+++ b/petclaw/lib/api/bootstrap.ts
@@ -1,14 +1,15 @@
 import {
   API_ENDPOINTS,
+  cacheDirectGatewayBaseUrl,
   DIRECT_PET_TOKEN_PATH,
   getApiBaseUrl,
   getDirectGatewayBaseUrl,
-  withLauncherAuthRequest,
 } from './config'
 import { ensureLauncherAuthSession, fetchWithAuthRetry } from './auth-bootstrap'
 
 interface GatewayStatusResponse {
   gateway_status?: string
+  gateway_base_url?: string
   gateway_start_allowed?: boolean
   gateway_start_reason?: string
 }
@@ -58,7 +59,11 @@ async function getGatewayStatus(): Promise<GatewayStatusResponse> {
   if (!res.ok) {
     throw new Error(`gateway status failed: ${res.status}`)
   }
-  return (await res.json()) as GatewayStatusResponse
+  const data = (await res.json()) as GatewayStatusResponse
+  if (data.gateway_base_url) {
+    cacheDirectGatewayBaseUrl(data.gateway_base_url)
+  }
+  return data
 }
 
 async function isDirectGatewayHealthy(): Promise<boolean> {
@@ -112,23 +117,23 @@ async function waitGatewayRunning(maxAttempts = 12, delayMs = 800): Promise<bool
   return false
 }
 
-async function isWsProxyReady(wsPath: string): Promise<boolean> {
-  const url = `${getApiBaseUrl()}${wsPath}?session_id=preflight`
-  const res = await fetch(url, withLauncherAuthRequest(url, { method: 'GET' }))
+async function isLauncherPetChannelReady(): Promise<boolean> {
+  let res = await fetchWithAuthRetry(`${getApiBaseUrl()}${API_ENDPOINTS.PET.TOKEN}`, {
+    credentials: 'include',
+  })
 
-  // Without upgrade headers this endpoint is expected to return 400/403,
-  // but should not return 503 when gateway proxy is unavailable.
-  return res.status !== 503
-}
-
-async function ensureWsProxyReady(): Promise<boolean> {
-  const petReady = await isWsProxyReady(API_ENDPOINTS.CHAT.WS).catch(() => false)
-  if (petReady) {
-    return true
+  if (res.status === 404) {
+    res = await fetchWithAuthRetry(`${getApiBaseUrl()}${API_ENDPOINTS.PICO.TOKEN}`, {
+      credentials: 'include',
+    })
   }
 
-  const picoReady = await isWsProxyReady(API_ENDPOINTS.CHAT.WS_LEGACY).catch(() => false)
-  return picoReady
+  if (!res.ok) {
+    return false
+  }
+
+  const data = (await res.json()) as { enabled?: boolean; ws_url?: string }
+  return Boolean(data.enabled && data.ws_url)
 }
 
 async function ensureChannelSetup(): Promise<void> {
@@ -278,10 +283,10 @@ export async function ensureBackendReadyForChat(): Promise<BackendBootstrapResul
 
   const status = await getGatewayStatus()
   if (status.gateway_status === 'running') {
-    const wsReady = await ensureWsProxyReady()
-    return wsReady
+    const channelReady = await isLauncherPetChannelReady()
+    return channelReady
       ? { ok: true }
-      : { ok: false, reason: 'websocket proxy unavailable (gateway not ready)' }
+      : { ok: false, reason: 'pet channel token unavailable (gateway not ready)' }
   }
 
   if (await isDirectGatewayReady()) {
@@ -301,11 +306,11 @@ export async function ensureBackendReadyForChat(): Promise<BackendBootstrapResul
     }
   }
 
-  const wsReady = await ensureWsProxyReady()
-  if (!wsReady) {
+  const channelReady = await isLauncherPetChannelReady()
+  if (!channelReady) {
     return {
       ok: false,
-      reason: 'websocket proxy unavailable (gateway not ready)',
+      reason: 'pet channel token unavailable (gateway not ready)',
     }
   }
 

--- a/petclaw/lib/api/client.ts
+++ b/petclaw/lib/api/client.ts
@@ -76,6 +76,16 @@ async function fetchDirectGatewayHealth(baseUrl?: string): Promise<{ uptime?: st
   }
 }
 
+export interface GatewayStatus {
+  running: boolean
+  state: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting'
+  pid?: number
+  restartRequired: boolean
+  startAllowed?: boolean
+  startReason?: string
+  uptime?: string
+}
+
 // 认证 API
 export const authApi = {
   login: (token: string) =>
@@ -96,7 +106,7 @@ export const authApi = {
 
 // 网关 API
 export const gatewayApi = {
-  status: async () => {
+  status: async (): Promise<GatewayStatus> => {
     let raw:
       | {
           gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'

--- a/petclaw/lib/api/client.ts
+++ b/petclaw/lib/api/client.ts
@@ -1,5 +1,6 @@
 import {
   API_ENDPOINTS,
+  cacheDirectGatewayBaseUrl,
   getApiBaseUrl,
   getDirectGatewayBaseUrl,
   getAuthRequestCredentials,
@@ -58,9 +59,14 @@ async function request<T>(
   return JSON.parse(text)
 }
 
-async function fetchDirectGatewayHealth(): Promise<{ uptime?: string } | null> {
+async function fetchDirectGatewayHealth(baseUrl?: string): Promise<{ uptime?: string } | null> {
+  const targetBase = (baseUrl || getDirectGatewayBaseUrl()).trim()
+  if (!targetBase) {
+    return null
+  }
+
   try {
-    const res = await fetch(`${getDirectGatewayBaseUrl()}/health`)
+    const res = await fetch(`${targetBase}/health`)
     if (!res.ok) {
       return null
     }
@@ -95,6 +101,7 @@ export const gatewayApi = {
       | {
           gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'
           pid?: number
+          gateway_base_url?: string
           gateway_restart_required?: boolean
           gateway_start_allowed?: boolean
           gateway_start_reason?: string
@@ -105,6 +112,7 @@ export const gatewayApi = {
       raw = await request<{
         gateway_status?: 'stopped' | 'starting' | 'running' | 'stopping' | 'restarting' | 'error'
         pid?: number
+        gateway_base_url?: string
         gateway_restart_required?: boolean
         gateway_start_allowed?: boolean
         gateway_start_reason?: string
@@ -125,7 +133,11 @@ export const gatewayApi = {
       }
     }
 
-    const direct = await fetchDirectGatewayHealth()
+    if (raw.gateway_base_url) {
+      cacheDirectGatewayBaseUrl(raw.gateway_base_url)
+    }
+
+    const direct = await fetchDirectGatewayHealth(raw.gateway_base_url)
     if (direct && raw.gateway_status !== 'running') {
       return {
         running: true,

--- a/petclaw/lib/api/config.ts
+++ b/petclaw/lib/api/config.ts
@@ -1,5 +1,7 @@
 const LOCAL_DEFAULT_ORIGIN = 'http://127.0.0.1:18800'
-const LOCAL_DIRECT_GATEWAY_ORIGIN = process.env.NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL || 'http://127.0.0.1:18790'
+const DIRECT_GATEWAY_ENV_ORIGIN = process.env.NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL || ''
+const LOCAL_DIRECT_GATEWAY_ORIGIN = DIRECT_GATEWAY_ENV_ORIGIN || 'http://127.0.0.1:18790'
+const DIRECT_GATEWAY_CACHE_KEY = 'petclaw.directGatewayBaseUrl'
 export const DIRECT_PET_TOKEN_PATH = '/pet/token'
 export const DIRECT_PET_WS_PATH = '/pet/ws'
 
@@ -8,6 +10,14 @@ export const WS_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_WS_URL || ''
 export const WSS_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_WSS_URL || ''
 export const LAUNCHER_TOKEN = process.env.NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN || ''
 export const USE_CREDENTIALS = process.env.NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS !== 'false'
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function normalizeBaseUrl(value: string): string {
+  return trimTrailingSlash(value.trim())
+}
 
 export function getApiBaseUrl(): string {
   if (API_BASE_URL) {
@@ -33,7 +43,49 @@ export function getApiBaseUrl(): string {
 }
 
 export function getDirectGatewayBaseUrl(): string {
-  return LOCAL_DIRECT_GATEWAY_ORIGIN
+  if (DIRECT_GATEWAY_ENV_ORIGIN.trim()) {
+    return normalizeBaseUrl(DIRECT_GATEWAY_ENV_ORIGIN)
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      const cached = window.sessionStorage.getItem(DIRECT_GATEWAY_CACHE_KEY)
+      if (cached && cached.trim()) {
+        return normalizeBaseUrl(cached)
+      }
+    } catch {
+    }
+
+    try {
+      const cached = window.localStorage.getItem(DIRECT_GATEWAY_CACHE_KEY)
+      if (cached && cached.trim()) {
+        return normalizeBaseUrl(cached)
+      }
+    } catch {
+    }
+  }
+  return normalizeBaseUrl(LOCAL_DIRECT_GATEWAY_ORIGIN)
+}
+
+export function cacheDirectGatewayBaseUrl(value?: string | null): void {
+  const normalized = typeof value === 'string' ? normalizeBaseUrl(value) : ''
+  if (!normalized) {
+    return
+  }
+
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.sessionStorage.setItem(DIRECT_GATEWAY_CACHE_KEY, normalized)
+  } catch {
+  }
+
+  try {
+    window.localStorage.setItem(DIRECT_GATEWAY_CACHE_KEY, normalized)
+  } catch {
+  }
 }
 
 export function getWsBaseUrl(): string {
@@ -191,9 +243,11 @@ export const API_ENDPOINTS = {
   PET: {
     TOKEN: '/api/pet/token',
     SETUP: '/api/pet/setup',
+    ONBOARDING: '/api/pet/onboarding',
   },
   PICO: {
     TOKEN: '/api/pico/token',
     SETUP: '/api/pico/setup',
+    ONBOARDING: '/api/pico/onboarding',
   },
 } as const

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -578,7 +578,7 @@ try {
     Ensure-GatewayPortAvailable -ConfigPath $LauncherConfigPath
 
     $gatewayStatus = Invoke-LauncherApi -Method GET -Path "/api/gateway/status" -LauncherToken $LauncherToken
-    if ($gatewayStatus.gateway_status -ne "running") {
+    if ($gatewayStatus.gateway_status -eq "stopped" -or $gatewayStatus.gateway_status -eq "error") {
       $null = Invoke-LauncherApi -Method POST -Path "/api/gateway/start" -LauncherToken $LauncherToken
     }
 
@@ -621,6 +621,9 @@ try {
   throw "Gateway preflight failed: $($_.Exception.Message)"
 }
 
+$gatewayPort = Get-GatewayPortFromConfig -ConfigPath $LauncherConfigPath
+$directGatewayUrl = "http://127.0.0.1:$gatewayPort"
+
 if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListening -Port 3000)) {
   Write-Step "Petclaw dashboard already running at $DashboardUrl"
 } else {
@@ -632,11 +635,13 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
     }
     Write-Step "Starting petclaw dashboard (prod mode)..."
     $escapedLauncherToken = $LauncherToken.Replace("'", "''")
-    $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run start -- --hostname 127.0.0.1 --port 3000"
+    $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")
+    $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL='$escapedDirectGatewayUrl'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run start -- --hostname 127.0.0.1 --port 3000"
   } else {
     Write-Step "Starting petclaw dashboard (dev mode)..."
     $escapedLauncherToken = $LauncherToken.Replace("'", "''")
-    $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run dev -- --hostname 127.0.0.1 --port 3000 --webpack"
+    $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")
+    $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL='$escapedDirectGatewayUrl'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run dev -- --hostname 127.0.0.1 --port 3000 --webpack"
   }
 
   Start-DetachedPowerShell -Title "GoClaw - Petclaw" -Command $petclawCmd

--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -198,6 +198,29 @@ func getGatewayHealthByURL(url string, timeout time.Duration) (*health.StatusRes
 	return &healthResponse, resp.StatusCode, nil
 }
 
+func (h *Handler) currentGatewayBaseURL(cfg *config.Config) string {
+	port := 18790
+	host := ""
+
+	gateway.mu.Lock()
+	if d := gateway.pidData; d != nil {
+		if d.Port > 0 {
+			port = d.Port
+		}
+		host = strings.TrimSpace(d.Host)
+	}
+	gateway.mu.Unlock()
+
+	if port == 18790 && cfg != nil && cfg.Gateway.Port != 0 {
+		port = cfg.Gateway.Port
+	}
+	if host == "" {
+		host = gatewayProbeHost(h.effectiveGatewayBindHost(cfg))
+	}
+
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 // registerGatewayRoutes binds gateway lifecycle endpoints to the ServeMux.
 func (h *Handler) registerGatewayRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/gateway/status", h.handleGatewayStatus)
@@ -244,7 +267,19 @@ func (h *Handler) TryAutoStartGateway() {
 	defer gateway.mu.Unlock()
 
 	if gateway.cmd != nil && gateway.cmd.Process != nil {
+		if isCmdProcessAliveLocked(gateway.cmd) {
+			logger.InfoC(
+				"gateway",
+				fmt.Sprintf("Gateway auto-start skipped: process already starting/running (PID: %d)", gateway.cmd.Process.Pid),
+			)
+			return
+		}
+
 		gateway.cmd = nil
+		gateway.owned = false
+		gateway.bootDefaultModel = ""
+		gateway.bootConfigSignature = ""
+		gateway.pidData = nil
 	}
 
 	ready, reason, err := h.gatewayStartReady()
@@ -764,7 +799,21 @@ func (h *Handler) handleGatewayStart(w http.ResponseWriter, r *http.Request) {
 	defer gateway.mu.Unlock()
 
 	if gateway.cmd != nil && gateway.cmd.Process != nil {
+		if isCmdProcessAliveLocked(gateway.cmd) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"status":         "ok",
+				"pid":            gateway.cmd.Process.Pid,
+				"gateway_status": gatewayStatusWithoutHealthLocked(),
+			})
+			return
+		}
+
 		gateway.cmd = nil
+		gateway.owned = false
+		gateway.bootDefaultModel = ""
+		gateway.bootConfigSignature = ""
+		gateway.pidData = nil
 		setGatewayRuntimeStatusLocked("stopped")
 	}
 
@@ -955,6 +1004,7 @@ func (h *Handler) gatewayStatusData() map[string]any {
 		if configDefaultModel != "" {
 			data["config_default_model"] = configDefaultModel
 		}
+		data["gateway_base_url"] = h.currentGatewayBaseURL(cfg)
 	}
 
 	// Primary detection: read PID file and check if process is alive.

--- a/web/backend/api/gateway.go
+++ b/web/backend/api/gateway.go
@@ -198,18 +198,25 @@ func getGatewayHealthByURL(url string, timeout time.Duration) (*health.StatusRes
 	return &healthResponse, resp.StatusCode, nil
 }
 
-func (h *Handler) currentGatewayBaseURL(cfg *config.Config) string {
+func (h *Handler) currentGatewayBaseURL(cfg *config.Config, runtimePIDData *ppid.PidFileData) string {
 	port := 18790
 	host := ""
 
-	gateway.mu.Lock()
-	if d := gateway.pidData; d != nil {
-		if d.Port > 0 {
-			port = d.Port
+	if runtimePIDData != nil {
+		if runtimePIDData.Port > 0 {
+			port = runtimePIDData.Port
 		}
-		host = strings.TrimSpace(d.Host)
+		host = strings.TrimSpace(runtimePIDData.Host)
+	} else {
+		gateway.mu.Lock()
+		if d := gateway.pidData; d != nil {
+			if d.Port > 0 {
+				port = d.Port
+			}
+			host = strings.TrimSpace(d.Host)
+		}
+		gateway.mu.Unlock()
 	}
-	gateway.mu.Unlock()
 
 	if port == 18790 && cfg != nil && cfg.Gateway.Port != 0 {
 		port = cfg.Gateway.Port
@@ -1004,7 +1011,6 @@ func (h *Handler) gatewayStatusData() map[string]any {
 		if configDefaultModel != "" {
 			data["config_default_model"] = configDefaultModel
 		}
-		data["gateway_base_url"] = h.currentGatewayBaseURL(cfg)
 	}
 
 	// Primary detection: read PID file and check if process is alive.
@@ -1037,6 +1043,10 @@ func (h *Handler) gatewayStatusData() map[string]any {
 		data["gateway_status"] = gatewayStatusWithoutHealthLocked()
 		gateway.pidData = nil
 		gateway.mu.Unlock()
+	}
+
+	if cfg != nil {
+		data["gateway_base_url"] = h.currentGatewayBaseURL(cfg, pidData)
 	}
 
 	gatewayStatus, _ := data["gateway_status"].(string)

--- a/web/backend/api/gateway_host.go
+++ b/web/backend/api/gateway_host.go
@@ -208,7 +208,11 @@ func (h *Handler) picoWebUIAddr(r *http.Request) string {
 }
 
 func (h *Handler) buildWsURL(r *http.Request) string {
-	return requestWSScheme(r) + "://" + h.picoWebUIAddr(r) + "/pico/ws"
+	return h.buildChannelWsURL(r, "/pico/ws")
+}
+
+func (h *Handler) buildChannelWsURL(r *http.Request, path string) string {
+	return requestWSScheme(r) + "://" + h.picoWebUIAddr(r) + path
 }
 
 func (h *Handler) buildPicoEventsURL(r *http.Request) string {

--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -402,6 +402,65 @@ func TestGatewayStatusIncludesStartConditionWhenNotReady(t *testing.T) {
 	}
 }
 
+func TestHandleGatewayStartReusesAliveTrackedProcess(t *testing.T) {
+	resetGatewayTestState(t)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	cfg := config.DefaultConfig()
+	cfg.Agents.Defaults.ModelName = cfg.ModelList[0].ModelName
+	cfg.ModelList[0].SetAPIKey("test-key")
+	if err := config.SaveConfig(configPath, cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	h := NewHandler(configPath)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	cmd := startLongRunningProcess(t)
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	fakeBinary := filepath.Join(t.TempDir(), "not-a-real-gateway.txt")
+	if err := os.WriteFile(fakeBinary, []byte("not executable"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("PICOCLAW_BINARY", fakeBinary)
+
+	gateway.mu.Lock()
+	gateway.cmd = cmd
+	gateway.owned = true
+	setGatewayRuntimeStatusLocked("running")
+	gateway.mu.Unlock()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/gateway/start", nil)
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if got := body["pid"]; got != float64(cmd.Process.Pid) {
+		t.Fatalf("pid = %#v, want %d", got, cmd.Process.Pid)
+	}
+
+	gateway.mu.Lock()
+	defer gateway.mu.Unlock()
+	if gateway.cmd != cmd {
+		t.Fatal("gateway.cmd should keep pointing to the existing alive process")
+	}
+}
+
 func TestGatewayStatusKeepsRunningWhenHealthProbeFailsAfterRunning(t *testing.T) {
 	resetGatewayTestState(t)
 

--- a/web/backend/api/gateway_test.go
+++ b/web/backend/api/gateway_test.go
@@ -461,6 +461,24 @@ func TestHandleGatewayStartReusesAliveTrackedProcess(t *testing.T) {
 	}
 }
 
+func TestCurrentGatewayBaseURLPrefersRuntimePidData(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	h := NewHandler(configPath)
+
+	cfg := config.DefaultConfig()
+	cfg.Gateway.Host = "127.0.0.1"
+	cfg.Gateway.Port = 18790
+
+	pidData := &ppid.PidFileData{
+		Host: "127.0.0.1",
+		Port: 18888,
+	}
+
+	if got := h.currentGatewayBaseURL(cfg, pidData); got != "http://127.0.0.1:18888" {
+		t.Fatalf("currentGatewayBaseURL() = %q, want %q", got, "http://127.0.0.1:18888")
+	}
+}
+
 func TestGatewayStatusKeepsRunningWhenHealthProbeFailsAfterRunning(t *testing.T) {
 	resetGatewayTestState(t)
 

--- a/web/backend/api/pico.go
+++ b/web/backend/api/pico.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 
 	"github.com/sipeed/picoclaw/pkg/config"
@@ -18,10 +21,12 @@ func (h *Handler) registerPicoRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/pet/token", h.handleGetPicoToken)
 	mux.HandleFunc("POST /api/pet/token", h.handleRegenPicoToken)
 	mux.HandleFunc("POST /api/pet/setup", h.handlePicoSetup)
+	mux.HandleFunc("POST /api/pet/onboarding", h.handlePetOnboarding)
 
 	mux.HandleFunc("GET /api/pico/token", h.handleGetPicoToken)
 	mux.HandleFunc("POST /api/pico/token", h.handleRegenPicoToken)
 	mux.HandleFunc("POST /api/pico/setup", h.handlePicoSetup)
+	mux.HandleFunc("POST /api/pico/onboarding", h.handlePetOnboarding)
 
 	// WebSocket proxy: forward /pico/ws to gateway
 	// This allows the frontend to connect via the same port as the web UI,
@@ -105,13 +110,19 @@ func (h *Handler) handleGetPicoToken(w http.ResponseWriter, r *http.Request) {
 		cfg.Channels.Pico.SetToken(token)
 	}
 
+	protocol := "pico"
 	wsURL := h.buildWsURL(r)
+	if strings.Contains(r.URL.Path, "/api/pet/") {
+		protocol = "pet"
+		wsURL = h.buildChannelWsURL(r, "/pet/ws")
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"token":   cfg.Channels.Pico.Token.String(),
-		"ws_url":  wsURL,
-		"enabled": cfg.Channels.Pico.Enabled,
+		"token":    cfg.Channels.Pico.Token.String(),
+		"ws_url":   wsURL,
+		"enabled":  cfg.Channels.Pico.Enabled,
+		"protocol": protocol,
 	})
 }
 
@@ -138,12 +149,18 @@ func (h *Handler) handleRegenPicoToken(w http.ResponseWriter, r *http.Request) {
 	gateway.picoToken = token
 	gateway.mu.Unlock()
 
+	protocol := "pico"
 	wsURL := h.buildWsURL(r)
+	if strings.Contains(r.URL.Path, "/api/pet/") {
+		protocol = "pet"
+		wsURL = h.buildChannelWsURL(r, "/pet/ws")
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"token":  token,
-		"ws_url": wsURL,
+		"token":    token,
+		"ws_url":   wsURL,
+		"protocol": protocol,
 	})
 }
 
@@ -207,14 +224,20 @@ func (h *Handler) handlePicoSetup(w http.ResponseWriter, r *http.Request) {
 		refreshPicoToken(cfg)
 	}
 
+	protocol := "pico"
 	wsURL := h.buildWsURL(r)
+	if strings.Contains(r.URL.Path, "/api/pet/") {
+		protocol = "pet"
+		wsURL = h.buildChannelWsURL(r, "/pet/ws")
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"token":   cfg.Channels.Pico.Token.String(),
-		"ws_url":  wsURL,
-		"enabled": true,
-		"changed": changed,
+		"token":    cfg.Channels.Pico.Token.String(),
+		"ws_url":   wsURL,
+		"enabled":  true,
+		"changed":  changed,
+		"protocol": protocol,
 	})
 }
 
@@ -226,4 +249,35 @@ func generateSecureToken() string {
 		return fmt.Sprintf("%032x", time.Now().UnixNano())
 	}
 	return hex.EncodeToString(b)
+}
+
+func (h *Handler) handlePetOnboarding(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	target := h.gatewayProxyURL()
+	target.Path = "/pet/onboarding"
+
+	req, err := http.NewRequest(http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to build request: %v", err), http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to call gateway onboarding endpoint: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }

--- a/web/backend/api/pico_test.go
+++ b/web/backend/api/pico_test.go
@@ -306,6 +306,37 @@ func TestHandlePicoSetup_Response(t *testing.T) {
 	}
 }
 
+func TestHandleGetPicoToken_PetEndpointReturnsPetProtocolAndWSURL(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	h := NewHandler(configPath)
+
+	if _, err := h.EnsurePicoChannel(""); err != nil {
+		t.Fatalf("EnsurePicoChannel() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:18800/api/pet/token", nil)
+	req.Host = "127.0.0.1:18800"
+	rec := httptest.NewRecorder()
+
+	h.handleGetPicoToken(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if got := resp["protocol"]; got != "pet" {
+		t.Fatalf("protocol = %#v, want %q", got, "pet")
+	}
+	if got := resp["ws_url"]; got != "ws://127.0.0.1:18800/pet/ws" {
+		t.Fatalf("ws_url = %#v, want %q", got, "ws://127.0.0.1:18800/pet/ws")
+	}
+}
+
 func TestHandleWebSocketProxyReloadsGatewayTargetFromConfig(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	h := NewHandler(configPath)


### PR DESCRIPTION
﻿## Summary
- stop ClawPet frontends from hardcoding a stale direct gateway port when the launcher auto-rebinds the gateway
- return PET-specific websocket metadata from `/api/pet/token` and expose the current gateway base URL in launcher status
- avoid duplicate launcher-side gateway starts when a tracked gateway process is already alive

## Problem
The remote `dev` branch still has a few defects in the ClawPet startup path:
- desktop/frontend code still assumes direct gateway traffic stays on `127.0.0.1:18790`, so once the launcher moves the gateway to another free port the UI starts probing the wrong endpoint
- chat bootstrap uses plain `fetch()` calls against `/pet/ws` / `/pico/ws` as a readiness probe, which triggers browser preflight/redirect behavior instead of checking the actual token endpoints
- `/api/pet/token` is still shaped like the legacy Pico response, so PET clients need extra heuristics to guess whether they should connect to `/pet/ws` or `/pico/ws`
- the launcher can try to start a second gateway while the first tracked process is still alive, which is what causes repeated "port already in use" failures

## Validation
- `go test ./web/backend/api -run 'TestHandleGetPicoToken_PetEndpointReturnsPetProtocolAndWSURL|TestHandleGatewayStartReusesAliveTrackedProcess' -count=1`
- `go test ./web/backend/api -run 'TestHandlePicoSetup_Response|TestHandleWebSocketProxyLoadsCachedPicoTokenWhenMissing' -count=1`
