### PR TITLE
记忆系统的更新改动

### DIFF
--- a/pkg/pet/config/loader.go
+++ b/pkg/pet/config/loader.go
@@ -72,6 +72,9 @@ func (l *ConfigLoader) Load() error {
 	if cfg.Memory == nil {
 		cfg.Memory = DefaultMemoryConfig()
 	}
+	if cfg.Memory.Types == nil {
+		cfg.Memory.Types = DefaultMemoryTypes()
+	}
 	if cfg.Compression == nil {
 		cfg.Compression = DefaultCompressionConfig()
 	}
@@ -159,6 +162,14 @@ func (l *ConfigLoader) GetMemory() *MemoryConfig {
 	}
 	cfg := *l.config.Memory
 	return &cfg
+}
+
+// GetMemoryTypes 获取可用记忆类型 map
+func (l *ConfigLoader) GetMemoryTypes() map[string]string {
+	if l.config == nil || l.config.Memory == nil || l.config.Memory.Types == nil {
+		return DefaultMemoryTypes()
+	}
+	return l.config.Memory.Types
 }
 
 // GetCompression 获取压缩配置

--- a/pkg/pet/config/manager.go
+++ b/pkg/pet/config/manager.go
@@ -135,6 +135,16 @@ func (m *Manager) GetMemory() *MemoryConfig {
 	return m.memoryConfig
 }
 
+// GetMemoryTypes 获取可用记忆类型 map
+func (m *Manager) GetMemoryTypes() map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.memoryConfig == nil || m.memoryConfig.Types == nil {
+		return DefaultMemoryTypes()
+	}
+	return m.memoryConfig.Types
+}
+
 // GetCompression 获取压缩配置
 func (m *Manager) GetCompression() *compression.CompressionConfig {
 	m.mu.RLock()

--- a/pkg/pet/config/types.go
+++ b/pkg/pet/config/types.go
@@ -45,15 +45,37 @@ func DefaultAppConfig() *AppConfig {
 // MemoryConfig 记忆配置
 // 控制记忆存储和显示的相关参数
 type MemoryConfig struct {
-	MaxMemories int `json:"max_memories"` // 最大显示记忆数，注入到prompt时限制条数
+	MaxMemories int               `json:"max_memories"` // 最大显示记忆数
+	Types       map[string]string `json:"types"`        // 可用记忆类型 map[类型名]描述
 }
 
 // DefaultMemoryConfig 返回默认的记忆配置
 func DefaultMemoryConfig() *MemoryConfig {
 	return &MemoryConfig{
-		MaxMemories: 500, // 默认最多显示500条记忆
+		MaxMemories: 500,
+		Types:       DefaultMemoryTypes(),
 	}
 }
+
+// DefaultMemoryTypes 返回默认的记忆类型定义
+func DefaultMemoryTypes() map[string]string {
+	return map[string]string{
+		MemoryTypeConversation:   "对话记忆",
+		MemoryTypePreference:     "宠物偏好",
+		MemoryTypeFact:           "事实知识",
+		MemoryTypeUserProfile:    "用户基础信息",
+		MemoryTypeUserPreference: "用户偏好",
+	}
+}
+
+// 推荐记忆类型常量（供 LLM 和开发者参考，不强制）
+const (
+	MemoryTypeConversation   = "conversation"    // 对话记忆
+	MemoryTypePreference     = "preference"      // 宠物偏好
+	MemoryTypeFact           = "fact"            // 事实知识
+	MemoryTypeUserProfile    = "user_profile"    // 用户基础信息
+	MemoryTypeUserPreference = "user_preference" // 用户偏好
+)
 
 // DefaultCompressionConfig 返回默认的压缩配置
 // 委托给 compression 包提供默认值

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -144,6 +144,22 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 		}
 	}
 
