### PR TITLE
ci(release): stabilize tag-based release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  APP_NAME: picoclaw
+  APP_NAME: clawpet
   BUILD_TAGS: goolm,stdjson
   BUILD_ENTRY: ./cmd/picoclaw
 
@@ -117,9 +117,33 @@ jobs:
           BIN="${APP_NAME}"
 
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
-            zip "${BASE}.zip" "${BIN}.exe"
+            cat > "${BIN}-gateway.bat" <<'EOF'
+@echo off
+setlocal
+set "SELF_DIR=%~dp0"
+"%SELF_DIR%clawpet.exe" gateway %*
+set "EXIT_CODE=%ERRORLEVEL%"
+
+if "%CLAWPET_NO_PAUSE%"=="1" (
+  exit /b %EXIT_CODE%
+)
+
+echo.
+echo clawpet gateway exited with code %EXIT_CODE%.
+echo Press any key to close...
+pause >nul
+exit /b %EXIT_CODE%
+EOF
+            zip "${BASE}.zip" "${BIN}.exe" "${BIN}-gateway.bat"
           else
-            tar -czf "${BASE}.tar.gz" "${BIN}"
+            cat > "${BIN}-gateway" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/clawpet" gateway "$@"
+EOF
+            chmod +x "${BIN}-gateway"
+            tar -czf "${BASE}.tar.gz" "${BIN}" "${BIN}-gateway"
           fi
 
       - name: Upload package artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,9 @@ jobs:
     needs: build
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,31 +117,31 @@ jobs:
           BIN="${APP_NAME}"
 
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
-            cat > "${BIN}-gateway.bat" <<'EOF'
-@echo off
-setlocal
-set "SELF_DIR=%~dp0"
-"%SELF_DIR%clawpet.exe" gateway %*
-set "EXIT_CODE=%ERRORLEVEL%"
-
-if "%CLAWPET_NO_PAUSE%"=="1" (
-  exit /b %EXIT_CODE%
-)
-
-echo.
-echo clawpet gateway exited with code %EXIT_CODE%.
-echo Press any key to close...
-pause >nul
-exit /b %EXIT_CODE%
-EOF
+            printf '%s\n' \
+              '@echo off' \
+              'setlocal' \
+              'set "SELF_DIR=%~dp0"' \
+              '"%SELF_DIR%clawpet.exe" gateway %*' \
+              'set "EXIT_CODE=%ERRORLEVEL%"' \
+              '' \
+              'if "%CLAWPET_NO_PAUSE%"=="1" (' \
+              '  exit /b %EXIT_CODE%' \
+              ')' \
+              '' \
+              'echo.' \
+              'echo clawpet gateway exited with code %EXIT_CODE%.' \
+              'echo Press any key to close...' \
+              'pause >nul' \
+              'exit /b %EXIT_CODE%' \
+              > "${BIN}-gateway.bat"
             zip "${BASE}.zip" "${BIN}.exe" "${BIN}-gateway.bat"
           else
-            cat > "${BIN}-gateway" <<'EOF'
-#!/usr/bin/env sh
-set -eu
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-exec "$SCRIPT_DIR/clawpet" gateway "$@"
-EOF
+            printf '%s\n' \
+              '#!/usr/bin/env sh' \
+              'set -eu' \
+              'SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"' \
+              'exec "$SCRIPT_DIR/clawpet" gateway "$@"' \
+              > "${BIN}-gateway"
             chmod +x "${BIN}-gateway"
             tar -czf "${BASE}.tar.gz" "${BIN}" "${BIN}-gateway"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cd dist
