### PR TITLE
fix(petclaw): improve chat WS fallback across pet/pico channels

### DIFF
--- a/petclaw/lib/api/bootstrap.ts
+++ b/petclaw/lib/api/bootstrap.ts
@@ -1,6 +1,7 @@
 import {
   API_ENDPOINTS,
   cacheDirectGatewayBaseUrl,
+  DIRECT_PICO_TOKEN_PATH,
   DIRECT_PET_TOKEN_PATH,
   getApiBaseUrl,
   getDirectGatewayBaseUrl,
@@ -88,11 +89,27 @@ async function isDirectPetChannelReady(): Promise<boolean> {
   }
 }
 
+async function isDirectPicoChannelReady(): Promise<boolean> {
+  try {
+    const res = await fetch(`${getDirectGatewayBaseUrl()}${DIRECT_PICO_TOKEN_PATH}`)
+    if (!res.ok) {
+      return false
+    }
+    const data = (await res.json()) as { enabled?: boolean; ws_url?: string }
+    return Boolean(data.enabled && data.ws_url)
+  } catch {
+    return false
+  }
+}
+
 async function isDirectGatewayReady(): Promise<boolean> {
   if (!(await isDirectGatewayHealthy())) {
     return false
   }
-  return isDirectPetChannelReady()
+  if (await isDirectPetChannelReady()) {
+    return true
+  }
+  return isDirectPicoChannelReady()
 }
 
 async function startGateway(): Promise<void> {

--- a/petclaw/lib/api/config.ts
+++ b/petclaw/lib/api/config.ts
@@ -2,8 +2,11 @@ const LOCAL_DEFAULT_ORIGIN = 'http://127.0.0.1:18800'
 const DIRECT_GATEWAY_ENV_ORIGIN = process.env.NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL || ''
 const LOCAL_DIRECT_GATEWAY_ORIGIN = DIRECT_GATEWAY_ENV_ORIGIN || 'http://127.0.0.1:18790'
 const DIRECT_GATEWAY_CACHE_KEY = 'petclaw.directGatewayBaseUrl'
+const LOCAL_LAUNCHER_PORT = '18800'
 export const DIRECT_PET_TOKEN_PATH = '/pet/token'
 export const DIRECT_PET_WS_PATH = '/pet/ws'
+export const DIRECT_PICO_TOKEN_PATH = '/pico/token'
+export const DIRECT_PICO_WS_PATH = '/pico/ws'
 
 export const API_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_API_URL || ''
 export const WS_BASE_URL = process.env.NEXT_PUBLIC_PICOCLAW_WS_URL || ''
@@ -17,6 +20,27 @@ function trimTrailingSlash(value: string): string {
 
 function normalizeBaseUrl(value: string): string {
   return trimTrailingSlash(value.trim())
+}
+
+function sanitizeDirectGatewayBaseUrl(value: string): string {
+  const normalized = normalizeBaseUrl(value)
+  if (!normalized) {
+    return ''
+  }
+
+  try {
+    const parsed = new URL(normalized)
+    const isLoopbackHost =
+      parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost'
+
+    if (isLoopbackHost && parsed.port === LOCAL_LAUNCHER_PORT) {
+      return normalizeBaseUrl(LOCAL_DIRECT_GATEWAY_ORIGIN)
+    }
+  } catch {
+    return ''
+  }
+
+  return normalized
 }
 
 export function getApiBaseUrl(): string {
@@ -44,14 +68,14 @@ export function getApiBaseUrl(): string {
 
 export function getDirectGatewayBaseUrl(): string {
   if (DIRECT_GATEWAY_ENV_ORIGIN.trim()) {
-    return normalizeBaseUrl(DIRECT_GATEWAY_ENV_ORIGIN)
+    return sanitizeDirectGatewayBaseUrl(DIRECT_GATEWAY_ENV_ORIGIN)
   }
 
   if (typeof window !== 'undefined') {
     try {
       const cached = window.sessionStorage.getItem(DIRECT_GATEWAY_CACHE_KEY)
       if (cached && cached.trim()) {
-        return normalizeBaseUrl(cached)
+        return sanitizeDirectGatewayBaseUrl(cached)
       }
     } catch {
     }
@@ -59,16 +83,18 @@ export function getDirectGatewayBaseUrl(): string {
     try {
       const cached = window.localStorage.getItem(DIRECT_GATEWAY_CACHE_KEY)
       if (cached && cached.trim()) {
-        return normalizeBaseUrl(cached)
+        return sanitizeDirectGatewayBaseUrl(cached)
       }
     } catch {
     }
   }
-  return normalizeBaseUrl(LOCAL_DIRECT_GATEWAY_ORIGIN)
+  return sanitizeDirectGatewayBaseUrl(LOCAL_DIRECT_GATEWAY_ORIGIN)
 }
 
 export function cacheDirectGatewayBaseUrl(value?: string | null): void {
-  const normalized = typeof value === 'string' ? normalizeBaseUrl(value) : ''
+  const normalized = typeof value === 'string'
+    ? sanitizeDirectGatewayBaseUrl(value)
+    : ''
   if (!normalized) {
     return
   }

--- a/petclaw/lib/api/websocket.ts
+++ b/petclaw/lib/api/websocket.ts
@@ -263,14 +263,21 @@ export class PicoClawWebSocket {
 
       const wsPathFromToken = this.normalizeWsPath(data.ws_url)
       const wsBaseUrl = this.normalizeWsBaseUrl(data.ws_url, candidate.baseUrl)
+      const hasExplicitPicoSignal =
+        data.protocol === "pico" ||
+        candidate.tokenPath === API_ENDPOINTS.PICO.TOKEN ||
+        wsPathFromToken === DIRECT_PICO_WS_PATH ||
+        wsPathFromToken === API_ENDPOINTS.CHAT.WS_LEGACY
       // Compatibility shim:
       // some launcher builds expose /api/pet/token but only proxy /pico/ws upstream.
       const resolvedPath =
-        candidate.useLauncherAuth && wsPathFromToken === API_ENDPOINTS.CHAT.WS
+        candidate.useLauncherAuth &&
+        hasExplicitPicoSignal &&
+        wsPathFromToken === API_ENDPOINTS.CHAT.WS
           ? API_ENDPOINTS.CHAT.WS_LEGACY
           : wsPathFromToken || candidate.wsPath
       const mode: WSMode =
-        data.protocol === "pico" ||
+        hasExplicitPicoSignal ||
         resolvedPath === DIRECT_PICO_WS_PATH ||
         resolvedPath === API_ENDPOINTS.CHAT.WS_LEGACY
           ? "pico"

--- a/petclaw/lib/api/websocket.ts
+++ b/petclaw/lib/api/websocket.ts
@@ -1,5 +1,7 @@
 import {
   API_ENDPOINTS,
+  DIRECT_PICO_TOKEN_PATH,
+  DIRECT_PICO_WS_PATH,
   DIRECT_PET_TOKEN_PATH,
   DIRECT_PET_WS_PATH,
   getApiBaseUrl,
@@ -50,6 +52,7 @@ interface TokenResponse {
   enabled?: boolean
   token?: string
   ws_url?: string
+  protocol?: string
 }
 
 interface TokenCandidate {
@@ -60,8 +63,16 @@ interface TokenCandidate {
 }
 
 type WSEventData = ChatMessage | string | Record<string, unknown>
-type WSMode = "pet"
+type WSMode = "pet" | "pico"
 type OutboundRequest = PetRequest
+
+interface PicoWireMessage {
+  type?: string
+  id?: string
+  session_id?: string
+  timestamp?: number
+  payload?: Record<string, unknown>
+}
 
 export type WSEventType =
   | "connected"
@@ -196,9 +207,21 @@ export class PicoClawWebSocket {
         useLauncherAuth: false,
       },
       {
+        baseUrl: getDirectGatewayBaseUrl(),
+        tokenPath: DIRECT_PICO_TOKEN_PATH,
+        wsPath: DIRECT_PICO_WS_PATH,
+        useLauncherAuth: false,
+      },
+      {
         baseUrl: getApiBaseUrl(),
         tokenPath: API_ENDPOINTS.PET.TOKEN,
         wsPath: API_ENDPOINTS.CHAT.WS,
+        useLauncherAuth: true,
+      },
+      {
+        baseUrl: getApiBaseUrl(),
+        tokenPath: API_ENDPOINTS.PICO.TOKEN,
+        wsPath: API_ENDPOINTS.CHAT.WS_LEGACY,
         useLauncherAuth: true,
       },
     ]
@@ -240,11 +263,23 @@ export class PicoClawWebSocket {
 
       const wsPathFromToken = this.normalizeWsPath(data.ws_url)
       const wsBaseUrl = this.normalizeWsBaseUrl(data.ws_url, candidate.baseUrl)
+      // Compatibility shim:
+      // some launcher builds expose /api/pet/token but only proxy /pico/ws upstream.
+      const resolvedPath =
+        candidate.useLauncherAuth && wsPathFromToken === API_ENDPOINTS.CHAT.WS
+          ? API_ENDPOINTS.CHAT.WS_LEGACY
+          : wsPathFromToken || candidate.wsPath
+      const mode: WSMode =
+        data.protocol === "pico" ||
+        resolvedPath === DIRECT_PICO_WS_PATH ||
+        resolvedPath === API_ENDPOINTS.CHAT.WS_LEGACY
+          ? "pico"
+          : "pet"
       return {
         token: data.token || "",
-        wsPath: wsPathFromToken || candidate.wsPath,
+        wsPath: resolvedPath,
         wsBaseUrl,
-        mode: "pet",
+        mode,
       }
     }
 
@@ -325,6 +360,11 @@ export class PicoClawWebSocket {
       this.ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data)
+
+          if (this.wsMode === "pico") {
+            this.handlePicoMessage(data as PicoWireMessage)
+            return
+          }
 
           if (data.type === "push") {
             this.handlePush(data as PetPush)
@@ -533,7 +573,58 @@ export class PicoClawWebSocket {
     })
   }
 
-  private handleResponse(_resp: PetResponse): void {}
+  private handlePicoMessage(msg: PicoWireMessage): void {
+    const msgType = (msg.type || "").trim()
+    const payload = msg.payload || {}
+    const timestamp = msg.timestamp || Date.now()
+
+    switch (msgType) {
+      case "message.create":
+      case "message.update": {
+        const content = String(payload.content || payload.text || "").trim()
+        if (!content) {
+          return
+        }
+        const messageId =
+          String(payload.message_id || msg.id || `assistant-${timestamp}`)
+        this.emit({
+          type: "message",
+          data: {
+            id: messageId,
+            role: "assistant",
+            content,
+            timestamp,
+            streaming: false,
+          } satisfies ChatMessage,
+        })
+        return
+      }
+      case "typing.start":
+        this.emit({ type: "typing", data: "true" })
+        return
+      case "typing.stop":
+        this.emit({ type: "typing", data: "false" })
+        return
+      case "error": {
+        const message = String(payload.message || payload.error || "Pico channel error")
+        this.emit({ type: "error", data: message })
+        return
+      }
+      case "session.info":
+      case "pong":
+        return
+      default:
+        return
+    }
+  }
+
+  private handleResponse(resp: PetResponse): void {
+    if (resp.status === "error") {
+      const message =
+        String(resp.error || (resp.data?.error as string) || "Unknown error")
+      this.emit({ type: "error", data: message })
+    }
+  }
 
   disconnect(): void {
     if (this.ws) {
@@ -550,6 +641,28 @@ export class PicoClawWebSocket {
 
   send(content: string): void {
     this.resetAssistantState()
+    if (this.wsMode === "pico") {
+      const requestId = `req-${++this.msgIdCounter}-${Date.now()}`
+      const msg: PicoWireMessage = {
+        type: "message.send",
+        id: requestId,
+        session_id: this.ensureSessionId(),
+        timestamp: Date.now(),
+        payload: {
+          content,
+        },
+      }
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.sendRaw(msg)
+        return
+      }
+      this.messageQueue.push(msg as OutboundRequest)
+      this.connect().catch(() => {
+        this.emit({ type: "error", data: "Connection failed" })
+      })
+      return
+    }
+
     this.sendAction(CHAT_ACTION, {
       text: content,
       session_key: this.ensureSessionId(),


### PR DESCRIPTION
## 总结
- 增加了直连网关 URL 的清洗逻辑，避免把 launcher 代理端口（`18800`）缓存为直连后端地址。  
- 在启动检查中，将直连 `pico` 的 token 就绪也视为“聊天可用”条件。  
- 为 `pet` 和 `pico` 两条链路都加入了 WebSocket token/路径回退逻辑，并补充了 `pico` 协议的消息收发兼容处理。  

## 为什么这样改
部分 launcher/runtime 组合只暴露 `pico` 通道，或返回会触发 WebSocket 鉴权失败/重连死循环的地址。这个补丁通过运行时自动选择可用通道与路径，保证聊天功能可用。  

## 验证
- 在 `petclaw` 目录执行 `npm install`  
- 执行 `npm run build` 并通过