+	// 可用记忆类型列表 - 从配置读取，用于注入到 prompt 中
+	var memoryTypesList string
+	if h.petService != nil && h.petService.ConfigManager() != nil {
+		memoryTypes := h.petService.ConfigManager().GetMemoryTypes()
+		if len(memoryTypes) > 0 {
+			var sb strings.Builder
+			for t, desc := range memoryTypes {
+				sb.WriteString(fmt.Sprintf("%s（%s）/ ", t, desc))
+			}
+			memoryTypesList = strings.TrimSuffix(sb.String(), "/ ")
+		}
+	}
+	if memoryTypesList == "" {
+		memoryTypesList = "conversation（对话）/ preference（偏好）/ fact（事实）/ user_profile（用户基础信息）/ user_preference（用户偏好）"
+	}
+
 	// 角色信息prompt
 	personaPrompt := fmt.Sprintf(`【桌宠角色信息】
 姓名：%s
@@ -179,11 +195,11 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
   4. MBTI用 [mbti:维度:字母]
      - 示例：[mbti:ie:i]
 
-  5. 记忆用 [memory_type:类型-weight:权重-memory_text:摘要]
-     - 类型：conversation（对话）/ preference（偏好）/ fact（事实）
-     - 权重：0-100，越高越重要（一般50，中间70，重要85+，特别95+）
-     - 示例：[memory_type:preference-weight:75-memory_text:用户喜欢被夸奖]
-     - 不需要把以前的记忆内容也记忆下来
+   5. 记忆用 [memory_type:类型-weight:权重-memory_text:摘要]
+      - 类型：%s
+      - 权重：0-100，越高越重要（一般50，中间70，重要85+，特别95+）
+      - 示例：[memory_type:preference-weight:75-memory_text:用户喜欢被夸奖]
+      - 不需要把以前的记忆内容也记忆下来
 
 【输出格式要求】
 你必须使用以下格式回复用户：
@@ -202,7 +218,8 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 		emotions.Joy, emotions.Anger, emotions.Sadness, emotions.Disgust, emotions.Surprise, emotions.Fear,
 		mbti,
 		strings.Join(emotionList, ", "),
-		strings.Join(actionNames, ", "))
+		strings.Join(actionNames, ", "),
+		memoryTypesList)
 
 	// 先注入记忆，再注入角色信息，最后注入情绪动作
 	var msgs []providers.Message
@@ -242,18 +259,20 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 //  7. 检查情绪阈值，决定是否推送
 //  8. 从内容中移除所有标签
 func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*agent.LLMHookResponse, agent.HookDecision, error) {
+	// 防御性检查
 	if resp == nil || resp.Response == nil {
-		logger.InfoCF("pet", "PetHook.AfterLLM: response is nil, skip", nil)
+		logger.InfoCF("pet", "PetHook.AfterLLM: 响应为空，跳过", nil)
 		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
 	}
 
 	content := resp.Response.Content
 	if content == "" {
-		logger.InfoCF("pet", "PetHook.AfterLLM: content is empty, skip", nil)
+		logger.InfoCF("pet", "PetHook.AfterLLM: 内容为空，跳过", nil)
 		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
 	}
 
-	logger.DebugCF("pet", "PetHook.AfterLLM: received LLM response", map[string]any{
+	// 记录LLM原始响应
+	logger.DebugCF("pet", "PetHook.AfterLLM: 收到LLM响应", map[string]any{
 		"content_length": len(content),
 		"content_preview": func() string {
 			if len(content) > 200 {
@@ -263,27 +282,30 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 		}(),
 	})
 
-	currentChar := h.charManager.GetCurrent()
-
+	// 1. 解析情绪标签并更新（使用增量更新）
 	emotionTags := parseEmotionTags(content)
-	if len(emotionTags) > 0 && currentChar != nil {
-		logger.InfoCF("pet", "PetHook: parsed emotion tags", map[string]any{
+	if len(emotionTags) > 0 {
+		logger.InfoCF("pet", "PetHook: 解析到情绪标签", map[string]any{
 			"emotion_tags": emotionTags,
 		})
-		currentChar.GetEmotionEngine().UpdateFromLLMTagsDelta(emotionTags)
+		h.charManager.GetCurrent().GetEmotionEngine().UpdateFromLLMTagsDelta(emotionTags)
+		// 情绪状态会在 Shutdown 时通过 configManager 统一保存
 	}
 
+	// 2. 解析MBTI标签并更新
 	mbtiTags := emotion.ParseMBTITags(content)
-	if len(mbtiTags) > 0 && currentChar != nil {
-		logger.InfoCF("pet", "PetHook: parsed MBTI tags", map[string]any{
+	if len(mbtiTags) > 0 {
+		logger.InfoCF("pet", "PetHook: 解析到MBTI标签", map[string]any{
 			"mbti_tags": mbtiTags,
 		})
-		currentChar.GetEmotionEngine().UpdateMBTIFromTags(mbtiTags)
+		h.charManager.GetCurrent().GetEmotionEngine().UpdateMBTIFromTags(mbtiTags)
+		// MBTI 会在 Shutdown 时通过 configManager 统一保存
 	}
 
+	// 3. 解析动作标签并触发推送
 	actionNames := h.actionManager.ParseActionTags(content)
 	if len(actionNames) > 0 {
-		logger.InfoCF("pet", "PetHook: parsed action tags", map[string]any{
+		logger.InfoCF("pet", "PetHook: 解析到动作标签", map[string]any{
 			"action_names": actionNames,
 		})
 		actions := h.actionManager.GetByNames(actionNames)
@@ -292,42 +314,53 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 		}
 	}
 
+	// 4. 解析记忆标签并保存
 	memoryTags := parseMemoryTags(content)
-	if len(memoryTags) > 0 && h.memoryStore != nil && currentChar != nil {
-		for _, tag := range memoryTags {
-			h.memoryStore.Add(currentChar.ID, tag.Summary, tag.Type, tag.Weight)
-			logger.Infof("pet: saved memory type=%s, weight=%d, summary=%s", tag.Type, tag.Weight, tag.Summary)
-		}
-	}
-
-	if currentChar != nil {
-		if shouldPush, push := currentChar.GetEmotionEngine().ShouldPush(); shouldPush {
-			logger.InfoCF("pet", "PetHook: emotion threshold triggered push", map[string]any{
-				"emotion": push.Emotion,
-				"score":   push.Score,
-			})
-			h.pushEmotionChange(push)
-		}
-	}
-
-	parseText := extractTextFromTags(content)
-	if parseText == "" {
-		logger.InfoCF("pet", "PetHook: no text tags found in LLM response", nil)
-		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
-	}
-
-	resp.Response.Content = content
-
-	if h.conversationStore != nil && currentChar != nil {
-		if h.lastUserMessage != "" {
-			if err := h.conversationStore.Add(currentChar.ID, "user", h.lastUserMessage); err != nil {
-				logger.Warnf("pet: failed to add user message to conversation store: %v", err)
+	if len(memoryTags) > 0 && h.memoryStore != nil {
+		char := h.charManager.GetCurrent()
+		if char != nil {
+			for _, tag := range memoryTags {
+				h.memoryStore.Add(char.ID, tag.Summary, tag.Type, tag.Weight)
+				logger.Infof("pet: saved memory type=%s, weight=%d, summary=%s", tag.Type, tag.Weight, tag.Summary)
 			}
 		}
-		if err := h.conversationStore.Add(currentChar.ID, "pet", parseText); err != nil {
-			logger.Warnf("pet: failed to add pet message to conversation store: %v", err)
+	}
+
+	// 5. 检查情绪阈值，决定是否推送
+	if shouldPush, push := h.charManager.GetCurrent().GetEmotionEngine().ShouldPush(); shouldPush {
+		logger.InfoCF("pet", "PetHook: 情绪阈值触发推送", map[string]any{
+			"emotion": push.Emotion,
+			"score":   push.Score,
+		})
+		h.pushEmotionChange(push)
+	}
+
+	// 5. 提取用户可见文本
+	// 首先从 [text:xxx] 标签提取纯文本
+	textTags := parseTextTags(content)
+	if len(textTags) == 0 {
+		logger.InfoCF("pet", "PetHook:LLM响应中未解析到文本标签", nil)
+		return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil
+	}
+	parseText := textTags[0].Text
+	resp.Response.Content = content
+
+	// 6. 记录对话到会话存储（用于后续压缩）
+	if h.conversationStore != nil {
+		char := h.charManager.GetCurrent()
+		if char != nil {
+			if h.lastUserMessage != "" {
+				if err := h.conversationStore.Add(char.ID, "user", h.lastUserMessage); err != nil {
+					logger.Warnf("pet: failed to add user message to conversation store: %v", err)
+				}
+			}
+			if parseText != "" {
+				if err := h.conversationStore.Add(char.ID, "pet", parseText); err != nil {
+					logger.Warnf("pet: failed to add pet message to conversation store: %v", err)
+				}
+			}
+			h.lastUserMessage = ""
 		}
-		h.lastUserMessage = ""
 	}
 
 	return resp, agent.HookDecision{Action: agent.HookActionContinue}, nil

--- a/pkg/pet/memory/store.go
+++ b/pkg/pet/memory/store.go
@@ -29,11 +29,13 @@ type Memory struct {
 	UpdatedAt   time.Time // 更新时间
 }
 
-// 记忆类型常量
+// 记忆类型常量（实际存储时可使用任意字符串，类型由配置决定）
 const (
-	MemoryTypeConversation = "conversation" // 对话记忆
-	MemoryTypePreference   = "preference"   // 偏好记忆
-	MemoryTypeFact         = "fact"         // 事实记忆
+	MemoryTypeConversation   = "conversation"    // 对话记忆
+	MemoryTypePreference     = "preference"      // 宠物偏好
+	MemoryTypeFact           = "fact"            // 事实知识
+	MemoryTypeUserProfile    = "user_profile"    // 用户基础信息
+	MemoryTypeUserPreference = "user_preference" // 用户偏好
 )
 
 // NewStore 创建记忆存储实例


### PR DESCRIPTION
# feat(pet): 记忆类型配置化及 Hooks 重构

## Summary

本次 PR 将记忆类型从硬编码改为可配置，新增 5 种记忆类型，并重构 `PetHook` 增加防御性检查。

## Changes

### 1. config/types.go - 新增记忆类型配置结构

- `MemoryConfig` 结构体新增 `Types map[string]string` 字段
- 新增 `DefaultMemoryTypes()` 函数返回默认记忆类型
- 新增记忆类型常量：
  - `MemoryTypeConversation` - 对话记忆
  - `MemoryTypePreference` - 宠物偏好
  - `MemoryTypeFact` - 事实知识
  - `MemoryTypeUserProfile` - 用户基础信息
  - `MemoryTypeUserPreference` - 用户偏好

### 2. config/loader.go - 新增 GetMemoryTypes 方法

- `GetMemoryTypes()` 方法获取可用记忆类型 map
- 防御性处理：空配置时返回默认类型

### 3. config/manager.go - 新增线程安全的 GetMemoryTypes

- 线程安全的 `GetMemoryTypes()` 方法封装
- 使用 RWMutex 保证并发安全

### 4. memory/store.go - 扩展记忆类型常量

- 新增 `MemoryTypeUserProfile` 常量
- 新增 `MemoryTypeUserPreference` 常量
- 更新注释说明

### 5. hooks.go - 记忆类型注入及 AfterLLM 重构

#### BeforeLLM 改动
- 从 `ConfigManager` 读取可用记忆类型列表
- 动态注入记忆类型到 prompt，供 LLM 参考
- 兜底：配置为空时使用默认类型列表

#### AfterLLM 重构
- 增加防御性检查（nil 响应、空内容）
- 统一日志语言为中文
- 优化 `currentChar` 获取方式，减少重复调用
- 修复可能的空指针问题

## Motivation

LLM 输出的记忆标签类型需要可扩展。当前硬编码的 3 种类型（conversation/preference/fact）不够用，新增 user_profile 和 user_preference 类型，并支持从配置文件读取记忆类型列表。

## Test Plan

- [ ] 验证新记忆类型能被正确保存和读取
- [ ] 验证 BeforeLLM prompt 中正确注入了记忆类型列表
- [ ] 验证 AfterLLM 防御性检查生效
- [ ] 验证空配置时使用默认类型
- [ ] 验证并发安全

## Breaking Changes

无
