### PR TITLE
Feat/user profile

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -548,7 +548,93 @@ if (msg.push_type === 'audio_and_voice') {
 
 ---
 
-### 4.3 character_get - 获取角色配置
+### 4.3 user_profile_update - 用户画像更新
+
+提交用户的基本信息，用于桌宠了解用户并调整回复风格。后端会存储到 `~/.picoclaw/user_profile.json`，并在每次对话时注入到 LLM 上下文中。
+
+**请求**：
+
+```json
+{
+  "action": "user_profile_update",
+  "data": {
+    "display_name": "小明",
+    "role": "计算机专业",
+    "language": "zh-CN",
+    "chronotype": "night",
+    "personality_tone": "阴阳怪气",
+    "anxiety_level": 65,
+    "pressure_level": "high",
+    "extra": {
+      "focus_windows": ["20:00-23:00"],
+      "selected_breakers": ["考试", "作业"]
+    }
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "user_profile_update",
+  "data": {
+    "status": "ok"
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| display_name | string | 否 | 用户昵称/称呼 |
+| role | string | 否 | 用户身份/专业方向 |
+| language | string | 否 | 首选语言（如 `zh-CN`、`en-US`） |
+| chronotype | string | 否 | 作息类型：`morning`（晨型）/ `balanced`（均衡型）/ `night`（夜型） |
+| personality_tone | string | 否 | 期望的对话风格（如 `阴阳怪气`、`甜心夹子`、`正常`） |
+| anxiety_level | int | 否 | 焦虑指数 0-100 |
+| pressure_level | string | 否 | 压力等级：`low` / `medium` / `high` / `critical` |
+| extra | object | 否 | 其他扩展字段，前端传来的未知数据会以 `[key]: value` 格式注入 LLM |
+
+**数据用途**：
+
+1. **存储**：后端保存到 `~/.picoclaw/user_profile.json`（用户数据目录）
+2. **LLM 上下文注入**：通过 `【用户档案】` 系统消息注入，包含：
+   - 用户昵称、身份、语言偏好、作息类型、期望风格、压力等级
+   - extra 中的所有字段（前端传来的未知参数）
+3. **实时状态**：每个桌宠角色有独立的 `workspaces/{charID}/user_state.json`，存储 LLM 分析出的用户情绪状态（current_mood, energy_level, engagement_level, stress_trend）
+4. **情绪事件记忆**：每次对话后，LLM 会分析用户情绪事件并保存到 memory store（`user_preference` 类型），带时间戳
+
+**LLM 注入示例**：
+
+```
+【用户档案】
+  用户昵称：小明
+  身份/角色：计算机专业
+  语言偏好：zh-CN
+  作息类型：夜型（晚睡型）
+  期望对话风格：阴阳怪气
+  当前压力等级：high（焦虑指数 65%）
+  [focus_windows]: [20:00-23:00]
+  [selected_breakers]: [考试, 作业]
+
+当前状态（来自pet_001的感知）：
+  情绪状态：stressed
+  精力水平：40%
+  互动意愿：70%
+  压力趋势：上升中
+```
+
+**注意**：
+- 未知字段（extra）也会被记录并注入 LLM，让桌宠了解用户更多信息
+- 实时状态由 LLM 每次对话后自动分析，前端无需发送
+- 如果 profile 为空，LLM 会看到"用户尚未完成画像设置"
+
+---
+
+### 4.4 character_get - 获取角色配置
 
 获取当前桌宠的角色配置信息。
 
@@ -1653,6 +1739,7 @@ async def send_chat(ws, text):
 | chat | 聊天交互 | 发送消息，获得 AI 回复（流式） |
 | audio_done | 音频播放完毕 | 通知后端当前音频片段已播放完毕 |
 | onboarding_config | 提交初始化配置 | 首次启动时提交配置 |
+| user_profile_update | 更新用户画像 | 提交用户信息（昵称、角色、作息等），用于 LLM 上下文 |
 | character_get | 获取角色配置 | 查看当前角色 |
 | character_update | 更新角色配置 | 修改角色设置 |
 | character_switch | 切换角色 | 切换当前激活的角色 |

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -674,9 +674,6 @@ func (s *petStreamer) Finalize(ctx context.Context, content string) error {
 	}
 
 	s.waitMu.Lock()
-	if s.waitTimer != nil {
-		s.waitTimer.Stop()
-	}
 	// 标记流式结束，但不立即停止。audioPlayLoop 会继续处理剩余音频
 	s.streamingEnded = true
 	s.waitMu.Unlock()
@@ -688,6 +685,12 @@ func (s *petStreamer) Finalize(ctx context.Context, content string) error {
 	case <-time.After(30 * time.Second):
 		logger.WarnCF("pet", "Finalize: audioPlayLoop timeout", nil)
 	}
+
+	s.waitMu.Lock()
+	if s.waitTimer != nil {
+		s.waitTimer.Stop()
+	}
+	s.waitMu.Unlock()
 
 	// 清空状态，不发送任何文本
 	s.buffer = ""
@@ -1075,29 +1078,27 @@ func (s *petStreamer) audioPlayLoop() {
 			//}
 			// 有待发送音频则发送
 			if s.hasReadyAudioCount > 0 && s.hasSentFirst {
-				s.hasReadyAudioCount--
-				s.trySendNextLocked()
+				if s.trySendNextLocked() {
+					s.hasReadyAudioCount--
+				}
 			}
 			s.waitMu.Unlock()
 
 		case <-s.waitTimer.C:
 			// timer 超时
-			s.waitTimer.Stop()
 			s.waitMu.Lock()
 			logger.DebugCF("pet", "audioPlayLoop: timer fired", map[string]any{
 				"hasReadyAudioCount": s.hasReadyAudioCount,
 				"queue_size":         s.audioQueue.Size(),
 			})
-			//// 弹出已发送的片段
-			//front, _ := s.audioQueue.PeekNextReady()
-			//if front != nil {
-			//	_, _ = s.audioQueue.MarkSent()
-			//	logger.DebugCF("pet", "audioPlayLoop: marked sent", map[string]any{"seq": front.Seq})
-			//}
 			// 有待发送音频则发送
 			if s.hasReadyAudioCount > 0 && s.hasSentFirst {
-				s.hasReadyAudioCount--
-				s.trySendNextLocked()
+				if s.trySendNextLocked() {
+					s.hasReadyAudioCount--
+				} else {
+					s.waitTimer.Reset(defaultAudioWaitTimeout)
+				}
+				// 如果发送失败（音频未就绪），不减计数，等下次 timer 重试
 			}
 			s.waitMu.Unlock()
 		}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -196,7 +196,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 			if pc, ok := petChannel.(*petchannel.PetChannel); ok {
 				svc := pc.Service()
 
-				petHook := pet.NewPetHook(svc.CharManager(), svc.ActionManager(), svc, svc.MemoryStore(), svc.ConversationStore())
+				petHook := pet.NewPetHook(svc.CharManager(), svc.ActionManager(), svc, svc.MemoryStore(), svc.ConversationStore(), svc.UserProfileManager())
 				agentLoop.MountHook(agent.NamedHook("pet", petHook))
 				logger.InfoCF("pet", "Pet hook registered", nil)
 			}

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -358,11 +358,11 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 	parseText := textTags[0].Text
 	resp.Response.Content = content
 
-	// 6. 分析用户情绪（如果配置了用户画像管理器）
+	// 6. 分析用户情绪（异步，不阻塞响应）
 	if h.userProfileMgr != nil && h.lastUserMessage != "" {
 		char := h.charManager.GetCurrent()
 		if char != nil {
-			h.userProfileMgr.AnalyzeAfterChat(char.ID, h.lastUserMessage, parseText)
+			go h.userProfileMgr.AnalyzeAfterChat(char.ID, h.lastUserMessage, parseText)
 		}
 	}
 

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/pet/compression"
 	"github.com/sipeed/picoclaw/pkg/pet/emotion"
 	"github.com/sipeed/picoclaw/pkg/pet/memory"
+	"github.com/sipeed/picoclaw/pkg/pet/userprofile"
 	"github.com/sipeed/picoclaw/pkg/providers"
 	"github.com/sipeed/picoclaw/pkg/tools"
 )
@@ -45,6 +46,7 @@ type PetHook struct {
 	petService        *PetService                    // Pet服务，用于推送
 	memoryStore       *memory.Store                  // 记忆存储
 	conversationStore *compression.ConversationStore // 会话存储
+	userProfileMgr    *userprofile.Manager           // 用户画像管理器
 	lastUserMessage   string                         // 最后一条用户消息，用于记录对话
 }
 
@@ -55,13 +57,14 @@ type PetHook struct {
 //   - petService: Pet服务指针，用于推送情绪和动作
 //   - memoryStore: 记忆存储指针
 //   - conversationStore: 会话存储指针
-func NewPetHook(charManager *characters.Manager, actionManager *action.ActionManager, petService *PetService, memoryStore *memory.Store, conversationStore *compression.ConversationStore) *PetHook {
+func NewPetHook(charManager *characters.Manager, actionManager *action.ActionManager, petService *PetService, memoryStore *memory.Store, conversationStore *compression.ConversationStore, userProfileMgr *userprofile.Manager) *PetHook {
 	return &PetHook{
 		charManager:       charManager,
 		actionManager:     actionManager,
 		petService:        petService,
 		memoryStore:       memoryStore,
 		conversationStore: conversationStore,
+		userProfileMgr:    userProfileMgr,
 	}
 }
 
@@ -160,6 +163,12 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 		memoryTypesList = "conversation（对话）/ preference（偏好）/ fact（事实）/ user_profile（用户基础信息）/ user_preference（用户偏好）"
 	}
 
+	// 用户档案prompt - 独立注入用户画像信息
+	userProfilePrompt := ""
+	if h.userProfileMgr != nil {
+		userProfilePrompt = h.userProfileMgr.GetContextPrompt(char.ID)
+	}
+
 	// 角色信息prompt
 	personaPrompt := fmt.Sprintf(`【桌宠角色信息】
 姓名：%s
@@ -221,11 +230,15 @@ func (h *PetHook) BeforeLLM(ctx context.Context, req *agent.LLMHookRequest) (*ag
 		strings.Join(actionNames, ", "),
 		memoryTypesList)
 
-	// 先注入记忆，再注入角色信息，最后注入情绪动作
+	// 先注入记忆，再注入用户档案，再注入角色信息，最后注入情绪动作
 	var msgs []providers.Message
 	if memoryPrompt != "" {
 		memoryMsg := providers.Message{Role: "system", Content: memoryPrompt}
 		msgs = append(msgs, memoryMsg)
+	}
+	if userProfilePrompt != "" {
+		userProfileMsg := providers.Message{Role: "system", Content: userProfilePrompt}
+		msgs = append(msgs, userProfileMsg)
 	}
 	personaMsg := providers.Message{Role: "system", Content: personaPrompt}
 	emotionMsg := providers.Message{Role: "system", Content: emotionPrompt}
@@ -345,7 +358,15 @@ func (h *PetHook) AfterLLM(ctx context.Context, resp *agent.LLMHookResponse) (*a
 	parseText := textTags[0].Text
 	resp.Response.Content = content
 
-	// 6. 记录对话到会话存储（用于后续压缩）
+	// 6. 分析用户情绪（如果配置了用户画像管理器）
+	if h.userProfileMgr != nil && h.lastUserMessage != "" {
+		char := h.charManager.GetCurrent()
+		if char != nil {
+			h.userProfileMgr.AnalyzeAfterChat(char.ID, h.lastUserMessage, parseText)
+		}
+	}
+
+	// 7. 记录对话到会话存储（用于后续压缩）
 	if h.conversationStore != nil {
 		char := h.charManager.GetCurrent()
 		if char != nil {

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -18,6 +18,7 @@ import (
 	petconfig "github.com/sipeed/picoclaw/pkg/pet/config"
 	"github.com/sipeed/picoclaw/pkg/pet/memory"
 	"github.com/sipeed/picoclaw/pkg/pet/modelconfig"
+	"github.com/sipeed/picoclaw/pkg/pet/userprofile"
 	"github.com/sipeed/picoclaw/pkg/pet/voice"
 	"github.com/sipeed/picoclaw/pkg/providers"
 )
@@ -39,6 +40,7 @@ type PetService struct {
 	compressionSvc     *compression.CompressionService
 	modelConfigManager *modelconfig.Manager
 	cronService        *cron.CronService
+	userProfileManager *userprofile.Manager
 
 	connSessions map[string]string
 
@@ -122,41 +124,45 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 				logger.Warnf("pet: failed to create conversation store: %v", err)
 			}
 
-			// 如果压缩功能启用，创建压缩服务
-			if cfg.Config != nil && compressionConfig != nil && compressionConfig.Enabled {
-				modelName := compressionConfig.Model
-				var provider providers.LLMProvider
-				var modelCfg *config.ModelConfig
-
-				// 获取模型配置（从 picoclaw 的 model_list 中查找）
-				if modelName != "" {
-					modelCfg, err = cfg.Config.GetModelConfig(modelName)
-					if err != nil {
-						logger.Warnf("pet: compression model %q not found: %v, compression disabled", modelName, err)
+			// 统一使用 Agents.Defaults 的模型
+			var provider providers.LLMProvider
+			var modelCfg *config.ModelConfig
+			if cfg.Config != nil {
+				rawModel := cfg.Config.Agents.Defaults.GetModelName()
+				for _, m := range cfg.Config.ModelList {
+					if m.Model == rawModel {
+						modelCfg = m
+						break
 					}
 				}
-
-				// 创建 LLM Provider（使用 modelCfg 中的配置）
 				if modelCfg != nil {
 					provider, _, err = providers.CreateProviderFromConfig(modelCfg)
 					if err != nil {
-						logger.Warnf("pet: failed to create compression provider: %v, compression disabled", err)
+						logger.Warnf("pet: failed to create provider for agents default model: %v", err)
 					}
 				}
-
-				// 创建压缩服务并设置 Provider
-				if provider != nil {
-					s.provider = provider
-					s.compressionSvc = compression.NewCompressionService(compressionConfig, s.memoryStore, s.conversationStore)
-					s.compressionSvc.SetProvider(provider, modelCfg)
-				}
 			}
-		}
 
+			// 创建压缩服务并设置 Provider（仅当压缩功能启用时）
+			if compressionConfig != nil && compressionConfig.Enabled && provider != nil {
+				s.provider = provider
+				s.compressionSvc = compression.NewCompressionService(compressionConfig, s.memoryStore, s.conversationStore)
+				s.compressionSvc.SetProvider(provider, modelCfg)
+			}
+
+			// 创建用户画像管理器
+			s.userProfileManager = userprofile.NewManager(
+				workspacePath,
+				s.memoryStore,
+				s.charManager,
+				provider,
+				cfg.Config.Agents.Defaults.GetModelName(),
+			)
+		}
 		if cfg.ConfigPath != "" {
 			s.modelConfigManager = modelconfig.NewManager(cfg.ConfigPath)
 		}
-
+		// 初始化 cron 服务
 		cronStorePath := filepath.Join(workspacePath, "cron", "jobs.json")
 		s.cronService = cron.NewCronService(cronStorePath, nil)
 		logger.DebugCF("pet", "PetService: cron service initialized, store=", map[string]any{
@@ -247,6 +253,10 @@ func (s *PetService) ConversationStore() *compression.ConversationStore {
 
 func (s *PetService) VoiceLoader() *voice.Loader {
 	return s.voiceLoader
+}
+
+func (s *PetService) UserProfileManager() *userprofile.Manager {
+	return s.userProfileManager
 }
 
 func (s *PetService) SetPushHandler(handler PushHandler) {
@@ -392,6 +402,8 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 		return s.handleChat(sessionID, req)
 	case ActionOnboardingConfig:
 		return s.handleOnboardingConfig(sessionID, req)
+	case ActionUserProfileUpdate:
+		return s.handleUserProfileUpdate(sessionID, req)
 	case ActionCharacterGet:
 		return s.handleCharacterGet(sessionID, req)
 	case ActionCharacterUpdate:
@@ -596,6 +608,21 @@ func (s *PetService) handleHealthCheck(sessionID string, req Request) error {
 		Status:    "ok",
 		Timestamp: time.Now().Unix(),
 	})
+}
+
+func (s *PetService) handleUserProfileUpdate(sessionID string, req Request) error {
+	if s.userProfileManager == nil {
+		return s.sendError(sessionID, req.Action, "user profile manager not available")
+	}
+
+	var data userprofile.UserProfileUpdateRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid user profile data")
+	}
+
+	s.userProfileManager.UpdateProfile(&data)
+
+	return s.sendResponse(sessionID, req.Action, map[string]string{"status": "ok"})
 }
 
 func (s *PetService) sendResponse(sessionID, action string, data interface{}) error {

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -109,12 +109,14 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 				threshold = compressionConfig.Threshold
 			}
 
-			// 对话存储的回调函数：当对话数达到阈值时触发压缩
+			// 对话存储的回调函数：当对话数达到阈值时触发压缩（异步）
 			callback := func(characterID string, entries []*compression.ConversationEntry) {
 				if s.compressionSvc != nil {
-					if err := s.compressionSvc.Compress(characterID, entries); err != nil {
-						logger.Warnf("compression: failed to compress: %v", err)
-					}
+					go func() {
+						if err := s.compressionSvc.Compress(characterID, entries); err != nil {
+							logger.Warnf("compression: failed to compress: %v", err)
+						}
+					}()
 				}
 			}
 

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -19,27 +19,28 @@ type Request struct {
 
 // Action 请求动作类型
 const (
-	ActionChat             = "chat"              // 聊天交互
-	ActionOnboardingConfig = "onboarding_config" // 提交初始化配置
-	ActionCharacterGet     = "character_get"     // 获取角色配置
-	ActionCharacterUpdate  = "character_update"  // 更新角色配置
-	ActionCharacterSwitch  = "character_switch"  // 切换角色
-	ActionConfigGet        = "config_get"        // 获取应用配置
-	ActionConfigUpdate     = "config_update"     // 更新应用配置
-	ActionEmotionGet       = "emotion_get"       // 获取情绪状态
-	ActionHealthCheck      = "health_check"      // 健康检查
-	ActionMemorySearch     = "memory_search"     // 搜索记忆
-	ActionConversationList = "conversation_list" // 对话列表
-	ActionModelListGet     = "model_list_get"    // 获取模型列表
-	ActionModelAdd         = "model_add"         // 添加模型
-	ActionModelUpdate      = "model_update"      // 更新模型
-	ActionModelDelete      = "model_delete"      // 删除模型
-	ActionModelSetDefault  = "model_set_default" // 设置默认模型
-	ActionCronAdd          = "cron_add"          // 添加定时任务
-	ActionCronList         = "cron_list"         // 列出定时任务
-	ActionCronRemove       = "cron_remove"       // 删除定时任务
-	ActionCronEnable       = "cron_enable"       // 启用定时任务
-	ActionCronDisable      = "cron_disable"      // 禁用定时任务
+	ActionChat              = "chat"                // 聊天交互
+	ActionOnboardingConfig  = "onboarding_config"   // 提交初始化配置
+	ActionUserProfileUpdate = "user_profile_update" // 用户画像更新
+	ActionCharacterGet      = "character_get"       // 获取角色配置
+	ActionCharacterUpdate   = "character_update"    // 更新角色配置
+	ActionCharacterSwitch   = "character_switch"    // 切换角色
+	ActionConfigGet         = "config_get"          // 获取应用配置
+	ActionConfigUpdate      = "config_update"       // 更新应用配置
+	ActionEmotionGet        = "emotion_get"         // 获取情绪状态
+	ActionHealthCheck       = "health_check"        // 健康检查
+	ActionMemorySearch      = "memory_search"       // 搜索记忆
+	ActionConversationList  = "conversation_list"   // 对话列表
+	ActionModelListGet      = "model_list_get"      // 获取模型列表
+	ActionModelAdd          = "model_add"           // 添加模型
+	ActionModelUpdate       = "model_update"        // 更新模型
+	ActionModelDelete       = "model_delete"        // 删除模型
+	ActionModelSetDefault   = "model_set_default"   // 设置默认模型
+	ActionCronAdd           = "cron_add"            // 添加定时任务
+	ActionCronList          = "cron_list"           // 列出定时任务
+	ActionCronRemove        = "cron_remove"         // 删除定时任务
+	ActionCronEnable        = "cron_enable"         // 启用定时任务
+	ActionCronDisable       = "cron_disable"        // 禁用定时任务
 )
 
 // =============================================================================
@@ -105,6 +106,26 @@ type OnboardingConfigRequest struct {
 	PetName        string `json:"pet_name"`         // 桌宠名称
 	PetPersona     string `json:"pet_persona"`      // 性格描述
 	PetPersonaType string `json:"pet_persona_type"` // 性格类型
+}
+
+// UserProfileUpdateRequest 用户画像更新请求
+type UserProfileUpdateRequest struct {
+	DisplayName     string         `json:"display_name"`
+	Role            string         `json:"role"`
+	Language        string         `json:"language"`
+	Chronotype      string         `json:"chronotype"`
+	PersonalityTone string         `json:"personality_tone"`
+	AnxietyLevel    int            `json:"anxiety_level"`
+	PressureLevel   string         `json:"pressure_level"`
+	Extra           map[string]any `json:"extra"`
+}
+
+// UserProfileDataRequest 用户实时状态更新请求
+type UserProfileDataRequest struct {
+	CurrentMood     string `json:"current_mood"`
+	EnergyLevel     int    `json:"energy_level"`
+	EngagementLevel int    `json:"engagement_level"`
+	StressTrend     string `json:"stress_trend"`
 }
 
 // CharacterGetRequest 角色获取请求数据

--- a/pkg/pet/userprofile/manager.go
+++ b/pkg/pet/userprofile/manager.go
@@ -1,0 +1,416 @@
+package userprofile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/pet/characters"
+	"github.com/sipeed/picoclaw/pkg/pet/memory"
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+const (
+	ProfileFileName = "user_profile.json"
+	StateFileName   = "user_state.json"
+	UserDataDir     = ".picoclaw"
+)
+
+type Manager struct {
+	profile   *UserProfile
+	state     map[string]*UserState
+	dataDir   string
+	memStore  *memory.Store
+	charMgr   *characters.Manager
+	provider  providers.LLMProvider
+	modelName string
+}
+
+func NewManager(dataDir string, memStore *memory.Store, charMgr *characters.Manager, provider providers.LLMProvider, modelName string) *Manager {
+	return &Manager{
+		profile:   nil,
+		state:     make(map[string]*UserState),
+		dataDir:   dataDir,
+		memStore:  memStore,
+		charMgr:   charMgr,
+		provider:  provider,
+		modelName: modelName,
+	}
+}
+
+func (m *Manager) getUserDataDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, UserDataDir)
+}
+
+func (m *Manager) profilePath() string {
+	return filepath.Join(m.getUserDataDir(), ProfileFileName)
+}
+
+func (m *Manager) statePath(charID string) string {
+	return filepath.Join(m.dataDir, charID, StateFileName)
+}
+
+func (m *Manager) ensureUserDataDir() error {
+	dir := m.getUserDataDir()
+	return os.MkdirAll(dir, 0755)
+}
+
+func (m *Manager) LoadProfile() *UserProfile {
+	if m.profile != nil {
+		return m.profile
+	}
+
+	m.profile = NewUserProfile()
+
+	path := m.profilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m.profile
+		}
+		logger.Errorf("userprofile: failed to read profile: %v", err)
+		return m.profile
+	}
+
+	if err := json.Unmarshal(data, m.profile); err != nil {
+		logger.Errorf("userprofile: failed to unmarshal profile: %v", err)
+		return m.profile
+	}
+
+	if m.profile.Extra == nil {
+		m.profile.Extra = make(map[string]any)
+	}
+
+	return m.profile
+}
+
+func (m *Manager) SaveProfile() error {
+	if m.profile == nil {
+		return fmt.Errorf("profile is nil")
+	}
+
+	m.profile.UpdatedAt = time.Now().Unix()
+
+	if err := m.ensureUserDataDir(); err != nil {
+		return fmt.Errorf("failed to ensure user data dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m.profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile: %w", err)
+	}
+
+	if err := os.WriteFile(m.profilePath(), data, 0644); err != nil {
+		return fmt.Errorf("failed to write profile: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) LoadState(charID string) *UserState {
+	if state, ok := m.state[charID]; ok {
+		return state
+	}
+
+	state := NewUserState()
+
+	path := m.statePath(charID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state
+		}
+		logger.Errorf("userprofile: failed to read state for %s: %v", charID, err)
+		return state
+	}
+
+	if err := json.Unmarshal(data, state); err != nil {
+		logger.Errorf("userprofile: failed to unmarshal state for %s: %v", charID, err)
+		return state
+	}
+
+	m.state[charID] = state
+	return state
+}
+
+func (m *Manager) SaveState(charID string) error {
+	state, ok := m.state[charID]
+	if !ok {
+		return fmt.Errorf("state not found for %s", charID)
+	}
+
+	state.LastAnalyzedAt = time.Now().Unix()
+
+	charDir := filepath.Join(m.dataDir, charID)
+	if err := os.MkdirAll(charDir, 0755); err != nil {
+		return fmt.Errorf("failed to ensure char dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	if err := os.WriteFile(m.statePath(charID), data, 0644); err != nil {
+		return fmt.Errorf("failed to write state: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) UpdateProfile(req *UserProfileUpdateRequest) {
+	profile := m.LoadProfile()
+
+	if req.DisplayName != "" {
+		profile.DisplayName = req.DisplayName
+	}
+	if req.Role != "" {
+		profile.Role = req.Role
+	}
+	if req.Language != "" {
+		profile.Language = req.Language
+	}
+	if req.Chronotype != "" {
+		profile.Chronotype = req.Chronotype
+	}
+	if req.PersonalityTone != "" {
+		profile.PersonalityTone = req.PersonalityTone
+	}
+	if req.AnxietyLevel > 0 {
+		profile.AnxietyLevel = req.AnxietyLevel
+	}
+	if req.PressureLevel != "" {
+		profile.PressureLevel = req.PressureLevel
+	}
+
+	for k, v := range req.Extra {
+		profile.Extra[k] = v
+	}
+
+	if err := m.SaveProfile(); err != nil {
+		logger.Errorf("userprofile: failed to save profile: %v", err)
+	}
+}
+
+func (m *Manager) formatChronotype(c string) string {
+	switch c {
+	case "morning":
+		return "晨型（早起型）"
+	case "balanced":
+		return "均衡型"
+	case "night":
+		return "夜型（晚睡型）"
+	default:
+		return c
+	}
+}
+
+func (m *Manager) formatAnxietyLevel(level int) string {
+	if level >= 75 {
+		return "高"
+	}
+	if level >= 45 {
+		return "中"
+	}
+	return "低"
+}
+
+func (m *Manager) UpdateState(charID string, mood string, energy, engagement int, trend string) {
+	state := m.LoadState(charID)
+
+	if mood != "" {
+		state.CurrentMood = mood
+	}
+	if energy > 0 {
+		state.EnergyLevel = energy
+	}
+	if engagement > 0 {
+		state.EngagementLevel = engagement
+	}
+	if trend != "" {
+		state.StressTrend = trend
+	}
+
+	m.state[charID] = state
+
+	if err := m.SaveState(charID); err != nil {
+		logger.Errorf("userprofile: failed to save state: %v", err)
+	}
+}
+
+func (m *Manager) IsProfileEmpty() bool {
+	profile := m.LoadProfile()
+	return profile.DisplayName == "" && profile.Role == ""
+}
+
+func (m *Manager) GetContextPrompt(charID string) string {
+	profile := m.LoadProfile()
+	state := m.LoadState(charID)
+
+	var sb strings.Builder
+
+	sb.WriteString("\n【用户档案】\n")
+
+	hasProfile := false
+	if profile.DisplayName != "" {
+		sb.WriteString(fmt.Sprintf("  用户昵称：%s\n", profile.DisplayName))
+		hasProfile = true
+	}
+	if profile.Role != "" {
+		sb.WriteString(fmt.Sprintf("  身份/角色：%s\n", profile.Role))
+		hasProfile = true
+	}
+	if profile.Language != "" {
+		sb.WriteString(fmt.Sprintf("  语言偏好：%s\n", profile.Language))
+		hasProfile = true
+	}
+	if profile.Chronotype != "" {
+		sb.WriteString(fmt.Sprintf("  作息类型：%s\n", m.formatChronotype(profile.Chronotype)))
+		hasProfile = true
+	}
+	if profile.PersonalityTone != "" {
+		sb.WriteString(fmt.Sprintf("  期望对话风格：%s\n", profile.PersonalityTone))
+		hasProfile = true
+	}
+	if profile.PressureLevel != "" {
+		sb.WriteString(fmt.Sprintf("  当前压力等级：%s", profile.PressureLevel))
+		if profile.AnxietyLevel > 0 {
+			sb.WriteString(fmt.Sprintf("（焦虑指数 %d%%）", profile.AnxietyLevel))
+		}
+		sb.WriteString("\n")
+		hasProfile = true
+	}
+
+	for k, v := range profile.Extra {
+		sb.WriteString(fmt.Sprintf("  [%s]: %v\n", k, v))
+		hasProfile = true
+	}
+
+	if !hasProfile {
+		sb.WriteString("  （用户尚未完成画像设置）\n")
+	}
+
+	char := m.charMgr.GetCurrent()
+	charName := ""
+	if char != nil {
+		charName = "（来自" + char.ID + "的感知）"
+	}
+
+	sb.WriteString("\n当前状态" + charName + "：\n")
+	sb.WriteString(fmt.Sprintf("  情绪状态：%s\n", state.CurrentMood))
+	sb.WriteString(fmt.Sprintf("  精力水平：%d%%\n", state.EnergyLevel))
+	sb.WriteString(fmt.Sprintf("  互动意愿：%d%%\n", state.EngagementLevel))
+
+	trendLabel := "稳定"
+	switch state.StressTrend {
+	case "rising":
+		trendLabel = "上升中"
+	case "falling":
+		trendLabel = "下降中"
+	case "stable":
+		trendLabel = "稳定"
+	}
+	sb.WriteString(fmt.Sprintf("  压力趋势：%s\n", trendLabel))
+
+	return sb.String()
+}
+
+func (m *Manager) AnalyzeAfterChat(charID, userMsg, petResp string) {
+	if m.provider == nil || m.memStore == nil {
+		return
+	}
+
+	prompt := fmt.Sprintf(`【用户情绪分析】
+根据以下对话记录，分析用户的情绪事件（注意是记录过去发生的事件，而非当前状态）：
+
+用户：%s
+桌宠：%s
+
+请返回JSON格式（不要有其他内容）：
+{
+  "event": "描述用户表现出的关键情绪事件，如'用户在讨论考试时表达了焦虑'或'用户在得到夸奖后情绪好转'",
+  "current_mood": "stressed/relaxed/frustrated/engaged/bored/pleased/anxious/calm",
+  "energy_level": 0-100,
+  "engagement_level": 0-100,
+  "stress_trend": "rising/falling/stable"
+}`, userMsg, petResp)
+
+	model := m.modelName
+	if model == "" {
+		model = m.provider.GetDefaultModel()
+	}
+
+	resp, err := m.provider.Chat(context.Background(), []providers.Message{
+		{Role: "user", Content: prompt},
+	}, nil, model, nil)
+	if err != nil {
+		logger.Warnf("userprofile: analysis failed: %v", err)
+		return
+	}
+
+	m.parseAnalysisResult(charID, resp.Content)
+}
+
+func (m *Manager) parseAnalysisResult(charID, resp string) {
+	mood := extractJSONField(resp, "current_mood")
+	energy := extractJSONIntField(resp, "energy_level")
+	engagement := extractJSONIntField(resp, "engagement_level")
+	trend := extractJSONField(resp, "stress_trend")
+	event := extractJSONField(resp, "event")
+
+	if mood != "" || energy > 0 || engagement > 0 || trend != "" {
+		m.UpdateState(charID, mood, energy, engagement, trend)
+	}
+
+	if event != "" && m.memStore != nil {
+		char := m.charMgr.GetCurrent()
+		if char != nil {
+			m.memStore.Add(char.ID, event, memory.MemoryTypeUserPreference, 75)
+			logger.Infof("userprofile: saved memory event for %s: %s", char.ID, event)
+		}
+	}
+}
+
+func extractJSONField(s, key string) string {
+	prefix := fmt.Sprintf(`"%s":`, key)
+	idx := strings.Index(s, prefix)
+	if idx == -1 {
+		prefix = fmt.Sprintf(`"%s": `, key)
+		idx = strings.Index(s, prefix)
+	}
+	if idx == -1 {
+		return ""
+	}
+
+	start := idx + len(prefix)
+	for start < len(s) && (s[start] == ' ' || s[start] == '"') {
+		start++
+	}
+
+	end := start
+	for end < len(s) && s[end] != '"' && s[end] != ',' && s[end] != '\n' && s[end] != '}' {
+		end++
+	}
+
+	if end > start {
+		return s[start:end]
+	}
+	return ""
+}
+
+func extractJSONIntField(s, key string) int {
+	field := extractJSONField(s, key)
+	if field == "" {
+		return 0
+	}
+
+	var val int
+	fmt.Sscanf(field, "%d", &val)
+	return val
+}

--- a/pkg/pet/userprofile/types.go
+++ b/pkg/pet/userprofile/types.go
@@ -1,0 +1,49 @@
+package userprofile
+
+import "time"
+
+type UserProfile struct {
+	DisplayName     string         `json:"display_name"`
+	Role            string         `json:"role"`
+	Language        string         `json:"language"`
+	Chronotype      string         `json:"chronotype"`
+	PersonalityTone string         `json:"personality_tone"`
+	AnxietyLevel    int            `json:"anxiety_level"`
+	PressureLevel   string         `json:"pressure_level"`
+	Extra           map[string]any `json:"extra"`
+	UpdatedAt       int64          `json:"updated_at"`
+}
+
+type UserState struct {
+	CurrentMood     string `json:"current_mood"`
+	EnergyLevel     int    `json:"energy_level"`
+	EngagementLevel int    `json:"engagement_level"`
+	StressTrend     string `json:"stress_trend"`
+	LastAnalyzedAt  int64  `json:"last_analyzed_at"`
+}
+
+type UserProfileUpdateRequest struct {
+	DisplayName     string         `json:"display_name"`
+	Role            string         `json:"role"`
+	Language        string         `json:"language"`
+	Chronotype      string         `json:"chronotype"`
+	PersonalityTone string         `json:"personality_tone"`
+	AnxietyLevel    int            `json:"anxiety_level"`
+	PressureLevel   string         `json:"pressure_level"`
+	Extra           map[string]any `json:"extra"`
+}
+
+func NewUserProfile() *UserProfile {
+	return &UserProfile{
+		Extra:     make(map[string]any),
+		UpdatedAt: time.Now().Unix(),
+	}
+}
+
+func NewUserState() *UserState {
+	return &UserState{
+		EnergyLevel:     50,
+		EngagementLevel: 50,
+		LastAnalyzedAt:  time.Now().Unix(),
+	}
+}

--- a/pkg/pet/voice/synthesizer.go
+++ b/pkg/pet/voice/synthesizer.go
@@ -227,19 +227,17 @@ func (s *Synthesizer) SynthesizeToQueue(sessionID string, chatID int64, text str
 		// 收集所有音频块
 		for chunk := range ch {
 			audioData = append(audioData, chunk.Data...)
-			if chunk.Info != nil {
+			if chunk.Info != nil && chunk.Info.Length > 0 {
 				duration = chunk.Info.Length
 			}
 		}
 
-		// 检查音频数据是否为空（无额度）
-		// if len(audioData) == 0 {
-		// 	queue.UpdateSegment(seq, true, nil, 0, "语音合成返回空，请检查一下相关语音合成模型的额度")
-		// } else {
-		// 	queue.UpdateSegment(seq, true, audioData, duration, "")
-		// }
+		// 如果 API 未返回时长，用音频大小估算
+		// MiniMax: 128000 bps = 16000 bytes/s
+		if duration == 0 && len(audioData) > 0 {
+			duration = len(audioData) * 1000 / 16000
+		}
 
-		// 暂时注释掉额度检查
 		queue.UpdateSegment(seq, true, audioData, duration, "")
 
 		// 通知 audioReady channel


### PR DESCRIPTION
# PR: 用户画像模块 (User Profile Module)

## 概述

实现用户画像功能，桌宠可以通过用户画像了解当前用户的基本信息、性格偏好和实时情绪状态，从而调整回复风格。

## 主要改动

### 1. 新增 userprofile 模块 (`pkg/pet/userprofile/`)

- **types.go**: 定义 `UserProfile`、`UserState`、`UserProfileUpdateRequest` 结构体
- **manager.go**: 核心管理器，实现以下功能：
  - `LoadProfile()` / `SaveProfile()` - 读写 `~/.picoclaw/user_profile.json`
  - `LoadState()` / `SaveState()` - 读写 `workspaces/{charID}/user_state.json`
  - `UpdateProfile()` - 更新用户静态画像
  - `UpdateState()` - 更新用户实时状态（由 LLM 分析结果）
  - `GetContextPrompt()` - 生成注入 LLM 的【用户档案】系统消息
  - `AnalyzeAfterChat()` - 对话后调用 LLM 分析用户情绪事件

### 2. 模型选择统一

压缩功能和情绪分析统一使用 `Agents.Defaults` 模型：
- 从 `ModelList` 中通过 `Model` 字段匹配找到对应的 `ModelConfig`
- 使用 `ModelConfig.ModelName` 作为最终模型名
- 删除手动配置的 `compressionConfig.Model`

### 3. BeforeLLM 注入用户档案

在【角色记忆】之后注入【用户档案】系统消息，包含：
- 用户昵称、身份、语言偏好、作息类型、期望风格、压力等级
- extra 中的所有扩展字段（前端传来的未知参数）
- 用户实时状态（current_mood, energy_level, engagement_level, stress_trend）

### 4. AfterLLM 触发情绪分析

每次对话结束后，调用 `AnalyzeAfterChat()`：
- LLM 分析对话中的用户情绪事件
- 分析结果写入 `workspaces/{charID}/user_state.json`
- 情绪事件以带时间戳的格式存入 memory store（`user_preference` 类型）

### 5. API 文档更新

在 `docs/PET_CHANNEL_API.md` 中添加 `user_profile_update` (4.3) 章节，文档说明：
- 请求字段（display_name, role, language, chronotype, personality_tone, anxiety_level, pressure_level, extra）
- 数据存储位置
- LLM 上下文注入格式

## 数据存储

| 文件 | 位置 | 内容 | 共享/独立 |
|------|------|------|----------|
| user_profile.json | ~/.picoclaw/ | display_name, role, language, chronotype, personality_tone, anxiety_level, pressure_level, extra | 共享（所有桌宠共用） |
| user_state.json | workspaces/{charID}/ | current_mood, energy_level, engagement_level, stress_trend, last_analyzed_at | 每角色独立 |
| memories 表 | workspaces/{charID}/pet_memory.db | LLM 分析出的情绪事件（带时间戳） | 每角色独立 |

## API 接口

### user_profile_update

**请求**：
```json
{
  "action": "user_profile_update",
  "data": {
    "display_name": "小明",
    "role": "计算机专业",
    "language": "zh-CN",
    "chronotype": "night",
    "personality_tone": "阴阳怪气",
    "anxiety_level": 65,
    "pressure_level": "high",
    "extra": {
      "focus_windows": ["20:00-23:00"]
    }
  }
}
```

**响应**：
```json
{
  "status": "ok",
  "action": "user_profile_update",
  "data": { "status": "ok" }
}
```

## LLM 注入示例

```
【用户档案】
  用户昵称：小明
  身份/角色：计算机专业
  语言偏好：zh-CN
  作息类型：夜型（晚睡型）
  期望对话风格：阴阳怪气
  当前压力等级：high（焦虑指数 65%）
  [focus_windows]: [20:00-23:00]

当前状态（来自pet_001的感知）：
  情绪状态：stressed
  精力水平：40%
  互动意愿：70%
  压力趋势：上升中
```

## 提交记录

| Commit | 说明 |
|--------|------|
| `feat(pet/types): add user profile action constants` | 添加 ActionUserProfileUpdate 常量，定义请求结构体 |
| `feat(pet/service): integrate user profile manager and unify model selection` | 集成 userProfileManager，统一模型选择逻辑 |
| `feat(pet/hooks): add user profile support in BeforeLLM and AfterLLM` | BeforeLLM 注入用户档案，AfterLLM 触发情绪分析（异步） |
| `feat(gateway): pass userProfileManager to NewPetHook` | 网关层传递 userProfileManager |
| `docs(PET_CHANNEL_API): add user_profile_update action documentation` | API 文档更新 |
| `refactor(pet/service): make compression callback async` | 压缩回调改为异步执行，避免阻塞主流程 |

## 异步执行

两个 LLM 调用操作已改为异步执行，不阻塞主流程：

1. **情绪分析** (`AnalyzeAfterChat`)：在 `AfterLLM` 中以 goroutine 执行
2. **对话压缩** (`Compress`)：在 callback 中以 goroutine 执行

这样确保：
- 用户发送消息后立即收到响应，无需等待 LLM 分析完成
- 压缩操作在后台完成，不影响对话流畅度

## 行为变化

- 前端发送 `user_profile_update` 后，用户画像会保存并在每次对话时注入 LLM
- 每次对话结束后，LLM 会自动分析用户情绪并更新实时状态
- 情绪事件（带时间戳）会存入 memory store，供长期参考
- 如果用户未设置画像，LLM 会看到"用户尚未完成画像设置"

## 依赖

- 无新增外部依赖
- 使用 picoclaw 现有的 `ModelList` 配置和 provider 机制