### PR TITLE
feat: startup progress UI + first-run onboarding panel routing (rebased)

### DIFF
--- a/GoClaw-OneClickStart.bat
+++ b/GoClaw-OneClickStart.bat
@@ -4,20 +4,7 @@ setlocal
 set "SCRIPT_DIR=%~dp0"
 set "PS1=%SCRIPT_DIR%GoClaw-OneClickStart.ps1"
 
-if not exist "%PS1%" (
-  echo [ERROR] Script not found: "%PS1%"
-  pause
-  exit /b 1
-)
+if not exist "%PS1%" exit /b 1
 
-echo [GoClaw] Starting with one click...
-powershell -NoProfile -ExecutionPolicy Bypass -File "%PS1%" -Mode petclaw
-
-set "EXIT_CODE=%ERRORLEVEL%"
-if not "%EXIT_CODE%"=="0" (
-  echo.
-  echo [ERROR] Startup failed with code %EXIT_CODE%.
-  pause
-)
-
-exit /b %EXIT_CODE%
+start "" powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "%PS1%" -Mode petclaw -NoTerminalWindows
+exit /b 0

--- a/GoClaw-OneClickStart.ps1
+++ b/GoClaw-OneClickStart.ps1
@@ -3,7 +3,8 @@ param(
     [string]$Mode = "petclaw",
 
     [switch]$NoBrowser,
-    [switch]$SkipNpmInstall
+    [switch]$SkipNpmInstall,
+    [switch]$NoTerminalWindows
 )
 
 Set-StrictMode -Version Latest
@@ -78,6 +79,9 @@ if ($Mode -ne "launcher") {
         "-Restart",
         "-PetclawMode", "dev"
     )