-
-          sha256sum * > checksums.txt
+          sha256sum dist/* > dist/checksums.txt
 
           TAG="${GITHUB_REF_NAME}"
           if ! gh release view "${TAG}" >/dev/null 2>&1; then
@@ -160,4 +158,4 @@ jobs:
               --generate-notes
           fi
 
-          gh release upload "${TAG}" * --clobber
+          gh release upload "${TAG}" dist/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,6 @@ jobs:
             goarch: loong64
             file_os: Linux
             file_arch: loong64
-          - goos: linux
-            goarch: mipsle
-            file_os: Linux
-            file_arch: mipsle
           - goos: darwin
             goarch: amd64
             file_os: Darwin
@@ -72,14 +68,6 @@ jobs:
           - goos: freebsd
             goarch: arm64
             file_os: Freebsd
-            file_arch: arm64
-          - goos: netbsd
-            goarch: amd64
-            file_os: Netbsd
-            file_arch: x86_64
-          - goos: netbsd
-            goarch: arm64
-            file_os: Netbsd
             file_arch: arm64
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,22 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup Node (Windows launcher build)
+        if: matrix.goos == 'windows'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build launcher embedded frontend (Windows)
+        if: matrix.goos == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          cd web/frontend
+          pnpm install --frozen-lockfile
+          pnpm build:backend
+
       - name: Prepare onboard workspace
         shell: bash
         run: go generate ./cmd/picoclaw/internal/onboard
@@ -107,6 +123,16 @@ jobs:
               -o "dist/${BIN}" \
               "${BUILD_ENTRY}"
 
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} GOARM="${GOARM}" CGO_ENABLED=0 \
+              go build \
+                -trimpath \
+                -tags "${BUILD_TAGS}" \
+                -ldflags "-s -w -X github.com/sipeed/picoclaw/pkg/config.Version=${VERSION} -X github.com/sipeed/picoclaw/pkg/config.GitCommit=${SHORT_SHA} -X github.com/sipeed/picoclaw/pkg/config.BuildTime=${BUILD_TIME}" \
+                -o "dist/${APP_NAME}-launcher.exe" \
+                ./web/backend
+          fi
+
       - name: Package
         shell: bash
         run: |
@@ -134,7 +160,24 @@ jobs:
               'pause >nul' \
               'exit /b %EXIT_CODE%' \
               > "${BIN}-gateway.bat"
-            zip "${BASE}.zip" "${BIN}.exe" "${BIN}-gateway.bat"
+            zip "${BASE}.zip" "${BIN}.exe" "${BIN}-launcher.exe" "${BIN}-gateway.bat"
+
+            ALL_BASE="${APP_NAME}_AllInOne_${{ matrix.file_os }}_${{ matrix.file_arch }}"
+            mkdir -p allinone/scripts
+            cp -f "${BIN}.exe" allinone/clawpet.exe
+            cp -f "${BIN}.exe" allinone/picoclaw.exe
+            cp -f "${BIN}-launcher.exe" allinone/clawpet-launcher.exe
+            cp -f "${BIN}-launcher.exe" allinone/picoclaw-launcher.exe
+            cp -f "${BIN}-gateway.bat" allinone/clawpet-gateway.bat
+            cp -f ../GoClaw-OneClickStart.bat allinone/GoClaw-OneClickStart.bat
+            cp -f ../GoClaw-OneClickStart.ps1 allinone/GoClaw-OneClickStart.ps1
+            cp -f ../scripts/run-goclaw-dev.ps1 allinone/scripts/run-goclaw-dev.ps1
+            cp -r ../petclaw allinone/petclaw
+            cp -r ../electron-frontend allinone/electron-frontend
+            (
+              cd allinone
+              zip -r "../${ALL_BASE}.zip" .
+            )
           else
             printf '%s\n' \
               '#!/usr/bin/env sh' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           set -euo pipefail
           corepack enable
           cd web/frontend
-          pnpm install --frozen-lockfile
+          pnpm install --no-frozen-lockfile
           pnpm build:backend
 
       - name: Prepare onboard workspace

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ powershell -ExecutionPolicy Bypass -File .\scripts\run-goclaw-dev.ps1 -Restart -
 
 and starts launcher, gateway, petclaw dashboard, electron frontend dev server, and Electron desktop pet in order.
 
+Notes for first launch:
+
+- If no model is configured yet, gateway startup may be deferred until onboarding/model setup is completed.
+- The package will auto-install npm dependencies for `petclaw` and `electron-frontend` on first run, so startup can take longer once.
+
 ## One-Click Startup
 
 You can also use the root one-click entry:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ This script will:
 5. Start the desktop renderer on `127.0.0.1:5173`
 6. Start Electron and point its settings/onboarding window to `petclaw`
 
+## Release Package (All-In-One)
+
+If you want a release package that starts the full stack (`18800`, `18790`, `3000`, `5173` + Electron) with one click, use the Windows asset:
+
+- `clawpet_AllInOne_Windows_x86_64.zip` (or arm64 variant)
+
+After extracting, run:
+
+- `GoClaw-OneClickStart.bat`
+
+This entry delegates to:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\run-goclaw-dev.ps1 -Restart -PetclawMode dev
+```
+
+and starts launcher, gateway, petclaw dashboard, electron frontend dev server, and Electron desktop pet in order.
+
 ## One-Click Startup
 
 You can also use the root one-click entry:

--- a/petclaw/hooks/use-chat.ts
+++ b/petclaw/hooks/use-chat.ts
@@ -8,6 +8,10 @@ import {
   type ChatMessage,
   type WSEvent,
 } from "@/lib/api"
+import { getSessionHistory, getSessions } from "@/lib/api/sessions"
+
+const SESSIONS_STORAGE_KEY = "petclaw_sessions"
+const ACTIVE_SESSION_KEY = "petclaw_active_session"
 
 export interface UseChatOptions {
   onMessage?: (message: ChatMessage) => void
@@ -37,6 +41,7 @@ export interface UseChatResult {
   sendMessage: (content: string) => void
   newChat: () => Promise<void>
   switchSession: (sessionId: string) => Promise<void>
+  loadSessionHistory: (sessionId: string) => Promise<void>
   reconnect: () => void
   clearError: () => void
 }
@@ -63,6 +68,71 @@ function createSessionState(id: string): ChatSessionState {
     updatedAt: now,
     messageCount: 0,
     messages: [],
+  }
+}
+
+// localStorage 持久化函数
+function saveSessionsToStorage(sessions: ChatSessionState[], activeSessionId: string) {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return
+  }
+
+  try {
+    const data = {
+      sessions: sessions.map((session) => ({
+        id: session.id,
+        title: session.title,
+        preview: session.preview,
+        updatedAt: session.updatedAt,
+        messageCount: session.messageCount,
+        messages: session.messages,
+      })),
+      activeSessionId,
+      savedAt: Date.now(),
+    }
+    window.localStorage.setItem(SESSIONS_STORAGE_KEY, JSON.stringify(data))
+    window.localStorage.setItem(ACTIVE_SESSION_KEY, activeSessionId)
+    console.log("[petclaw] 会话已保存到 localStorage", {
+      sessionCount: sessions.length,
+      activeSessionId,
+    })
+  } catch (error) {
+    console.error("[petclaw] 保存会话到 localStorage 失败:", error)
+  }
+}
+
+// 从 localStorage 恢复会话
+function loadSessionsFromStorage(): {
+  sessions: ChatSessionState[]
+  activeSessionId: string
+} | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null
+  }
+
+  try {
+    const dataStr = window.localStorage.getItem(SESSIONS_STORAGE_KEY)
+    if (!dataStr) {
+      return null
+    }
+
+    const data = JSON.parse(dataStr)
+    if (!data.sessions || !Array.isArray(data.sessions)) {
+      return null
+    }
+
+    console.log("[petclaw] 从 localStorage 恢复会话", {
+      sessionCount: data.sessions.length,
+      activeSessionId: data.activeSessionId,
+    })
+
+    return {
+      sessions: data.sessions,
+      activeSessionId: data.activeSessionId || data.sessions[0]?.id || "",
+    }
+  } catch (error) {
+    console.error("[petclaw] 从 localStorage 恢复会话失败:", error)
+    return null
   }
 }
 
@@ -149,12 +219,15 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
   const wsRef = useRef(getWebSocketInstance())
   const optionsRef = useRef(options)
   const initialSessionIdRef = useRef(wsRef.current.ensureSessionId())
+
+  // 尝试从 localStorage 加载会话
+  const storedSessions = loadSessionsFromStorage()
   const [activeSessionId, setActiveSessionId] = useState(
-    initialSessionIdRef.current,
+    storedSessions?.activeSessionId || initialSessionIdRef.current,
   )
-  const [sessionsState, setSessionsState] = useState<ChatSessionState[]>([
-    createSessionState(initialSessionIdRef.current),
-  ])
+  const [sessionsState, setSessionsState] = useState<ChatSessionState[]>(
+    storedSessions?.sessions || [createSessionState(initialSessionIdRef.current)],
+  )
   const activeSessionIdRef = useRef(activeSessionId)
   const audioStreamRef = useRef<{ chatId: number | null; chunks: Uint8Array[] }>(
     { chatId: null, chunks: [] },
@@ -165,8 +238,8 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
 
   const updateSessionMessages = useCallback(
     (sessionId: string, updater: (messages: ChatMessage[]) => ChatMessage[]) => {
-      setSessionsState((prev) =>
-        prev.map((session) => {
+      setSessionsState((prev) => {
+        const next = prev.map((session) => {
           if (session.id !== sessionId) {
             return session
           }
@@ -180,11 +253,84 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
             }),
             messages: nextMessages,
           }
-        }),
-      )
+        })
+
+        // 保存到 localStorage
+        saveSessionsToStorage(next, activeSessionIdRef.current)
+
+        return next
+      })
     },
     [],
   )
+
+  // 监听 activeSessionId 或 sessionsState 变化并保存到 localStorage
+  useEffect(() => {
+    saveSessionsToStorage(sessionsState, activeSessionId)
+  }, [activeSessionId, sessionsState])
+
+  // 页面卸载或组件卸载时保存会话
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      saveSessionsToStorage(sessionsState, activeSessionId)
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+      // 组件卸载时也保存
+      saveSessionsToStorage(sessionsState, activeSessionId)
+    }
+  }, [sessionsState, activeSessionId])
+
+  const loadSessionHistory = useCallback(async (sessionId: string) => {
+    try {
+      const history = await getSessionHistory(sessionId)
+      if (!history) {
+        return
+      }
+
+      const messages: ChatMessage[] = history.messages.map((msg, index) => ({
+        id: `${sessionId}-${index}`,
+        role: msg.role,
+        content: msg.content,
+        timestamp: Date.now(),
+      }))
+
+      setSessionsState((prev) => {
+        const existingIndex = prev.findIndex((s) => s.id === sessionId)
+        if (existingIndex >= 0) {
+          const updated = [...prev]
+          updated[existingIndex] = {
+            ...updated[existingIndex],
+            messages,
+            messageCount: messages.length,
+          }
+          return updated
+        }
+
+        const now = Date.now()
+        const firstUserMessage = messages.find(
+          (m) => m.role === "user" && m.content.trim(),
+        )
+        const newSession: ChatSessionState = {
+          id: sessionId,
+          title:
+            (firstUserMessage?.content || EMPTY_SESSION_TITLE)
+              .trim()
+              .slice(0, 18) || EMPTY_SESSION_TITLE,
+          preview: "",
+          updatedAt: now,
+          messageCount: messages.length,
+          messages,
+        }
+        return [newSession, ...prev]
+      })
+    } catch (err) {
+      console.warn("[petclaw] Failed to load session history:", err)
+    }
+  }, [])
 
   const showBubble = useCallback((text: string | null, audio?: string) => {
     window.electronAPI?.showBubble?.({
@@ -430,7 +576,11 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         ? prev
         : prev.filter((session) => session.id !== activeSessionIdRef.current)
 
-      return [nextSession, ...preservedSessions]
+      const nextSessions = [nextSession, ...preservedSessions]
+      // 保存到 localStorage
+      saveSessionsToStorage(nextSessions, nextSessionId)
+
+      return nextSessions
     })
     setActiveSessionId(nextSessionId)
 
@@ -442,6 +592,12 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       if (!sessionId || sessionId === activeSessionIdRef.current) {
         return
       }
+
+      // 保存当前会话状态
+      saveSessionsToStorage(sessionsState, sessionId)
+
+      // Load session history from backend
+      await loadSessionHistory(sessionId)
 
       wsRef.current.useSession(sessionId)
       if (currentAudioRef.current) {
@@ -455,7 +611,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
 
       await connectWithBootstrap()
     },
-    [connectWithBootstrap],
+    [connectWithBootstrap, loadSessionHistory, sessionsState],
   )
 
   const reconnect = useCallback(() => {
@@ -491,6 +647,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     sendMessage,
     newChat,
     switchSession,
+    loadSessionHistory,
     reconnect,
     clearError,
   }

--- a/petclaw/lib/api/sessions.ts
+++ b/petclaw/lib/api/sessions.ts
@@ -1,0 +1,73 @@
+import { getApiBaseUrl, withLauncherAuthRequest } from "./config"
+
+export interface SessionListItem {
+  id: string
+  title: string
+  preview: string
+  message_count: number
+  created: string
+  updated: string
+}
+
+export interface SessionDetail {
+  id: string
+  messages: Array<{
+    role: "user" | "assistant"
+    content: string
+    media?: string[]
+  }>
+  summary: string
+  created: string
+  updated: string
+}
+
+async function sessionFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const baseUrl = getApiBaseUrl()
+  const url = input.startsWith("http") ? input : `${baseUrl}${input}`
+  return fetch(url, withLauncherAuthRequest(url, init))
+}
+
+export async function getSessions(offset = 0, limit = 20): Promise<SessionListItem[]> {
+  const params = new URLSearchParams({
+    offset: offset.toString(),
+    limit: limit.toString(),
+  })
+
+  try {
+    const res = await sessionFetch(`/api/sessions?${params.toString()}`)
+    if (!res.ok) {
+      console.warn("[petclaw] Failed to fetch sessions:", res.status)
+      return []
+    }
+    return res.json()
+  } catch (err) {
+    console.warn("[petclaw] Fetch sessions error:", err)
+    return []
+  }
+}
+
+export async function getSessionHistory(id: string): Promise<SessionDetail | null> {
+  try {
+    const res = await sessionFetch(`/api/sessions/${encodeURIComponent(id)}`)
+    if (!res.ok) {
+      console.warn("[petclaw] Failed to fetch session history:", id, res.status)
+      return null
+    }
+    return res.json()
+  } catch (err) {
+    console.warn("[petclaw] Fetch session history error:", id, err)
+    return null
+  }
+}
+
+export async function deleteSession(id: string): Promise<boolean> {
+  try {
+    const res = await sessionFetch(`/api/sessions/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    })
+    return res.ok
+  } catch (err) {
+    console.warn("[petclaw] Delete session error:", id, err)
+    return false
+  }
+}

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -362,7 +362,8 @@ function Ensure-PicoAllowOrigins {
   )
 
   $current = @()
-  if ($cfg.channels.pico.allow_origins) {
+  $hasAllowOrigins = $cfg.channels.pico.PSObject.Properties.Name -contains "allow_origins"
+  if ($hasAllowOrigins -and $cfg.channels.pico.allow_origins) {
     $current = @($cfg.channels.pico.allow_origins)
   }
 
@@ -382,11 +383,30 @@ function Ensure-PicoAllowOrigins {
   }
 
   if ($changed -or $current.Count -eq 0) {
-    $cfg.channels.pico.allow_origins = @($normalized)
+    if (-not $hasAllowOrigins) {
+      $cfg.channels.pico | Add-Member -NotePropertyName "allow_origins" -NotePropertyValue @($normalized)
+    } else {
+      $cfg.channels.pico.allow_origins = @($normalized)
+    }
     $json = $cfg | ConvertTo-Json -Depth 30
     Write-JsonNoBom -Path $ConfigPath -Json $json
     Write-Step "Ensured pico allow_origins include localhost/127.0.0.1 dashboard origins"
   }
+}
+
+function Ensure-NpmDeps {
+  param(
+    [string]$ProjectDir,
+    [string]$DisplayName
+  )
+
+  $nodeModules = Join-Path $ProjectDir "node_modules"
+  if (Test-Path $nodeModules) {
+    return
+  }
+
+  Write-Step "Installing npm dependencies for $DisplayName (first run)..."
+  Invoke-Npm -WorkingDir $ProjectDir -Arguments "install"
 }
 
 function Get-FirstListeningPidOnPort {
@@ -574,12 +594,30 @@ if (-not [string]::IsNullOrWhiteSpace($resolvedLauncherBin)) {
 Write-Step "Ensuring gateway is running before opening UI..."
 try {
   $gatewayReady = $false
+  $gatewayPreconditionBlocked = $false
   for ($attempt = 1; $attempt -le 2; $attempt++) {
     Ensure-GatewayPortAvailable -ConfigPath $LauncherConfigPath
 
     $gatewayStatus = Invoke-LauncherApi -Method GET -Path "/api/gateway/status" -LauncherToken $LauncherToken
     if ($gatewayStatus.gateway_status -eq "stopped" -or $gatewayStatus.gateway_status -eq "error") {
-      $null = Invoke-LauncherApi -Method POST -Path "/api/gateway/start" -LauncherToken $LauncherToken
+      try {
+        $null = Invoke-LauncherApi -Method POST -Path "/api/gateway/start" -LauncherToken $LauncherToken
+      } catch {
+        if ($_.Exception.Message -match "failed \(400\)") {
+          $latest = Invoke-LauncherApi -Method GET -Path "/api/gateway/status" -LauncherToken $LauncherToken
+          $reason = ""
+          if ($latest.gateway_start_reason) {
+            $reason = "$($latest.gateway_start_reason)"
+          }
+          if ([string]::IsNullOrWhiteSpace($reason)) {
+            $reason = "gateway start preconditions are not met yet"
+          }
+          Write-Warning "Gateway not started yet: $reason. Continuing startup so onboarding/UI can open."
+          $gatewayPreconditionBlocked = $true
+          break
+        }
+        throw
+      }
     }
 
     if (Wait-GatewayRunning -LauncherToken $LauncherToken -TimeoutSeconds 25) {
@@ -612,17 +650,24 @@ try {
     throw "Gateway is not running after startup.$reason"
   }
 
-  if (-not $gatewayReady) {
+  if (-not $gatewayReady -and -not $gatewayPreconditionBlocked) {
     throw "Gateway is not running after startup."
   }
 
-  Write-Step "Gateway is running."
+  if ($gatewayReady) {
+    Write-Step "Gateway is running."
+  } else {
+    Write-Step "Gateway is not running yet (waiting for onboarding/model setup)."
+  }
 } catch {
   throw "Gateway preflight failed: $($_.Exception.Message)"
 }
 
 $gatewayPort = Get-GatewayPortFromConfig -ConfigPath $LauncherConfigPath
 $directGatewayUrl = "http://127.0.0.1:$gatewayPort"
+
+Ensure-NpmDeps -ProjectDir $petclawDir -DisplayName "petclaw"
+Ensure-NpmDeps -ProjectDir $electronDir -DisplayName "electron-frontend"
 
 if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListening -Port 3000)) {
   Write-Step "Petclaw dashboard already running at $DashboardUrl"
@@ -646,7 +691,7 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
 
   Start-DetachedPowerShell -Title "GoClaw - Petclaw" -Command $petclawCmd
 
-  if (-not (Wait-HttpReady -Url $DashboardUrl -TimeoutSeconds 35)) {
+  if (-not (Wait-HttpReady -Url $DashboardUrl -TimeoutSeconds 120)) {
     Write-Warning "Petclaw did not become ready at $DashboardUrl in time."
   } else {
     Write-Step "Petclaw is ready at $DashboardUrl"
@@ -661,8 +706,10 @@ if ($existingElectron.Count -gt 0) {
     Write-Step "Starting electron frontend vite server..."
     $viteCmd = "Set-Location '$electronDir'; npm run dev -- --host 127.0.0.1 --port 5173 --strictPort"
     Start-DetachedPowerShell -Title "GoClaw - Electron Vite" -Command $viteCmd
-    if (-not (Wait-HttpReady -Url "http://127.0.0.1:5173" -TimeoutSeconds 25)) {
-      throw "Electron Vite server did not become ready on http://127.0.0.1:5173"
+    if (-not (Wait-HttpReady -Url "http://127.0.0.1:5173" -TimeoutSeconds 120)) {
+      Write-Warning "Electron Vite server did not become ready on http://127.0.0.1:5173 in time."
+    } else {
+      Write-Step "Electron Vite server is ready on http://127.0.0.1:5173"
     }
   } else {
     Write-Step "Electron frontend vite server already running on :5173"


### PR DESCRIPTION
## Summary
- remove unsupported build matrix targets (linux/mipsle, 
etbsd/amd64, 
etbsd/arm64) that fail due modernc/sqlite constraints
- run gh release from repository root while uploading dist/* assets
- add actions/checkout in release job so gh release create --generate-notes has git context

## Verification
- Triggered tags v0.1.0~v0.1.2 during debugging and fixed each blocker
- Final tag v0.1.3 completed end-to-end successfully and published release assets