+    if ($NoTerminalWindows) {
+        $delegateArgs += "-NoTerminalWindows"
+    }
 
     if ($NoBrowser) {
         Write-Warning "-NoBrowser is not used by scripts\\run-goclaw-dev.ps1 and will be ignored"

--- a/electron-frontend/src/electron.d.ts
+++ b/electron-frontend/src/electron.d.ts
@@ -7,6 +7,21 @@ interface BubblePayload {
   audio?: string
 }
 
+interface StartupProgressStep {
+  key: string
+  label: string
+  status: 'pending' | 'running' | 'done' | 'warn' | 'error'
+  detail: string
+}
+
+interface StartupProgressPayload {
+  done: boolean
+  percent: number
+  title: string
+  subtitle: string
+  steps: StartupProgressStep[]
+}
+
 declare global {
   interface Window {
     electronAPI?: {
@@ -31,6 +46,8 @@ declare global {
       onChatHistoryUpdate: (callback: (history: any[]) => void) => void
       onBubbleShow: (callback: (data: BubblePayload) => void) => void
       onConnectionAlive: (callback: () => void) => void
+      onStartupProgress: (callback: (payload: StartupProgressPayload) => void) => void
+      getStartupState: () => Promise<StartupProgressPayload>
     }
   }
 }

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 
 let petWindow = null;
 let settingsWindow = null;
+let startupWindow = null;
+let startupPollTimer = null;
+let startupCompleted = false;
 
 const PET_WIDTH = 280;
 const PET_HEIGHT = 380;
@@ -32,6 +35,40 @@ const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:
 const dashboardBaseUrl = (process.env.GOCLAW_DASHBOARD_URL || 'http://127.0.0.1:3000').trim().replace(/\/+$/, '');
 const launcherToken = (process.env.GOCLAW_LAUNCHER_TOKEN || process.env.PICOCLAW_LAUNCHER_TOKEN || '').trim();
 const shouldOpenDevTools = process.env.ELECTRON_OPEN_DEVTOOLS === '1';
+const startupMode = process.env.GOCLAW_SHOW_STARTUP === '1';
+const openPanelOnReady = process.env.GOCLAW_OPEN_PANEL_ON_READY !== '0';
+let needsFirstTimeOnboarding = false;
+
+const startupState = {
+  done: false,
+  percent: 0,
+  title: '正在启动 ClawPet',
+  subtitle: '准备桌宠与桌面面板，请稍候…',
+  steps: [
+    { key: 'launcher', label: 'Launcher (18800)', status: 'running', detail: '正在检测服务…' },
+    { key: 'gateway', label: 'Gateway (18790)', status: 'pending', detail: '等待 launcher 状态…' },
+    { key: 'petclaw', label: '桌面面板 (3000)', status: 'pending', detail: '等待前端服务启动…' },
+    { key: 'renderer', label: '桌宠渲染 (5173)', status: 'pending', detail: '等待 Electron 渲染服务…' },
+  ],
+};
+
+function shouldOpenOnboardingFromGatewayStatus(data) {
+  if (!data || data.gateway_status === 'running') {
+    return false;
+  }
+  if (data.gateway_start_allowed !== false) {
+    return false;
+  }
+  const reason = String(data.gateway_start_reason || '').toLowerCase();
+  if (!reason) {
+    return false;
+  }
+  return (
+    reason.includes('no default model configured') ||
+    reason.includes('has no credentials configured') ||
+    reason.includes('model') && reason.includes('credential')
+  );
+}
 
 function getPetBounds() {
   const display = screen.getPrimaryDisplay();
@@ -42,6 +79,62 @@ function getPetBounds() {
     width: PET_WIDTH,
     height: PET_HEIGHT,
   };
+}
+
+function updateStartupPercent() {
+  const total = startupState.steps.length;
+  let score = 0;
+  for (const step of startupState.steps) {
+    if (step.status === 'done' || step.status === 'warn') {
+      score += 1;
+      continue;
+    }
+    if (step.status === 'running') {
+      score += 0.5;
+    }
+  }
+  startupState.percent = Math.max(5, Math.min(100, Math.round((score / total) * 100)));
+  if (startupState.done) {
+    startupState.percent = 100;
+  }
+}
+
+function emitStartupProgress() {
+  updateStartupPercent();
+  if (startupWindow && !startupWindow.isDestroyed()) {
+    startupWindow.webContents.send('startup-progress', startupState);
+  }
+}
+
+function setStartupStepStatus(key, status, detail) {
+  const step = startupState.steps.find((item) => item.key === key);
+  if (!step) {
+    return;
+  }
+  step.status = status;
+  if (detail) {
+    step.detail = detail;
+  }
+  emitStartupProgress();
+}
+
+async function fetchWithTimeout(url, init = {}, timeoutMs = 1200) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function isHttpReady(url) {
+  try {
+    const response = await fetchWithTimeout(url, { method: 'GET' }, 1200);
+    return response.status >= 200 && response.status < 500;
+  } catch {
+    return false;
+  }
 }
 
 function createPetWindow() {
@@ -123,6 +216,23 @@ function buildSettingsWindowUrl({ onboarding = false } = {}) {
     : buildDashboardUrl();
 }
 
+async function resolveInitialSettingsTargetUrl() {
+  try {
+    const headers = launcherToken ? { Authorization: `Bearer ${launcherToken}` } : {};
+    const response = await fetchWithTimeout('http://127.0.0.1:18800/api/gateway/status', { headers }, 1400);
+    if (response.ok) {
+      const data = await response.json();
+      needsFirstTimeOnboarding = shouldOpenOnboardingFromGatewayStatus(data);
+      if (needsFirstTimeOnboarding) {
+        return buildSettingsWindowUrl({ onboarding: true });
+      }
+    }
+  } catch {
+    // Keep default panel route when status is temporarily unavailable.
+  }
+  return buildSettingsWindowUrl();
+}
+
 function createSettingsWindow(targetUrl = buildSettingsWindowUrl()) {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     if (targetUrl && settingsWindow.webContents.getURL() !== targetUrl) {
@@ -188,9 +298,146 @@ function createSettingsWindow(targetUrl = buildSettingsWindowUrl()) {
   });
 }
 
-ipcMain.on('open-settings', () => {
+function createStartupWindow() {
+  if (startupWindow && !startupWindow.isDestroyed()) {
+    startupWindow.show();
+    startupWindow.focus();
+    return;
+  }
+
+  startupWindow = new BrowserWindow({
+    width: 860,
+    height: 560,
+    minWidth: 760,
+    minHeight: 500,
+    show: false,
+    frame: false,
+    transparent: false,
+    backgroundColor: '#f7ecdf',
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  const startupHtmlPath = path.join(__dirname, '..', 'startup.html');
+  startupWindow.loadFile(startupHtmlPath).catch((err) => {
+    logToFile(`[STARTUP WINDOW] loadFile failed: ${String(err)}`);
+  });
+
+  startupWindow.once('ready-to-show', () => {
+    startupWindow.show();
+    startupWindow.focus();
+    emitStartupProgress();
+  });
+
+  startupWindow.on('closed', () => {
+    startupWindow = null;
+  });
+}
+
+function completeStartupAndShowDesktop() {
+  if (startupCompleted) {
+    return;
+  }
+  startupCompleted = true;
+  startupState.done = true;
+  startupState.title = '启动成功';
+  startupState.subtitle = '正在打开桌宠与桌面面板…';
+  emitStartupProgress();
+
+  if (startupPollTimer) {
+    clearInterval(startupPollTimer);
+    startupPollTimer = null;
+  }
+
+  setTimeout(() => {
+    if (!petWindow || petWindow.isDestroyed()) {
+      createPetWindow();
+    }
+    const finish = async () => {
+      if (openPanelOnReady) {
+        const targetUrl = needsFirstTimeOnboarding
+          ? buildSettingsWindowUrl({ onboarding: true })
+          : await resolveInitialSettingsTargetUrl();
+        createSettingsWindow(targetUrl);
+      }
+      if (startupWindow && !startupWindow.isDestroyed()) {
+        startupWindow.close();
+      }
+    };
+    void finish();
+  }, 380);
+}
+
+async function pollStartupProgress() {
+  const launcherReady = await isHttpReady('http://127.0.0.1:18800');
+  if (launcherReady) {
+    setStartupStepStatus('launcher', 'done', 'Launcher 已就绪');
+  } else {
+    setStartupStepStatus('launcher', 'running', '等待 launcher 响应…');
+  }
+
+  if (launcherReady) {
+    try {
+      const headers = launcherToken ? { Authorization: `Bearer ${launcherToken}` } : {};
+      const response = await fetchWithTimeout('http://127.0.0.1:18800/api/gateway/status', { headers }, 1400);
+      if (response.ok) {
+        const data = await response.json();
+        needsFirstTimeOnboarding = shouldOpenOnboardingFromGatewayStatus(data);
+        if (data.gateway_status === 'running') {
+          setStartupStepStatus('gateway', 'done', 'Gateway 已运行');
+        } else if (data.gateway_start_allowed === false) {
+          const reason = data.gateway_start_reason || '需要先完成模型配置';
+          setStartupStepStatus('gateway', 'warn', `等待配置：${reason}`);
+        } else if (data.gateway_status === 'starting' || data.gateway_status === 'restarting') {
+          setStartupStepStatus('gateway', 'running', 'Gateway 启动中…');
+        } else {
+          setStartupStepStatus('gateway', 'pending', '等待 gateway 启动…');
+        }
+      } else {
+        setStartupStepStatus('gateway', 'pending', '暂未获取到 gateway 状态');
+      }
+    } catch {
+      setStartupStepStatus('gateway', 'pending', '暂未获取到 gateway 状态');
+    }
+  } else {
+    setStartupStepStatus('gateway', 'pending', '等待 launcher 状态…');
+  }
+
+  const panelReady = await isHttpReady('http://127.0.0.1:3000');
+  if (panelReady) {
+    setStartupStepStatus('petclaw', 'done', '桌面面板已就绪');
+  } else {
+    setStartupStepStatus('petclaw', 'running', '启动桌面面板服务中…');
+  }
+
+  const rendererReady = await isHttpReady('http://127.0.0.1:5173');
+  if (rendererReady) {
+    setStartupStepStatus('renderer', 'done', '桌宠渲染服务已就绪');
+  } else {
+    setStartupStepStatus('renderer', 'running', '启动桌宠渲染服务中…');
+  }
+
+  if (launcherReady && panelReady && rendererReady) {
+    completeStartupAndShowDesktop();
+  }
+}
+
+function startStartupFlow() {
+  createStartupWindow();
+  void pollStartupProgress();
+  startupPollTimer = setInterval(() => {
+    void pollStartupProgress();
+  }, 1000);
+}
+
+ipcMain.on('open-settings', async () => {
   logToFile('[IPC] open-settings');
-  createSettingsWindow(buildSettingsWindowUrl());
+  const targetUrl = await resolveInitialSettingsTargetUrl();
+  createSettingsWindow(targetUrl);
 });
 
 ipcMain.on('open-onboarding', () => {
@@ -295,10 +542,24 @@ ipcMain.on('connection-alive', () => {
   }
 });
 
+ipcMain.handle('startup-state', async () => startupState);
+
 app.whenReady().then(() => {
+  if (startupMode) {
+    logToFile('[STARTUP] startup progress page enabled');
+    startStartupFlow();
+    return;
+  }
   createPetWindow();
 });
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('before-quit', () => {
+  if (startupPollTimer) {
+    clearInterval(startupPollTimer);
+    startupPollTimer = null;
+  }
 });

--- a/electron-frontend/src/preload.js
+++ b/electron-frontend/src/preload.js
@@ -33,5 +33,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   onConnectionAlive: (callback) => {
     ipcRenderer.on('connection-alive', () => callback());
-  }
+  },
+  onStartupProgress: (callback) => {
+    ipcRenderer.on('startup-progress', (_event, payload) => callback(payload));
+  },
+  getStartupState: () => ipcRenderer.invoke('startup-state')
 });

--- a/electron-frontend/startup.html
+++ b/electron-frontend/startup.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ClawPet 启动中</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+        background: radial-gradient(circle at 15% 10%, #fff8ef 0%, #f8ecdf 45%, #f2e2d1 100%);
+        color: #5a3f2b;
+        overflow: hidden;
+      }
+      .shell {
+        width: 100%;
+        height: 100%;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        border: 1px solid rgba(208, 170, 131, 0.35);
+      }
+      .topbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 14px;
+        background: linear-gradient(120deg, rgba(255, 250, 245, 0.95), rgba(252, 237, 216, 0.9));
+        border-bottom: 1px solid rgba(213, 178, 143, 0.45);
+        -webkit-app-region: drag;
+      }
+      .brand {
+        font-size: 13px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #a66b35;
+      }
+      .actions { display: flex; gap: 8px; -webkit-app-region: no-drag; }
+      .actions button {
+        border: 1px solid rgba(221, 189, 156, 0.8);
+        background: rgba(255, 255, 255, 0.85);
+        color: #8f6644;
+        width: 30px;
+        height: 26px;
+        border-radius: 8px;
+        cursor: pointer;
+      }
+      .actions button:hover { background: rgba(255, 255, 255, 1); }
+      .content {
+        padding: 24px 26px;
+        display: grid;
+        grid-template-columns: 1.05fr 0.95fr;
+        gap: 18px;
+      }
+      .panel {
+        background: rgba(255, 255, 255, 0.68);
+        border: 1px solid rgba(224, 192, 161, 0.68);
+        border-radius: 18px;
+        padding: 18px;
+        box-shadow: 0 18px 38px -30px rgba(117, 74, 29, 0.75);
+      }
+      .title {
+        margin: 0;
+        font-size: 30px;
+        line-height: 1.12;
+      }
+      .subtitle {
+        margin-top: 8px;
+        color: #7c5a3e;
+        font-size: 14px;
+      }
+      .progress {
+        margin-top: 18px;
+        height: 10px;
+        border-radius: 999px;
+        overflow: hidden;
+        background: rgba(231, 202, 173, 0.72);
+      }
+      .bar {
+        height: 100%;
+        width: 8%;
+        background: linear-gradient(90deg, #eba75e 0%, #df8747 45%, #c9683b 100%);
+        transition: width 260ms ease;
+      }
+      .percent {
+        margin-top: 8px;
+        font-size: 12px;
+        color: #95694a;
+      }
+      .steps {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 10px;
+      }
+      .step {
+        border: 1px solid rgba(228, 201, 174, 0.82);
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.84);
+        padding: 10px 12px;
+        display: grid;
+        grid-template-columns: 26px 1fr;
+        gap: 10px;
+      }
+      .dot {
+        width: 22px;
+        height: 22px;
+        border-radius: 999px;
+        display: grid;
+        place-items: center;
+        font-size: 12px;
+        color: white;
+        background: #c5a78c;
+      }
+      .step.running .dot { background: #d98a42; animation: pulse 1.2s infinite; }
+      .step.done .dot { background: #4ca96d; }
+      .step.warn .dot { background: #cf7c33; }
+      .step.error .dot { background: #d04848; }
+      .step-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: #5f422d;
+      }
+      .step-detail {
+        margin-top: 2px;
+        font-size: 12px;
+        color: #8b6849;
+      }
+      .pet-wrap {
+        width: 100%;
+        height: 100%;
+        border: 1px solid rgba(229, 199, 170, 0.85);
+        border-radius: 16px;
+        background: radial-gradient(circle at 28% 18%, #ffe9ce 0%, #ffe1b8 52%, #ffd4a2 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .pet-wrap img {
+        width: 74%;
+        max-width: 270px;
+        object-fit: contain;
+      }
+      .footer {
+        border-top: 1px solid rgba(216, 182, 147, 0.45);
+        padding: 10px 18px;
+        font-size: 12px;
+        color: #8f6644;
+        background: rgba(255, 247, 236, 0.85);
+      }
+      @keyframes pulse {
+        0%, 100% { transform: scale(1); opacity: 1; }
+        50% { transform: scale(1.06); opacity: 0.72; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <div class="topbar">
+        <div class="brand">ClawPet Desktop Boot</div>
+        <div class="actions">
+          <button id="minBtn">—</button>
+          <button id="closeBtn">×</button>
+        </div>
+      </div>
+      <div class="content">
+        <section class="panel">
+          <h1 class="title" id="title">正在启动 ClawPet</h1>
+          <p class="subtitle" id="subtitle">准备桌宠与桌面面板，请稍候…</p>
+          <div class="progress"><div class="bar" id="bar"></div></div>
+          <div class="percent" id="percent">0%</div>
+        </section>
+        <section class="panel">
+          <ul class="steps" id="steps"></ul>
+        </section>
+      </div>
+      <div class="footer">启动完成后将只保留桌宠形象与桌面面板，不会弹出命令行或浏览器页面。</div>
+    </div>
+    <script>
+      const titleEl = document.getElementById('title');
+      const subtitleEl = document.getElementById('subtitle');
+      const barEl = document.getElementById('bar');
+      const percentEl = document.getElementById('percent');
+      const stepsEl = document.getElementById('steps');
+
+      document.getElementById('minBtn')?.addEventListener('click', () => {
+        window.electronAPI?.minimizeWindow?.();
+      });
+      document.getElementById('closeBtn')?.addEventListener('click', () => {
+        window.electronAPI?.closeWindow?.();
+      });
+
+      function iconFor(status) {
+        if (status === 'done') return '✓';
+        if (status === 'warn') return '!';
+        if (status === 'error') return '×';
+        if (status === 'running') return '…';
+        return '·';
+      }
+
+      function render(payload) {
+        if (!payload) return;
+        titleEl.textContent = payload.title || '正在启动 ClawPet';
+        subtitleEl.textContent = payload.subtitle || '';
+        barEl.style.width = `${Math.max(0, Math.min(100, payload.percent || 0))}%`;
+        percentEl.textContent = `${Math.max(0, Math.min(100, payload.percent || 0))}%`;
+
+        const steps = Array.isArray(payload.steps) ? payload.steps : [];
+        stepsEl.innerHTML = steps
+          .map((step) => {
+            const status = step.status || 'pending';
+            return `
+              <li class="step ${status}">
+                <div class="dot">${iconFor(status)}</div>
+                <div>
+                  <div class="step-title">${step.label || step.key || ''}</div>
+                  <div class="step-detail">${step.detail || ''}</div>
+                </div>
+              </li>
+            `;
+          })
+          .join('');
+      }
+
+      window.electronAPI?.onStartupProgress?.((payload) => {
+        render(payload);
+      });
+
+      window.electronAPI?.getStartupState?.().then(render).catch(() => {});
+    </script>
+  </body>
+</html>

--- a/petclaw/hooks/use-chat.ts
+++ b/petclaw/hooks/use-chat.ts
@@ -8,7 +8,7 @@ import {
   type ChatMessage,
   type WSEvent,
 } from "@/lib/api"
-import { getSessionHistory, getSessions } from "@/lib/api/sessions"
+import { getSessionHistory } from "@/lib/api/sessions"
 
 const SESSIONS_STORAGE_KEY = "petclaw_sessions"
 const ACTIVE_SESSION_KEY = "petclaw_active_session"

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -5,7 +5,8 @@ param(
   [ValidateSet("prod", "dev")]
   [string]$PetclawMode = "prod",
   [string]$LauncherToken = "goclaw-local-token",
-  [string]$LauncherConfigPath = ""
+  [string]$LauncherConfigPath = "",
+  [switch]$NoTerminalWindows
 )
 
 $ErrorActionPreference = "Stop"
@@ -135,6 +136,17 @@ function Start-DetachedPowerShell {
     [string]$Title,
     [string]$Command
   )
+
+  if ($NoTerminalWindows) {
+    $argList = @(
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-Command",
+      $Command
+    )
+    Start-Process -FilePath "powershell" -WindowStyle Hidden -ArgumentList $argList | Out-Null
+    return
+  }
 
   $argList = @(
     "-NoExit",
@@ -669,6 +681,21 @@ $directGatewayUrl = "http://127.0.0.1:$gatewayPort"
 Ensure-NpmDeps -ProjectDir $petclawDir -DisplayName "petclaw"
 Ensure-NpmDeps -ProjectDir $electronDir -DisplayName "electron-frontend"
 
+$escapedDashboard = $DashboardUrl.Replace("'", "''")
+$escapedLauncherToken = $LauncherToken.Replace("'", "''")
+$openPanelOnReady = if ($NoTerminalWindows) { "1" } else { "0" }
+
+$existingElectron = @(Get-Process -Name electron -ErrorAction SilentlyContinue)
+$electronRunning = $existingElectron.Count -gt 0
+
+if ($NoTerminalWindows -and -not $electronRunning) {
+  Write-Step "Starting desktop shell with startup progress page..."
+  $electronBootstrapCmd = "`$env:GOCLAW_DASHBOARD_URL='$escapedDashboard'; `$env:GOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:GOCLAW_SHOW_STARTUP='1'; `$env:GOCLAW_OPEN_PANEL_ON_READY='$openPanelOnReady'; Set-Location '$electronDir'; npx electron src/main.js"
+  Start-DetachedPowerShell -Title "GoClaw - Electron Boot" -Command $electronBootstrapCmd
+  Start-Sleep -Milliseconds 800
+  $electronRunning = $true
+}
+
 if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListening -Port 3000)) {
   Write-Step "Petclaw dashboard already running at $DashboardUrl"
 } else {
@@ -679,12 +706,10 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
       Invoke-Npm -WorkingDir $petclawDir -Arguments "run build"
     }
     Write-Step "Starting petclaw dashboard (prod mode)..."
-    $escapedLauncherToken = $LauncherToken.Replace("'", "''")
     $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")
     $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL='$escapedDirectGatewayUrl'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run start -- --hostname 127.0.0.1 --port 3000"
   } else {
     Write-Step "Starting petclaw dashboard (dev mode)..."
-    $escapedLauncherToken = $LauncherToken.Replace("'", "''")
     $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")
     $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL='$escapedDirectGatewayUrl'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run dev -- --hostname 127.0.0.1 --port 3000 --webpack"
   }
@@ -698,27 +723,25 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
   }
 }
 
+if (-not (Test-PortListening -Port 5173)) {
+  Write-Step "Starting electron frontend vite server..."
+  $viteCmd = "Set-Location '$electronDir'; npm run dev -- --host 127.0.0.1 --port 5173 --strictPort"
+  Start-DetachedPowerShell -Title "GoClaw - Electron Vite" -Command $viteCmd
+  if (-not (Wait-HttpReady -Url "http://127.0.0.1:5173" -TimeoutSeconds 120)) {
+    Write-Warning "Electron Vite server did not become ready on http://127.0.0.1:5173 in time."
+  } else {
+    Write-Step "Electron Vite server is ready on http://127.0.0.1:5173"
+  }
+} else {
+  Write-Step "Electron frontend vite server already running on :5173"
+}
+
 $existingElectron = @(Get-Process -Name electron -ErrorAction SilentlyContinue)
 if ($existingElectron.Count -gt 0) {
   Write-Step "Electron desktop pet already running."
 } else {
-  if (-not (Test-PortListening -Port 5173)) {
-    Write-Step "Starting electron frontend vite server..."
-    $viteCmd = "Set-Location '$electronDir'; npm run dev -- --host 127.0.0.1 --port 5173 --strictPort"
-    Start-DetachedPowerShell -Title "GoClaw - Electron Vite" -Command $viteCmd
-    if (-not (Wait-HttpReady -Url "http://127.0.0.1:5173" -TimeoutSeconds 120)) {
-      Write-Warning "Electron Vite server did not become ready on http://127.0.0.1:5173 in time."
-    } else {
-      Write-Step "Electron Vite server is ready on http://127.0.0.1:5173"
-    }
-  } else {
-    Write-Step "Electron frontend vite server already running on :5173"
-  }
-
   Write-Step "Starting electron desktop pet process..."
-  $escapedDashboard = $DashboardUrl.Replace("'", "''")
-  $escapedLauncherToken = $LauncherToken.Replace("'", "''")
-  $electronCmd = "`$env:GOCLAW_DASHBOARD_URL='$escapedDashboard'; `$env:GOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; Set-Location '$electronDir'; npx electron src/main.js"
+  $electronCmd = "`$env:GOCLAW_DASHBOARD_URL='$escapedDashboard'; `$env:GOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:GOCLAW_OPEN_PANEL_ON_READY='$openPanelOnReady'; Set-Location '$electronDir'; npx electron src/main.js"
   Start-DetachedPowerShell -Title "GoClaw - Electron" -Command $electronCmd
 }
 

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -161,15 +161,15 @@ function Start-DetachedPowerShell {
 function Invoke-Npm {
   param(
     [string]$WorkingDir,
-    [string]$Arguments
+    [string[]]$Arguments
   )
 
   $old = Get-Location
   try {
     Set-Location $WorkingDir
-    & npm $Arguments.Split(" ")
+    & npm @Arguments
     if (-not $?) {
-      throw "npm $Arguments failed in $WorkingDir"
+      throw "npm $($Arguments -join ' ') failed in $WorkingDir"
     }
   } finally {
     Set-Location $old
@@ -418,7 +418,7 @@ function Ensure-NpmDeps {
   }
 
   Write-Step "Installing npm dependencies for $DisplayName (first run)..."
-  Invoke-Npm -WorkingDir $ProjectDir -Arguments "install"
+  Invoke-Npm -WorkingDir $ProjectDir -Arguments @("install")
 }
 
 function Get-FirstListeningPidOnPort {
@@ -703,7 +703,7 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
     $buildId = Join-Path $petclawDir ".next\BUILD_ID"
     if (-not (Test-Path $buildId)) {
       Write-Step "Petclaw prod build not found, running npm run build..."
-      Invoke-Npm -WorkingDir $petclawDir -Arguments "run build"
+      Invoke-Npm -WorkingDir $petclawDir -Arguments @("run", "build")
     }
     Write-Step "Starting petclaw dashboard (prod mode)..."
     $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")


### PR DESCRIPTION
这是 `#138` 的重建（rebase）替代 PR，未对原分支进行 force push。

- 包含启动进度 UI 和隐藏式一键启动流程  
- 保留首次运行的 onboarding 路由，以及常规面板行为  
- 包含 `scripts/run-goclaw-dev.ps1` 中的 `npm` 参数处理修复  

该 PR 已基于当前 `dev` 分支完成 rebase，并推送为一个新分支，以满足“不允许 force push”的要求。