### PR TITLE
Feat/voice provider refactor

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -1,7 +1,7 @@
 # Pet Channel API 接口文档
 
-> 版本：v2.5  
-> 日期：2026-04-20  
+> 版本：v2.7  
+> 日期：2026-04-23  
 > 协议：WebSocket + JSON
 
 ---
@@ -1557,6 +1557,316 @@ if (msg.push_type === 'audio_and_voice') {
 
 ---
 
+### 4.22 voice_model_list_get - 获取语音模型列表
+
+获取所有语音模型配置（含预设供应商）。API Key 已掩码显示。
+
+**请求**：
+
+```json
+{
+  "action": "voice_model_list_get",
+  "data": {}
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "voice_model_list_get",
+  "data": {
+    "models": [
+      {
+        "name": "minimax",
+        "provider": "minimax",
+        "api_base": "https://api.minimaxi.com/v1/t2a_v2",
+        "model": "speech-2.8-hd",
+        "voice_id": "",
+        "api_key": "",
+        "extra": {},
+        "enabled": false,
+        "is_default": false
+      },
+      {
+        "name": "doubao",
+        "provider": "doubao",
+        "api_base": "https://openspeech.bytedance.com/api/v3/tts/unidirectional",
+        "model": "seed-tts-2.0-expressive",
+        "voice_id": "",
+        "api_key": "",
+        "extra": {
+          "accessKeyId": "",
+          "secretAccessKey": "",
+          "accessToken": "",
+          "appId": "",
+          "resourceId": "seed-tts-2.0"
+        },
+        "enabled": false,
+        "is_default": false
+      }
+    ],
+    "default": ""
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| models | array | 语音模型列表 |
+| models[].name | string | 模型标识名称 |
+| models[].provider | string | 供应商类型：`minimax` / `doubao` |
+| models[].api_base | string | API 地址 |
+| models[].model | string | 实际使用的模型 ID（如 `speech-2.8-hd`、`seed-tts-2.0-expressive`） |
+| models[].voice_id | string | 音色 ID（未选则为空） |
+| models[].api_key | string | API Key（已配置显示 `******`，未配置显示空） |
+| models[].extra | object | 供应商特定参数 |
+| models[].extra.accessKeyId | string | 豆包 AccessKeyId（敏感，已配置显示 `******`） |
+| models[].extra.secretAccessKey | string | 豆包 SecretAccessKey（敏感，已配置显示 `******`） |
+| models[].extra.accessToken | string | 豆包 AccessToken（敏感，已配置显示 `******`） |
+| models[].extra.appId | string | 豆包 AppId（敏感，已配置显示 `******`） |
+| models[].extra.resourceId | string | 豆包资源ID，如 `seed-tts-2.0`（非敏感字段，不掩码） |
+| models[].enabled | bool | 是否启用 |
+| models[].is_default | bool | 是否为默认模型 |
+| default | string | 当前默认模型名称 |
+
+**预设供应商**：
+
+| 供应商 | API Base | 默认 Model | 说明 |
+|--------|----------|------------|------|
+| minimax | `https://api.minimaxi.com/v1/t2a_v2` | `speech-2.8-hd` | MiniMax TTS |
+| doubao | `https://openspeech.bytedance.com/api/v3/tts/unidirectional` | `seed-tts-2.0-expressive` | 豆包 TTS V3 |
+
+---
+
+### 4.23 voice_model_get - 获取语音模型详情
+
+获取指定语音模型的详细配置。
+
+**请求**：
+
+```json
+{
+  "action": "voice_model_get",
+  "data": {
+    "name": "minimax"
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "voice_model_get",
+  "data": {
+    "name": "minimax",
+    "provider": "minimax",
+    "api_base": "https://api.minimaxi.com/v1/t2a_v2",
+    "model": "speech-2.8-hd",
+    "voice_id": "male-qn-qingse",
+    "api_key": "******",
+    "extra": {},
+    "enabled": true,
+    "is_default": true
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| name | string | 是 | 模型名称 |
+
+**错误**：`voice model xxx not found` - 模型不存在
+
+---
+
+### 4.24 voice_model_get_voices - 获取供应商可用音色
+
+查询指定供应商的可用音色列表。如果不提供凭证，优先使用配置中存储的凭证。
+
+**请求**：
+
+```json
+{
+  "action": "voice_model_get_voices",
+  "data": {
+    "provider": "doubao",
+    "model": "seed-tts-2.0",
+    "api_key": "accessKeyId（可选，不提供则从配置获取）",
+    "secret_key": "secretAccessKey（可选，不提供则从配置获取）"
+  }
+}
+```
+
+**说明**：
+- `provider`：供应商名称（`minimax` / `doubao`），必填
+- `model`：资源ID，如 `seed-tts-2.0`，可选，不提供则使用配置中的值
+- `api_key`：供应商凭证，可选，不提供则从配置中获取
+- `secret_key`：供应商凭证，可选，不提供则从配置中获取
+
+**响应（豆包）**：
+
+```json
+{
+  "status": "ok",
+  "action": "voice_model_get_voices",
+  "data": {
+    "provider": "doubao",
+    "volcengine_voices": [
+      {
+        "VoiceType": "zh_female_tianmeitaozi_mars_bigtts",
+        "Name": "甜美桃子",
+        "Gender": "女",
+        "Age": "青年",
+        "Description": "温柔的知心姐姐",
+        "Language": "zh-cn",
+        "Emotion": "normal"
+      }
+    ]
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| provider | string | 是 | 供应商类型：`minimax` / `doubao` |
+| model | string | 否 | 模型版本（如 `seed-tts-2.0`），不提供则使用配置中的值 |
+| api_key | string | 否 | API Key / AccessKeyId，不提供则从配置获取 |
+| secret_key | string | 否 | Secret Key / SecretAccessKey，不提供则从配置获取 |
+
+**凭证配置**：
+
+豆包供应商需要在模型配置的 `extra` 字段中存储以下凭证，`model` 字段已使用 `VoiceModelConfig.model`：
+
+| 字段 | 说明 |
+|------|------|
+| accessKeyId | HMAC 签名用的 AccessKeyId（用于获取音色列表） |
+| secretAccessKey | HMAC 签名用的 SecretAccessKey |
+| accessToken | 语音合成用的 Access Token |
+| appId | 语音合成用的 AppId |
+
+**错误**：`access_key_id is required` - 未提供凭证且配置中也没有存储
+
+---
+
+### 4.25 voice_model_update - 更新语音模型配置
+
+更新指定语音模型的配置。
+
+**请求**：
+
+```json
+{
+  "action": "voice_model_update",
+  "data": {
+    "name": "minimax",
+    "api_key": "用户的真实API Key",
+    "voice_id": "male-qn-qingse",
+    "extra": {
+      "some_param": "value"
+    }
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "voice_model_update",
+  "data": {
+    "status": "ok"
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| name | string | 是 | 模型名称 |
+| api_key | string | 否 | API Key |
+| api_base | string | 否 | API 地址 |
+| model | string | 否 | 模型 ID（如 `seed-tts-2.0-expressive`） |
+| voice_id | string | 否 | 音色 ID |
+| enabled | bool | 否 | 是否启用 |
+| extra | object | 否 | 供应商特定参数 |
+
+**extra 字段说明（豆包）**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| extra.accessKeyId | string | 豆包 AccessKeyId（敏感） |
+| extra.secretAccessKey | string | 豆包 SecretAccessKey（敏感） |
+| extra.accessToken | string | 豆包 AccessToken（敏感） |
+| extra.appId | string | 豆包 AppId（敏感） |
+| extra.resourceId | string | 豆包资源ID，如 `seed-tts-2.0`（决定计费和模型版本） |
+
+**注意**：
+- `api_key` 和 `extra` 中的敏感信息以明文保存（用于实际调用），返回给前端时会脱敏
+- 只有非空字段才会更新，空字符串字段保持原值
+
+**热切换说明**：
+- 当 `api_key`、`extra`、`model` 或 `voice_id` 变更时，会自动重新创建 TTS provider
+- 确保配置变更立即生效，无需重启服务
+- 正在进行的语音合成请求会使用旧的 provider 完成
+
+**错误**：`voice model xxx not found` - 模型不存在
+
+---
+
+### 4.26 voice_model_set_default - 设置默认语音模型
+
+设置默认使用的语音模型（热切换）。
+
+**请求**：
+
+```json
+{
+  "action": "voice_model_set_default",
+  "data": {
+    "name": "minimax"
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "voice_model_set_default",
+  "data": {
+    "status": "ok"
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| name | string | 是 | 模型名称 |
+
+**热切换说明**：
+- 等待当前语音合成请求完成后切换
+- 自动启用目标模型
+- 更新 `default_model` 配置
+
+**错误**：`voice model xxx not found` - 模型不存在
+
+---
+
 ## 五、错误码
 
 ### 5.1 WebSocket 错误 (status: error)
@@ -1581,6 +1891,10 @@ if (msg.push_type === 'audio_and_voice') {
 | `one of at_seconds, every_seconds, or cron_expr is required` | 调度参数必填 | 需要指定 at_seconds、every_seconds 或 cron_expr 之一 |
 | `job_id is required` | 任务ID必填 | 操作任务时缺少 job_id 字段 |
 | `job xxx not found` | 任务不存在 | 要操作的任务不存在 |
+| `voice model xxx not found` | 语音模型不存在 | 要更新/设置/获取的语音模型不存在 |
+| `unsupported provider: xxx` | 不支持的供应商 | 供应商类型不是 `minimax` 或 `doubao` |
+| `provider is required` | 供应商必填 | 查询音色时缺少 provider 字段 |
+| `api_key is required` | API Key 必填 | 查询音色时缺少 api_key 字段 |
 
 ### 5.2 错误响应示例
 
@@ -1759,6 +2073,11 @@ async def send_chat(ws, text):
 | cron_remove | 删除定时任务 | 删除指定的定时任务 |
 | cron_enable | 启用定时任务 | 启用指定的定时任务 |
 | cron_disable | 禁用定时任务 | 禁用指定的定时任务 |
+| voice_model_list_get | 获取语音模型列表 | 查看所有语音模型（含预设供应商） |
+| voice_model_get | 获取语音模型详情 | 查看指定模型的详细配置 |
+| voice_model_get_voices | 获取可用音色 | 查询供应商的音色列表 |
+| voice_model_update | 更新语音模型 | 修改模型的配置（API Key、音色等） |
+| voice_model_set_default | 设置默认语音模型 | 热切换到指定模型 |
 
 ### 7.2 push_type 快速索引
 

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -141,11 +141,8 @@ func NewPetChannel(cfg config.PetConfig, msgBus *bus.MessageBus, workspacePath s
 	// 初始化语音合成器
 	voiceLoader := pc.service.VoiceLoader()
 	if voiceLoader != nil {
-		ttsProvider := voiceLoader.GetProvider()
-		if ttsProvider != nil {
-			voiceSender := voice.NewSender(pc.sendVoicePush)
-			pc.voiceSynthesizer = voice.NewSynthesizer(ttsProvider, voiceSender)
-		}
+		voiceSender := voice.NewSender(pc.sendVoicePush)
+		pc.voiceSynthesizer = voice.NewSynthesizer(voiceLoader, voiceSender)
 	}
 
 	return pc, nil
@@ -324,7 +321,7 @@ func (c *PetChannel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		path = "/"
 	}
 
-	logger.Infof("pet: ServeHTTP called, path=%s, normalized=%s, method=%s", r.URL.Path, path, r.Method)
+	logger.Debugf("pet: ServeHTTP called, path=%s, normalized=%s, method=%s", r.URL.Path, path, r.Method)
 
 	switch path {
 	case "/ws", "/ws/", "/":

--- a/pkg/pet/config/manager.go
+++ b/pkg/pet/config/manager.go
@@ -243,3 +243,100 @@ func (m *Manager) SetAppConfig(config *AppConfig) {
 	defer m.mu.Unlock()
 	m.appConfig = config
 }
+
+// GetVoiceModel 获取指定语音模型配置
+func (m *Manager) GetVoiceModel(name string) *VoiceModelConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.voiceConfig == nil {
+		return nil
+	}
+	for _, model := range m.voiceConfig.ModelList {
+		if model.Name == name {
+			return model
+		}
+	}
+	return nil
+}
+
+// UpdateVoiceModel 更新语音模型配置
+func (m *Manager) UpdateVoiceModel(model *VoiceModelConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.voiceConfig == nil {
+		return fmt.Errorf("voice config not initialized")
+	}
+
+	for i, existing := range m.voiceConfig.ModelList {
+		if existing.Name == model.Name {
+			if model.Provider != "" {
+				m.voiceConfig.ModelList[i].Provider = model.Provider
+			}
+			if model.Model != "" {
+				m.voiceConfig.ModelList[i].Model = model.Model
+			}
+			if model.APIKey != "" {
+				m.voiceConfig.ModelList[i].APIKey = model.APIKey
+			}
+			if model.APIBase != "" {
+				m.voiceConfig.ModelList[i].APIBase = model.APIBase
+			}
+			if model.VoiceID != "" {
+				m.voiceConfig.ModelList[i].VoiceID = model.VoiceID
+			}
+			m.voiceConfig.ModelList[i].Enabled = model.Enabled
+			if model.Extra != nil {
+				if m.voiceConfig.ModelList[i].Extra == nil {
+					m.voiceConfig.ModelList[i].Extra = make(map[string]any)
+				}
+				for k, v := range model.Extra {
+					m.voiceConfig.ModelList[i].Extra[k] = v
+				}
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("voice model %s not found", model.Name)
+}
+
+// SaveVoiceConfig 保存语音配置到文件
+func (m *Manager) SaveVoiceConfig() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.voiceConfig == nil {
+		return nil
+	}
+
+	petCfg := &PetConfig{
+		Characters:  m.characters,
+		ActiveID:    m.activeID,
+		Voice:       m.voiceConfig,
+		App:         m.appConfig,
+		Memory:      m.memoryConfig,
+		Compression: m.compressionConfig,
+	}
+
+	return m.configLoader.SavePetConfig(petCfg)
+}
+
+// GetVoiceModelList 获取所有语音模型列表
+func (m *Manager) GetVoiceModelList() []*VoiceModelConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.voiceConfig == nil {
+		return nil
+	}
+	return m.voiceConfig.ModelList
+}
+
+// GetDefaultVoiceModelName 获取当前默认模型名
+func (m *Manager) GetDefaultVoiceModelName() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.voiceConfig == nil {
+		return ""
+	}
+	return m.voiceConfig.DefaultModel
+}

--- a/pkg/pet/config/types.go
+++ b/pkg/pet/config/types.go
@@ -160,13 +160,58 @@ type VoiceConfig struct {
 }
 
 // VoiceModelConfig 语音模型配置
-// 支持多种TTS服务商（如Minimax、OpenAI等）
+// 支持多种TTS服务商
 type VoiceModelConfig struct {
-	Name    string `json:"name"`     // 模型标识名称
-	Model   string `json:"model"`    // 实际使用的模型ID（如speech-2.8-hd）
-	APIKey  string `json:"api_key"`  // API密钥（支持${ENV_VAR}格式）
-	APIBase string `json:"api_base"` // API地址
-	Enabled bool   `json:"enabled"`  // 是否启用
+	Name     string         `json:"name"`     // 模型标识名称
+	Provider string         `json:"provider"` // 供应商类型：minimax / doubao
+	Model    string         `json:"model"`    // 实际使用的模型ID（如speech-2.8-hd）
+	APIKey   string         `json:"api_key"`  // API密钥（支持${ENV_VAR}格式）
+	APIBase  string         `json:"api_base"` // API地址
+	VoiceID  string         `json:"voice_id"` // 音色ID
+	Extra    map[string]any `json:"extra"`    // 供应商特定参数（如 secret_key）
+	Enabled  bool           `json:"enabled"`  // 是否启用
+}
+
+// MaskedAPIKey 返回脱敏后的 APIKey（已配置则显示 "******"）
+func (c *VoiceModelConfig) MaskedAPIKey() string {
+	if c.APIKey != "" {
+		return "******"
+	}
+	return ""
+}
+
+var sensitiveExtraKeys = []string{
+	"accessKeyId",
+	"secretAccessKey",
+	"accessToken",
+	"appId",
+	"apiKey",
+	"secret_key",
+}
+
+func isSensitiveExtraKey(key string) bool {
+	for _, k := range sensitiveExtraKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// MaskedExtra 返回脱敏后的 Extra
+func (c *VoiceModelConfig) MaskedExtra() map[string]any {
+	if c.Extra == nil {
+		return nil
+	}
+	result := make(map[string]any)
+	for k, v := range c.Extra {
+		if isSensitiveExtraKey(k) && v != "" {
+			result[k] = "******"
+		} else {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 // DefaultEmotionState 返回默认的中性情绪状态
@@ -214,8 +259,20 @@ func DefaultCharacterPrivateConfig(id string) *CharacterPrivateConfig {
 // DefaultVoiceConfig 返回默认的语音配置
 func DefaultVoiceConfig() *VoiceConfig {
 	return &VoiceConfig{
-		ModelList:    []*VoiceModelConfig{},
-		DefaultModel: "",
+		ModelList: []*VoiceModelConfig{
+			{
+				Name:     "doubao-tts",
+				Provider: "doubao",
+				Model:    "chatSpeech_t茄子_turbo_online",
+				APIBase:  "https://openspeech.bytedance.com/api/v1/tts",
+				VoiceID:  "BV001_tutorial",
+				Extra: map[string]any{
+					"secret_key": "",
+				},
+				Enabled: false,
+			},
+		},
+		DefaultModel: "doubao-tts",
 		ASREnabled:   false,
 	}
 }

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -444,6 +444,16 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 		return s.handleCronEnable(sessionID, req)
 	case ActionCronDisable:
 		return s.handleCronDisable(sessionID, req)
+	case ActionVoiceModelListGet:
+		return s.handleVoiceModelListGet(sessionID, req)
+	case ActionVoiceModelGet:
+		return s.handleVoiceModelGet(sessionID, req)
+	case ActionVoiceModelUpdate:
+		return s.handleVoiceModelUpdate(sessionID, req)
+	case ActionVoiceModelSetDefault:
+		return s.handleVoiceModelSetDefault(sessionID, req)
+	case ActionVoiceModelGetVoices:
+		return s.handleVoiceModelGetVoices(sessionID, req)
 	default:
 		return s.sendError(sessionID, req.Action, fmt.Sprintf("unknown action: %s", req.Action))
 	}
@@ -1156,4 +1166,217 @@ func (s *PetService) handleCronDisable(sessionID string, req Request) error {
 	}
 
 	return s.sendResponse(sessionID, req.Action, map[string]any{"job_id": job.ID, "enabled": job.Enabled})
+}
+
+// VoiceModelResponse 语音模型响应结构
+type VoiceModelResponse struct {
+	Name      string         `json:"name"`
+	Provider  string         `json:"provider"`
+	Model     string         `json:"model"`
+	APIBase   string         `json:"api_base"`
+	VoiceID   string         `json:"voice_id"`
+	APIKey    string         `json:"api_key"`
+	Extra     map[string]any `json:"extra"`
+	Enabled   bool           `json:"enabled"`
+	IsDefault bool           `json:"is_default"`
+}
+
+// VoiceModelListGetResponse 语音模型列表响应
+type VoiceModelListGetResponse struct {
+	Models  []VoiceModelResponse `json:"models"`
+	Default string               `json:"default"`
+}
+
+func (s *PetService) handleVoiceModelListGet(sessionID string, req Request) error {
+	models := s.voiceLoader.ListModels()
+	defaultModel := s.voiceLoader.GetCurrentModel()
+
+	resp := VoiceModelListGetResponse{
+		Models:  make([]VoiceModelResponse, 0, len(models)),
+		Default: defaultModel,
+	}
+
+	for _, m := range models {
+		resp.Models = append(resp.Models, VoiceModelResponse{
+			Name:      m.Name,
+			Provider:  m.Provider,
+			Model:     m.Model,
+			APIBase:   m.APIBase,
+			VoiceID:   m.VoiceID,
+			APIKey:    m.MaskedAPIKey(),
+			Extra:     m.MaskedExtra(),
+			Enabled:   m.Enabled,
+			IsDefault: m.Name == defaultModel,
+		})
+	}
+
+	return s.sendResponse(sessionID, req.Action, resp)
+}
+
+func (s *PetService) handleVoiceModelGet(sessionID string, req Request) error {
+	var data struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Name == "" {
+		return s.sendError(sessionID, req.Action, "name is required")
+	}
+
+	model := s.voiceLoader.GetModel(data.Name)
+	if model == nil {
+		return s.sendError(sessionID, req.Action, fmt.Sprintf("voice model %s not found", data.Name))
+	}
+
+	return s.sendResponse(sessionID, req.Action, VoiceModelResponse{
+		Name:      model.Name,
+		Provider:  model.Provider,
+		Model:     model.Model,
+		APIBase:   model.APIBase,
+		VoiceID:   model.VoiceID,
+		APIKey:    model.MaskedAPIKey(),
+		Extra:     model.MaskedExtra(),
+		Enabled:   model.Enabled,
+		IsDefault: model.Name == s.voiceLoader.GetCurrentModel(),
+	})
+}
+
+type VoiceModelUpdateRequest struct {
+	Name    string         `json:"name"`
+	APIKey  string         `json:"api_key,omitempty"`
+	APIBase string         `json:"api_base,omitempty"`
+	Model   string         `json:"model,omitempty"`
+	VoiceID string         `json:"voice_id,omitempty"`
+	Enabled *bool          `json:"enabled,omitempty"`
+	Extra   map[string]any `json:"extra,omitempty"`
+}
+
+func (s *PetService) handleVoiceModelUpdate(sessionID string, req Request) error {
+	var data VoiceModelUpdateRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Name == "" {
+		return s.sendError(sessionID, req.Action, "name is required")
+	}
+
+	model := s.voiceLoader.GetModel(data.Name)
+	if model == nil {
+		return s.sendError(sessionID, req.Action, fmt.Sprintf("voice model %s not found", data.Name))
+	}
+
+	if data.APIKey != "" {
+		model.APIKey = data.APIKey
+	}
+	if data.APIBase != "" {
+		model.APIBase = data.APIBase
+	}
+	if data.Model != "" {
+		model.Model = data.Model
+	}
+	if data.VoiceID != "" {
+		model.VoiceID = data.VoiceID
+	}
+	if data.Enabled != nil {
+		model.Enabled = *data.Enabled
+	}
+	if data.Extra != nil {
+		if model.Extra == nil {
+			model.Extra = make(map[string]any)
+		}
+		for k, v := range data.Extra {
+			model.Extra[k] = v
+		}
+	}
+
+	if err := s.configManager.UpdateVoiceModel(model); err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	needsSwitch := data.APIKey != "" || data.Extra != nil || data.Model != "" || data.VoiceID != ""
+	if needsSwitch && s.voiceLoader.GetCurrentModel() == data.Name {
+		logger.Infof("pet voice: config changed, reloading provider for %s", data.Name)
+		if err := s.voiceLoader.SwitchModel(data.Name, s.configManager); err != nil {
+			logger.Warnf("pet voice: failed to reload provider: %v", err)
+		}
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]string{"status": "ok"})
+}
+
+type VoiceModelSetDefaultRequest struct {
+	Name string `json:"name"`
+}
+
+func (s *PetService) handleVoiceModelSetDefault(sessionID string, req Request) error {
+	var data VoiceModelSetDefaultRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Name == "" {
+		return s.sendError(sessionID, req.Action, "name is required")
+	}
+
+	if err := s.voiceLoader.SwitchModel(data.Name, s.configManager); err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]string{"status": "ok"})
+}
+
+type VoiceModelGetVoicesRequest struct {
+	Provider  string `json:"provider"`
+	Model     string `json:"model,omitempty"`
+	APIKey    string `json:"api_key,omitempty"`
+	SecretKey string `json:"secret_key,omitempty"`
+}
+
+func (s *PetService) handleVoiceModelGetVoices(sessionID string, req Request) error {
+	var data VoiceModelGetVoicesRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Provider == "" {
+		return s.sendError(sessionID, req.Action, "provider is required")
+	}
+
+	// 如果用户没提供凭证，从配置中获取
+	apiKey := data.APIKey
+	secretKey := data.SecretKey
+	model := data.Model
+
+	if apiKey == "" || secretKey == "" || model == "" {
+		cfgModel := s.voiceLoader.GetModelByProvider(data.Provider)
+		if cfgModel != nil {
+			if apiKey == "" {
+				if data.Provider == "minimax" {
+					apiKey = voice.ResolveAPIKey(cfgModel.APIKey, cfgModel.Name)
+				} else {
+					if ak, ok := cfgModel.Extra["accessKeyId"].(string); ok {
+						apiKey = voice.ResolveAPIKey(ak, cfgModel.Name)
+					}
+				}
+			}
+			if secretKey == "" {
+				if sk, ok := cfgModel.Extra["secretAccessKey"].(string); ok {
+					secretKey = voice.ResolveAPIKey(sk, cfgModel.Name)
+				}
+			}
+			if model == "" {
+				model = cfgModel.Model
+			}
+		}
+	}
+
+	result, err := voice.GetVoices(data.Provider, apiKey, secretKey, model)
+	if err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	return s.sendResponse(sessionID, req.Action, result)
 }

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -19,28 +19,33 @@ type Request struct {
 
 // Action 请求动作类型
 const (
-	ActionChat              = "chat"                // 聊天交互
-	ActionOnboardingConfig  = "onboarding_config"   // 提交初始化配置
-	ActionUserProfileUpdate = "user_profile_update" // 用户画像更新
-	ActionCharacterGet      = "character_get"       // 获取角色配置
-	ActionCharacterUpdate   = "character_update"    // 更新角色配置
-	ActionCharacterSwitch   = "character_switch"    // 切换角色
-	ActionConfigGet         = "config_get"          // 获取应用配置
-	ActionConfigUpdate      = "config_update"       // 更新应用配置
-	ActionEmotionGet        = "emotion_get"         // 获取情绪状态
-	ActionHealthCheck       = "health_check"        // 健康检查
-	ActionMemorySearch      = "memory_search"       // 搜索记忆
-	ActionConversationList  = "conversation_list"   // 对话列表
-	ActionModelListGet      = "model_list_get"      // 获取模型列表
-	ActionModelAdd          = "model_add"           // 添加模型
-	ActionModelUpdate       = "model_update"        // 更新模型
-	ActionModelDelete       = "model_delete"        // 删除模型
-	ActionModelSetDefault   = "model_set_default"   // 设置默认模型
-	ActionCronAdd           = "cron_add"            // 添加定时任务
-	ActionCronList          = "cron_list"           // 列出定时任务
-	ActionCronRemove        = "cron_remove"         // 删除定时任务
-	ActionCronEnable        = "cron_enable"         // 启用定时任务
-	ActionCronDisable       = "cron_disable"        // 禁用定时任务
+	ActionChat                 = "chat"                    // 聊天交互
+	ActionOnboardingConfig     = "onboarding_config"       // 提交初始化配置
+	ActionUserProfileUpdate    = "user_profile_update"     // 用户画像更新
+	ActionCharacterGet         = "character_get"           // 获取角色配置
+	ActionCharacterUpdate      = "character_update"        // 更新角色配置
+	ActionCharacterSwitch      = "character_switch"        // 切换角色
+	ActionConfigGet            = "config_get"              // 获取应用配置
+	ActionConfigUpdate         = "config_update"           // 更新应用配置
+	ActionEmotionGet           = "emotion_get"             // 获取情绪状态
+	ActionHealthCheck          = "health_check"            // 健康检查
+	ActionMemorySearch         = "memory_search"           // 搜索记忆
+	ActionConversationList     = "conversation_list"       // 对话列表
+	ActionModelListGet         = "model_list_get"          // 获取模型列表
+	ActionModelAdd             = "model_add"               // 添加模型
+	ActionModelUpdate          = "model_update"            // 更新模型
+	ActionModelDelete          = "model_delete"            // 删除模型
+	ActionModelSetDefault      = "model_set_default"       // 设置默认模型
+	ActionCronAdd              = "cron_add"                // 添加定时任务
+	ActionCronList             = "cron_list"               // 列出定时任务
+	ActionCronRemove           = "cron_remove"             // 删除定时任务
+	ActionCronEnable           = "cron_enable"             // 启用定时任务
+	ActionCronDisable          = "cron_disable"            // 禁用定时任务
+	ActionVoiceModelListGet    = "voice_model_list_get"    // 获取语音模型列表
+	ActionVoiceModelGet        = "voice_model_get"         // 获取语音模型详情
+	ActionVoiceModelUpdate     = "voice_model_update"      // 更新语音模型配置
+	ActionVoiceModelSetDefault = "voice_model_set_default" // 设置默认语音模型
+	ActionVoiceModelGetVoices  = "voice_model_get_voices"  // 获取供应商可用音色
 )
 
 // =============================================================================

--- a/pkg/pet/voice/loader.go
+++ b/pkg/pet/voice/loader.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/sipeed/picoclaw/pkg/logger"
 	"github.com/sipeed/picoclaw/pkg/pet/config"
@@ -14,8 +15,105 @@ import (
 // Loader 语音服务加载器
 // 根据配置初始化TTS提供者
 type Loader struct {
-	cfg      *config.VoiceConfig // 语音配置
-	provider StreamingTTS        // TTS提供者实例
+	cfg          *config.VoiceConfig // 语音配置
+	provider     StreamingTTS        // TTS提供者实例
+	currentModel string              // 当前模型名称
+	mu           sync.RWMutex        // 保护并发访问
+	activeReqs   sync.WaitGroup      // 活跃请求计数
+}
+
+// TTSFactory TTS提供者工厂函数类型
+type TTSFactory func(apiBase, apiKey, model, voiceID string, extra map[string]any) StreamingTTS
+
+// providerRegistry 供应商注册表
+var providerRegistry = make(map[string]TTSFactory)
+
+// ConfigManager 配置管理器接口（用于持久化）
+type ConfigManager interface {
+	SelectVoiceModel(name string)
+	SaveVoiceConfig() error
+}
+
+// 默认语音模型配置（预设）
+var defaultVoiceModels = []*config.VoiceModelConfig{
+	{
+		Name:     "minimax",
+		Provider: "minimax",
+		APIBase:  "https://api.minimaxi.com/v1/t2a_v2",
+		Model:    "speech-2.8-hd",
+		VoiceID:  "",
+		APIKey:   "",
+		Extra:    nil,
+		Enabled:  false,
+	},
+	{
+		Name:     "doubao",
+		Provider: "doubao",
+		APIBase:  "https://openspeech.bytedance.com/api/v3/tts/unidirectional",
+		Model:    "seed-tts-2.0-expressive",
+		VoiceID:  "",
+		APIKey:   "",
+		Extra: map[string]any{
+			"accessKeyId":     "",
+			"secretAccessKey": "",
+			"accessToken":     "",
+			"appId":           "",
+			"resourceId":      "seed-tts-2.0",
+		},
+		Enabled: false,
+	},
+}
+
+// RegisterProvider 注册 TTS 供应商
+func RegisterProvider(name string, factory TTSFactory) {
+	providerRegistry[name] = factory
+	logger.DebugCF("pet-voice", "Registered provider", map[string]any{
+		"provider": name,
+	})
+}
+
+// mergeDefaultModels 将默认模型合并到配置中（如果不存在）
+func (l *Loader) mergeDefaultModels() {
+	if l.cfg == nil {
+		return
+	}
+
+	existingNames := make(map[string]bool)
+	for _, m := range l.cfg.ModelList {
+		existingNames[m.Name] = true
+	}
+
+	for _, defaultModel := range defaultVoiceModels {
+		if !existingNames[defaultModel.Name] {
+			// 模型不存在，直接添加
+			l.cfg.ModelList = append(l.cfg.ModelList, defaultModel)
+			logger.Infof("pet voice: added default model %s", defaultModel.Name)
+		} else {
+			// 模型已存在，合并 Extra 字段（补充缺失的字段）
+			l.mergeModelExtra(defaultModel)
+		}
+	}
+}
+
+// mergeModelExtra 合并模型的 Extra 字段（补充缺失字段，不覆盖已存在的）
+func (l *Loader) mergeModelExtra(defaultModel *config.VoiceModelConfig) {
+	for _, m := range l.cfg.ModelList {
+		if m.Name == defaultModel.Name && defaultModel.Extra != nil {
+			if m.Extra == nil {
+				m.Extra = make(map[string]any)
+			}
+			for k, v := range defaultModel.Extra {
+				if _, exists := m.Extra[k]; !exists {
+					m.Extra[k] = v
+					logger.DebugCF("pet-voice", "merged extra field", map[string]any{
+						"model": m.Name,
+						"field": k,
+						"value": v,
+					})
+				}
+			}
+		}
+	}
 }
 
 // NewLoader 创建语音加载器实例
@@ -24,8 +122,10 @@ func NewLoader(cfg *config.VoiceConfig) *Loader {
 }
 
 // Load 根据配置加载并初始化TTS提供者
-// 会根据DefaultModel或第一个启用的模型来确定使用哪个TTS
 func (l *Loader) Load() error {
+	// 合并默认模型：如果 cfg 中没有 minimax/doubao，自动加入
+	l.mergeDefaultModels()
+
 	if l.cfg == nil || len(l.cfg.ModelList) == 0 {
 		logger.Warnf("pet voice: no voice models configured")
 		return nil
@@ -64,31 +164,161 @@ func (l *Loader) Load() error {
 		return fmt.Errorf("voice model %s is disabled", modelName)
 	}
 
-	// 创建TTS提供者（目前仅支持Minimax）
-	// 先尝试从环境变量解析，再从 security.yml 解析
+	// 解析 APIKey
 	apiKey := resolveEnvVar(modelCfg.APIKey)
+	if apiKey == "" || strings.HasPrefix(apiKey, "$security:") {
+		apiKey = resolveSecurityRef(modelCfg.APIKey, modelCfg.Name)
+	}
 	if apiKey == "" {
-		apiKey = resolveSecurityRef(apiKey, modelCfg.Name)
+		logger.Warnf("pet voice: API key not resolved")
 	}
-	if apiKey == "" || apiKey == "$security:minimax-tts" {
-		logger.Warnf("pet voice: API key not resolved, security ref may have failed")
+
+	// 根据 provider 从注册表获取工厂函数
+	factory, ok := providerRegistry[modelCfg.Provider]
+	if !ok {
+		return fmt.Errorf("unsupported provider: %s", modelCfg.Provider)
 	}
-	l.provider = newMinimaxTTS(modelCfg.APIBase, apiKey, modelCfg.Model)
+
+	l.provider = factory(modelCfg.APIBase, apiKey, modelCfg.Model, modelCfg.VoiceID, modelCfg.Extra)
+	l.currentModel = modelName
 	return nil
 }
 
 // GetProvider 返回已加载的TTS提供者
 func (l *Loader) GetProvider() StreamingTTS {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.provider
+}
+
+// GetCurrentModel 返回当前使用的模型名称
+func (l *Loader) GetCurrentModel() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.currentModel
+}
+
+// ListModels 返回所有语音模型配置
+func (l *Loader) ListModels() []*config.VoiceModelConfig {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.cfg == nil {
+		return nil
+	}
+	return l.cfg.ModelList
+}
+
+// GetModel 获取指定模型配置
+func (l *Loader) GetModel(name string) *config.VoiceModelConfig {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.cfg == nil {
+		return nil
+	}
+	for _, m := range l.cfg.ModelList {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// GetModelByProvider 根据 provider 类型获取第一个匹配的配置
+func (l *Loader) GetModelByProvider(provider string) *config.VoiceModelConfig {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.cfg == nil {
+		return nil
+	}
+	for _, m := range l.cfg.ModelList {
+		if m.Provider == provider {
+			return m
+		}
+	}
+	return nil
+}
+
+// SwitchModel 切换到指定模型（热切换）
+func (l *Loader) SwitchModel(name string, configManager ConfigManager) error {
+	// 等待活跃请求完成
+	l.activeReqs.Wait()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// 查找目标模型
+	var targetModel *config.VoiceModelConfig
+	for _, m := range l.cfg.ModelList {
+		if m.Name == name {
+			targetModel = m
+			break
+		}
+	}
+
+	if targetModel == nil {
+		return fmt.Errorf("voice model %s not found", name)
+	}
+
+	// 自动启用目标模型
+	if !targetModel.Enabled {
+		targetModel.Enabled = true
+		logger.Infof("pet voice: auto enabled model %s for switch", name)
+	}
+
+	// 关闭旧 provider
+	if l.provider != nil {
+		l.provider.Close()
+		l.provider = nil
+	}
+
+	// 解析 APIKey
+	apiKey := resolveEnvVar(targetModel.APIKey)
+	if apiKey == "" || strings.HasPrefix(apiKey, "$security:") {
+		apiKey = resolveSecurityRef(targetModel.APIKey, targetModel.Name)
+	}
+
+	// 根据 provider 从注册表获取工厂函数
+	factory, ok := providerRegistry[targetModel.Provider]
+	if !ok {
+		return fmt.Errorf("unsupported provider: %s", targetModel.Provider)
+	}
+
+	l.provider = factory(targetModel.APIBase, apiKey, targetModel.Model, targetModel.VoiceID, targetModel.Extra)
+	l.currentModel = name
+
+	// 更新配置
+	l.cfg.DefaultModel = name
+
+	// 持久化配置
+	if configManager != nil {
+		configManager.SelectVoiceModel(name)
+		if err := configManager.SaveVoiceConfig(); err != nil {
+			logger.Warnf("pet voice: failed to save config after switch: %v", err)
+		}
+	}
+
+	logger.Infof("pet voice: switched to model %s", name)
+	return nil
+}
+
+// AddRequest 增加活跃请求计数
+func (l *Loader) AddRequest() {
+	l.activeReqs.Add(1)
+}
+
+// DoneRequest 减少活跃请求计数
+func (l *Loader) DoneRequest() {
+	l.activeReqs.Done()
 }
 
 // IsASREnabled 检查ASR（语音识别）功能是否启用
 func (l *Loader) IsASREnabled() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.cfg != nil && l.cfg.ASREnabled
 }
 
 // resolveEnvVar 解析配置值中的环境变量引用
-// 格式: ${ENV_VAR_NAME}，会替换为对应环境变量的值
 func resolveEnvVar(value string) string {
 	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
 		envKey := value[2 : len(value)-1]
@@ -97,8 +327,16 @@ func resolveEnvVar(value string) string {
 	return value
 }
 
+// ResolveAPIKey 解析 API Key，支持环境变量和 $security: 引用
+func ResolveAPIKey(value, modelName string) string {
+	// 先解析环境变量
+	value = resolveEnvVar(value)
+	// 再解析安全引用
+	value = resolveSecurityRef(value, modelName)
+	return value
+}
+
 // resolveSecurityRef 解析对 .security.yml 中 API key 的引用
-// 格式: $security:model_name，会从 .security.yml 的 model_list 中获取 API key
 func resolveSecurityRef(value string, modelName string) string {
 	if !strings.HasPrefix(value, "$security:") {
 		return value
@@ -109,7 +347,6 @@ func resolveSecurityRef(value string, modelName string) string {
 		refName = modelName
 	}
 
-	// 获取用户目录
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		logger.Warnf("pet voice: failed to get user home dir: %v", err)
@@ -123,7 +360,6 @@ func resolveSecurityRef(value string, modelName string) string {
 		return value
 	}
 
-	// 解析 YAML
 	var secCfg struct {
 		ModelList map[string]struct {
 			APIKeys []string `yaml:"api_keys"`
@@ -143,4 +379,30 @@ func resolveSecurityRef(value string, modelName string) string {
 
 	logger.Warnf("pet voice: no API key found in .security.yml for %s", refName)
 	return value
+}
+
+// GetVoices 获取指定供应商的可用音色列表
+func GetVoices(provider, apiKey, secretKey, model string) (*VoicesResult, error) {
+	switch provider {
+	case "minimax":
+		voices, err := GetMinimaxVoices(apiKey)
+		if err != nil {
+			return nil, err
+		}
+		return &VoicesResult{
+			Provider:      "minimax",
+			MinimaxVoices: voices,
+		}, nil
+	case "doubao":
+		voices, err := GetVolcEngineVoices(apiKey, secretKey, model)
+		if err != nil {
+			return nil, err
+		}
+		return &VoicesResult{
+			Provider:         "doubao",
+			VolcEngineVoices: voices,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
 }

--- a/pkg/pet/voice/minimax.go
+++ b/pkg/pet/voice/minimax.go
@@ -24,10 +24,7 @@ type MinimaxTTS struct {
 }
 
 // newMinimaxTTS 创建MiniMax TTS实例
-// apiBase: API基础地址，为空时使用默认的MiniMax API地址
-// apiKey: API密钥
-// model: 模型名称，为空时使用speech-2.8-hd
-func newMinimaxTTS(apiBase, apiKey, model string) *MinimaxTTS {
+func newMinimaxTTS(apiBase, apiKey, model, voiceID string, extra map[string]any) *MinimaxTTS {
 	if apiBase == "" {
 		apiBase = "https://api.minimaxi.com/v1/t2a_v2"
 	}
@@ -43,6 +40,12 @@ func newMinimaxTTS(apiBase, apiKey, model string) *MinimaxTTS {
 			Timeout: 60 * time.Second,
 		},
 	}
+}
+
+func init() {
+	RegisterProvider("minimax", func(apiBase, apiKey, model, voiceID string, extra map[string]any) StreamingTTS {
+		return newMinimaxTTS(apiBase, apiKey, model, voiceID, extra)
+	})
 }
 
 // Synthesize 执行语音合成，将文本转换为语音
@@ -240,4 +243,53 @@ func (t *MinimaxTTS) parseChunk(data string) (AudioChunk, error) {
 // Close 关闭TTS连接（MiniMax不需要显式关闭）
 func (t *MinimaxTTS) Close() error {
 	return nil
+}
+
+// GetMinimaxVoices 获取 MiniMax 可用音色列表
+func GetMinimaxVoices(apiKey string) ([]MinimaxVoiceInfo, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("api_key is required")
+	}
+
+	reqBody := map[string]any{
+		"voice_type": "all",
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		"https://api.minimaxi.com/v1/get_voice", bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result MinimaxVoicesResp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	var voices []MinimaxVoiceInfo
+	voices = append(voices, result.SystemVoice...)
+	voices = append(voices, result.VoiceCloning...)
+	voices = append(voices, result.VoiceGeneration...)
+
+	return voices, nil
 }

--- a/pkg/pet/voice/synthesizer.go
+++ b/pkg/pet/voice/synthesizer.go
@@ -9,15 +9,15 @@ import (
 // Synthesizer 语音合成器
 // 整合TTS提供者和消息发送者，支持从带标签的文本中解析出多个语音片段及其参数
 type Synthesizer struct {
-	provider StreamingTTS // TTS提供者
-	sender   *Sender      // 消息发送者
+	loader *Loader // TTS加载器（动态获取当前provider）
+	sender *Sender // 消息发送者
 }
 
 // NewSynthesizer 创建新的合成器实例
-func NewSynthesizer(provider StreamingTTS, sender *Sender) *Synthesizer {
+func NewSynthesizer(loader *Loader, sender *Sender) *Synthesizer {
 	return &Synthesizer{
-		provider: provider,
-		sender:   sender,
+		loader: loader,
+		sender: sender,
 	}
 }
 
@@ -57,7 +57,12 @@ func (s *Synthesizer) ParseAndSynthesize(sessionID string, chatID int64, content
 			params.Vol = 1.0
 		}
 
-		ch, err := s.provider.Synthesize(parsed.Text, params)
+		provider := s.loader.GetProvider()
+		if provider == nil {
+			s.sender.SendError(sessionID, chatID, "no voice provider available")
+			continue
+		}
+		ch, err := provider.Synthesize(parsed.Text, params)
 		if err != nil {
 			s.sender.SendError(sessionID, chatID, err.Error())
 			continue
@@ -207,7 +212,19 @@ func (s *Synthesizer) SynthesizeToQueue(sessionID string, chatID int64, text str
 	go func() {
 		params := DefaultVoiceParams()
 
-		ch, err := s.provider.Synthesize(text, params)
+		provider := s.loader.GetProvider()
+		if provider == nil {
+			queue.UpdateSegment(seq, true, nil, 0, "no voice provider available")
+			if audioReady != nil {
+				select {
+				case audioReady <- seq:
+				default:
+				}
+			}
+			return
+		}
+
+		ch, err := provider.Synthesize(text, params)
 		if err != nil {
 			// 更新队列，标记错误
 			queue.UpdateSegment(seq, true, nil, 0, err.Error())

--- a/pkg/pet/voice/types.go
+++ b/pkg/pet/voice/types.go
@@ -58,3 +58,43 @@ type AudioSegment struct {
 	Sent      bool   // 是否已发送
 	Error     string // 错误信息（如果有）
 }
+
+// MinimaxVoiceInfo MiniMax 音色信息
+type MinimaxVoiceInfo struct {
+	VoiceID   string   `json:"voice_id"`
+	VoiceName string   `json:"voice_name"`
+	Desc      []string `json:"description"`
+}
+
+// MinimaxVoicesResp MiniMax 音色列表响应
+type MinimaxVoicesResp struct {
+	SystemVoice     []MinimaxVoiceInfo `json:"system_voice"`
+	VoiceCloning    []MinimaxVoiceInfo `json:"voice_cloning"`
+	VoiceGeneration []MinimaxVoiceInfo `json:"voice_generation"`
+}
+
+// VolcEngineVoiceInfo 豆包音色信息
+type VolcEngineVoiceInfo struct {
+	VoiceType   string `json:"VoiceType"`
+	Name        string `json:"Name"`
+	Gender      string `json:"Gender"`
+	Age         string `json:"Age"`
+	Description string `json:"Description"`
+	Language    string `json:"language"`
+	Emotion     string `json:"emotion"`
+}
+
+// VolcEngineVoicesResp 豆包音色列表响应
+type VolcEngineVoicesResp struct {
+	Result struct {
+		Total    int                   `json:"Total"`
+		Speakers []VolcEngineVoiceInfo `json:"Speakers"`
+	} `json:"Result"`
+}
+
+// VoicesResult 获取音色的统一返回结构
+type VoicesResult struct {
+	Provider         string                `json:"provider"`
+	MinimaxVoices    []MinimaxVoiceInfo    `json:"minimax_voices,omitempty"`
+	VolcEngineVoices []VolcEngineVoiceInfo `json:"volcengine_voices,omitempty"`
+}

--- a/pkg/pet/voice/volcengine.go
+++ b/pkg/pet/voice/volcengine.go
@@ -1,0 +1,540 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/logger"
+)
+
+type VolcEngineTTS struct {
+	apiBase    string
+	apiKey     string
+	model      string
+	voiceID    string
+	secretKey  string
+	resourceId string
+	httpClient *http.Client
+}
+
+func newVolcEngineTTS(apiBase, apiKey, model, voiceID string, extra map[string]any) *VolcEngineTTS {
+	if apiBase == "" {
+		apiBase = "https://openspeech.bytedance.com/api/v3/tts/unidirectional"
+	}
+	if model == "" {
+		model = "seed-tts-2.0-expressive"
+	}
+	if voiceID == "" {
+		voiceID = "BV001_tutorial"
+	}
+
+	var secretKey, resourceId string
+	if extra != nil {
+		if sk, ok := extra["secret_key"].(string); ok {
+			secretKey = sk
+		}
+		if sk, ok := extra["secretAccessKey"].(string); ok {
+			secretKey = sk
+		}
+		if rid, ok := extra["resourceId"].(string); ok {
+			resourceId = rid
+		}
+	}
+	if resourceId == "" {
+		resourceId = "seed-tts-2.0"
+	}
+
+	return &VolcEngineTTS{
+		apiBase:    apiBase,
+		apiKey:     apiKey,
+		model:      model,
+		voiceID:    voiceID,
+		secretKey:  secretKey,
+		resourceId: resourceId,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func init() {
+	RegisterProvider("doubao", func(apiBase, apiKey, model, voiceID string, extra map[string]any) StreamingTTS {
+		return newVolcEngineTTS(apiBase, apiKey, model, voiceID, extra)
+	})
+}
+
+func (t *VolcEngineTTS) Synthesize(text string, params VoiceParams) (<-chan AudioChunk, error) {
+	logger.DebugCF("pet-voice", "VolcEngineTTS.Synthesize", map[string]any{
+		"text":        text[:min(len(text), 50)],
+		"text_len":    len(text),
+		"voice_id":    t.voiceID,
+		"model":       t.model,
+		"resource_id": t.resourceId,
+		"api_base":    t.apiBase,
+		"speed":       params.Speed,
+		"vol":         params.Vol,
+	})
+
+	reqBody := map[string]any{
+		"user": map[string]any{
+			"uid": "",
+		},
+		"req_params": map[string]any{
+			"text":    text,
+			"speaker": t.voiceID,
+			"model":   t.model,
+			"audio_params": map[string]any{
+				"format":        "mp3",
+				"sample_rate":   32000,
+				"speech_rate":   int(params.Speed*100) - 100,
+				"loudness_rate": int(params.Vol*100) - 50,
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", t.apiBase, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", t.apiKey)
+	req.Header.Set("X-Api-Resource-Id", t.resourceId)
+	req.Header.Set("X-Api-Request-Id", fmt.Sprintf("%d", time.Now().UnixNano()))
+
+	logger.DebugCF("pet-voice", "V3 request headers", map[string]any{
+		"X-Api-Key":         t.apiKey[:min(len(t.apiKey), 10)] + "...",
+		"X-Api-Resource-Id": t.resourceId,
+	})
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	logger.DebugCF("pet-voice", "V3 response status", map[string]any{
+		"status":      resp.StatusCode,
+		"status_text": resp.Status,
+	})
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		logger.DebugCF("pet-voice", "V3 response body", map[string]any{
+			"body": string(body),
+		})
+		resp.Body.Close()
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	ch := make(chan AudioChunk, 100)
+	go t.readStreamV3(resp.Body, ch)
+	return ch, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (t *VolcEngineTTS) readStream(body io.Reader, ch chan<- AudioChunk) {
+	defer close(ch)
+
+	reader := io.Reader(body)
+	buf := make([]byte, 4096)
+	partial := ""
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			partial += string(buf[:n])
+			lines := strings.Split(partial, "\n")
+
+			if len(lines) == 0 {
+				continue
+			}
+
+			partial = lines[len(lines)-1]
+
+			for i := 0; i < len(lines)-1; i++ {
+				line := strings.TrimSpace(lines[i])
+				if line == "" {
+					continue
+				}
+
+				if !strings.HasPrefix(line, "data:") {
+					continue
+				}
+
+				data := strings.TrimPrefix(line, "data:")
+				data = strings.TrimSpace(data)
+
+				if data == "" || data == "[DONE]" {
+					continue
+				}
+
+				chunk, parseErr := t.parseChunk(data)
+				if parseErr != nil {
+					logger.WarnCF("pet-voice", "failed to parse chunk", map[string]any{
+						"error": parseErr,
+						"data":  data,
+					})
+					continue
+				}
+
+				select {
+				case ch <- chunk:
+				default:
+					logger.WarnCF("pet-voice", "chunk channel full, dropping", nil)
+				}
+			}
+		}
+
+		if err != nil {
+			if err != io.EOF {
+				logger.WarnCF("pet-voice", "stream read error", map[string]any{"error": err})
+			}
+			if partial != "" {
+				line := strings.TrimSpace(partial)
+				if strings.HasPrefix(line, "data:") {
+					data := strings.TrimPrefix(line, "data:")
+					data = strings.TrimSpace(data)
+					chunk, parseErr := t.parseChunk(data)
+					if parseErr == nil {
+						select {
+						case ch <- chunk:
+						default:
+						}
+					}
+				}
+			}
+			break
+		}
+	}
+
+	logger.DebugCF("pet-voice", "VolcEngineTTS readStream finished", nil)
+}
+
+func (t *VolcEngineTTS) readStreamV3(body io.Reader, ch chan<- AudioChunk) {
+	defer close(ch)
+
+	reader := io.Reader(body)
+	buf := make([]byte, 4096)
+	partial := ""
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			partial += string(buf[:n])
+			lines := strings.Split(partial, "\n")
+
+			if len(lines) == 0 {
+				continue
+			}
+
+			partial = lines[len(lines)-1]
+
+			for i := 0; i < len(lines)-1; i++ {
+				line := strings.TrimSpace(lines[i])
+				if line == "" {
+					continue
+				}
+
+				chunk, parseErr := t.parseChunkV3(line)
+				if parseErr != nil {
+					logger.WarnCF("pet-voice", "failed to parse V3 chunk", map[string]any{
+						"error": parseErr,
+						"data":  line,
+					})
+					continue
+				}
+
+				select {
+				case ch <- chunk:
+				default:
+					logger.WarnCF("pet-voice", "chunk channel full, dropping", nil)
+				}
+			}
+		}
+
+		if err != nil {
+			if err != io.EOF {
+				logger.WarnCF("pet-voice", "stream read error", map[string]any{"error": err})
+			}
+			if partial != "" {
+				line := strings.TrimSpace(partial)
+				if line != "" {
+					chunk, parseErr := t.parseChunkV3(line)
+					if parseErr == nil {
+						select {
+						case ch <- chunk:
+						default:
+						}
+					}
+				}
+			}
+			break
+		}
+	}
+
+	logger.DebugCF("pet-voice", "VolcEngineTTS readStreamV3 finished", nil)
+}
+
+type volcengineV3Response struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    string `json:"data"`
+}
+
+func (t *VolcEngineTTS) parseChunkV3(data string) (AudioChunk, error) {
+	var resp volcengineV3Response
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		return AudioChunk{}, fmt.Errorf("failed to unmarshal chunk: %w", err)
+	}
+
+	logger.DebugCF("pet-voice", "V3 chunk", map[string]any{
+		"code":     resp.Code,
+		"message":  resp.Message,
+		"data_len": len(resp.Data),
+	})
+
+	if resp.Code == 20000000 || resp.Code == 152 {
+		return AudioChunk{IsLast: true}, nil
+	}
+
+	if resp.Code != 0 {
+		return AudioChunk{}, fmt.Errorf("API error (code %d): %s", resp.Code, resp.Message)
+	}
+
+	if resp.Data == "" {
+		return AudioChunk{IsLast: false}, nil
+	}
+
+	audioBytes, err := base64.StdEncoding.DecodeString(resp.Data)
+	if err != nil {
+		return AudioChunk{}, fmt.Errorf("failed to decode audio: %w", err)
+	}
+
+	return AudioChunk{
+		Data:   audioBytes,
+		IsLast: false,
+	}, nil
+}
+
+type volcengineResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Audio string `json:"audio"`
+	} `json:"data"`
+}
+
+func (t *VolcEngineTTS) parseChunk(data string) (AudioChunk, error) {
+	var resp volcengineResponse
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		return AudioChunk{}, fmt.Errorf("failed to unmarshal chunk: %w", err)
+	}
+
+	if resp.Code != 0 && resp.Code != 10007 {
+		return AudioChunk{}, fmt.Errorf("API error (code %d): %s", resp.Code, resp.Msg)
+	}
+
+	if resp.Data.Audio == "" {
+		return AudioChunk{IsLast: true}, nil
+	}
+
+	audioBytes, err := base64.StdEncoding.DecodeString(resp.Data.Audio)
+	if err != nil {
+		return AudioChunk{}, fmt.Errorf("failed to decode audio: %w", err)
+	}
+
+	return AudioChunk{
+		Data:   audioBytes,
+		IsLast: resp.Code == 10007 || resp.Msg == "success",
+	}, nil
+}
+
+func (t *VolcEngineTTS) Close() error {
+	return nil
+}
+
+func hashSHA256(data []byte) []byte {
+	h := sha256.New()
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func hexSHA256(data []byte) string {
+	return hex.EncodeToString(hashSHA256(data))
+}
+
+func getSignedKey(secretKey, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte(secretKey), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	kSigning := hmacSHA256(kService, []byte("request"))
+	return kSigning
+}
+
+// GetVolcEngineVoices 获取豆包可用音色列表（新接口 ListSpeakers）
+// accessKeyId: HMAC 签名用的 AccessKeyID
+// secretAccessKey: HMAC 签名用的 SecretAccessKey
+// model: 模型版本，如 seed-tts-2.0，不传则用默认值
+func GetVolcEngineVoices(accessKeyId, secretAccessKey, model string) ([]VolcEngineVoiceInfo, error) {
+	if accessKeyId == "" {
+		return nil, fmt.Errorf("access_key_id is required")
+	}
+	if secretAccessKey == "" {
+		return nil, fmt.Errorf("secret_access_key is required")
+	}
+
+	// 默认使用 seed-tts-2.0
+	if model == "" {
+		model = "seed-tts-2.0"
+	}
+
+	reqBody := map[string]any{
+		"ResourceIDs": []string{model},
+		"VoiceTypes":  []string{},
+		"Page":        1,
+		"Limit":       30,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	timestamp := time.Now().UTC().Format("20060102T150405Z")
+	date := timestamp[:8]
+	serviceName := "speech_saas_prod"
+	region := "cn-beijing"
+	host := "open.volcengineapi.com"
+	path := "/"
+
+	payload := hexSHA256(jsonData)
+
+	signedHeaders := []string{"host", "x-date", "x-content-sha256", "content-type"}
+	headerList := []string{
+		fmt.Sprintf("host:%s", host),
+		fmt.Sprintf("x-date:%s", timestamp),
+		fmt.Sprintf("x-content-sha256:%s", payload),
+		"content-type:application/json; charset=UTF-8",
+	}
+	headerString := strings.Join(headerList, "\n")
+
+	queryString := "Action=ListSpeakers&Version=2025-05-20"
+
+	canonicalString := strings.Join([]string{
+		"POST",
+		path,
+		queryString,
+		headerString + "\n",
+		strings.Join(signedHeaders, ";"),
+		payload,
+	}, "\n")
+
+	hashedCanonical := hexSHA256([]byte(canonicalString))
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/request", date, region, serviceName)
+	signString := strings.Join([]string{
+		"HMAC-SHA256",
+		timestamp,
+		credentialScope,
+		hashedCanonical,
+	}, "\n")
+
+	signedKey := getSignedKey(secretAccessKey, date, region, serviceName)
+	signature := hex.EncodeToString(hmacSHA256(signedKey, []byte(signString)))
+
+	authorization := fmt.Sprintf("HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKeyId, credentialScope, strings.Join(signedHeaders, ";"), signature)
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST",
+		fmt.Sprintf("https://%s/?%s", host, queryString), bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Set("X-Date", timestamp)
+	req.Header.Set("X-Content-Sha256", payload)
+	req.Header.Set("Authorization", authorization)
+
+	logger.DebugCF("pet-voice", "VolcEngine request", map[string]any{
+		"url":         req.URL.String(),
+		"timestamp":   timestamp,
+		"payload":     payload,
+		"canonical":   canonicalString,
+		"sign_string": signString,
+		"signature":   signature,
+		"auth":        authorization,
+	})
+
+	logger.DebugCF("pet-voice", "VolcEngine request details", map[string]any{
+		"host":    host,
+		"url":     fmt.Sprintf("https://%s/?%s", host, queryString),
+		"method":  "POST",
+		"headers": req.Header,
+	})
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	logger.DebugCF("pet-voice", "VolcEngine response", map[string]any{
+		"status": resp.StatusCode,
+		"body":   string(body),
+	})
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result VolcEngineVoicesResp
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	for i := range result.Result.Speakers {
+		v := &result.Result.Speakers[i]
+		if len(v.Language) == 0 {
+			v.Language = "zh-cn"
+		}
+		if len(v.Emotion) == 0 {
+			v.Emotion = "normal"
+		}
+	}
+
+	return result.Result.Speakers, nil
+}
+
+func sha256Sum(data []byte) string {
+	h := sha256.New()
+	h.Write(data)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}


### PR DESCRIPTION
# PR: Multi-Provider Voice Synthesis Support (Voice Model Management)

## 1. Summary

实现 Pet Service 的多供应商语音合成支持，包括统一的供应商注册机制（MIniMax 和豆包/Doubao）、语音模型管理 API，以及热切换功能。

## 2. Motivation

### 2.1 问题

1. **单一供应商限制**：之前的实现仅支持 MiniMax，无法扩展到其他 TTS 供应商
2. **配置热切换缺失**：用户切换语音模型后，实际语音合成仍使用旧的模型
3. **凭证管理混乱**：不同供应商的凭证存储方式不统一

### 2.2 目标

1. 支持多供应商（MiniMax、豆包）自动注册和切换
2. 提供统一的语音模型管理 API（CRUD + 获取音色列表）
3. 实现配置热切换：修改配置后无需重启即可生效
4. 统一凭证管理：支持环境变量和 `$security:` 引用

## 3. Proposed Changes

### 3.1 新增文件

| 文件 | 说明 |
|------|------|
| `pkg/pet/voice/volcengine.go` | 豆包 TTS 供应商实现（V3 API） |

### 3.2 修改文件

| 文件 | 变更说明 |
|------|----------|
| `pkg/pet/voice/loader.go` | 新增供应商注册机制、Loader 类、热切换支持 |
| `pkg/pet/voice/synthesizer.go` | Synthesizer 持有 Loader 引用实现动态 provider 获取 |
| `pkg/pet/voice/minimax.go` | 完善 MiniMax TTS 实现 |
| `pkg/pet/voice/types.go` | 新增音色信息响应结构体 |
| `pkg/pet/service.go` | 新增 5 个 voice_model API handlers |
| `pkg/pet/types.go` | 新增 voice_model action 常量 |
| `pkg/pet/config/types.go` | 增强 MaskedExtra() 支持敏感字段白名单 |
| `pkg/pet/config/manager.go` | 新增 GetVoiceModel/UpdateVoiceModel 方法 |
| `pkg/channels/pet/channel.go` | Synthesizer 初始化传入 loader 而非 provider |
| `docs/PET_CHANNEL_API.md` | 更新 voice_model API 文档至 v2.7 |

## 4. API Changes

### 4.1 新增 API

| Action | 说明 |
|--------|------|
| `voice_model_list_get` | 获取所有语音模型列表 |
| `voice_model_get` | 获取指定语音模型详情 |
| `voice_model_update` | 更新语音模型配置 |
| `voice_model_set_default` | 设置默认语音模型（热切换） |
| `voice_model_get_voices` | 获取供应商可用音色列表 |

### 4.2 API 详情

#### voice_model_list_get

**请求**：
```json
{
  "action": "voice_model_list_get",
  "data": {}
}
```

**响应**：
```json
{
  "status": "ok",
  "action": "voice_model_list_get",
  "data": {
    "models": [
      {
        "name": "minimax",
        "provider": "minimax",
        "api_base": "https://api.minimaxi.com/v1/t2a_v2",
        "model": "speech-2.8-hd",
        "voice_id": "",
        "api_key": "",
        "extra": {},
        "enabled": false,
        "is_default": false
      },
      {
        "name": "doubao",
        "provider": "doubao",
        "api_base": "https://openspeech.bytedance.com/api/v3/tts/unidirectional",
        "model": "seed-tts-2.0-expressive",
        "voice_id": "",
        "api_key": "",
        "extra": {
          "accessKeyId": "",
          "secretAccessKey": "",
          "resourceId": "seed-tts-2.0"
        },
        "enabled": false,
        "is_default": false
      }
    ],
    "default": ""
  }
}
```

#### voice_model_update

**请求**：
```json
{
  "action": "voice_model_update",
  "data": {
    "name": "doubao",
    "api_key": "your-api-key",
    "voice_id": "zh_female_shuangkuaisisi_moon_bigtts",
    "extra": {
      "resourceId": "seed-tts-2.0"
    }
  }
}
```

**热切换说明**：
- 当 `api_key`、`extra`、`model` 或 `voice_id` 变更时，会自动重新创建 TTS provider
- 确保配置变更立即生效，无需重启服务

## 5. Configuration

### 5.1 供应商配置

**MiniMax**：
```yaml
voice:
  model_list:
    - name: minimax
      provider: minimax
      api_base: https://api.minimaxi.com/v1/t2a_v2
      model: speech-2.8-hd
      api_key: ${MINIMAX_API_KEY}  # 支持环境变量
      enabled: true
```

**豆包**：
```yaml
voice:
  model_list:
    - name: doubao
      provider: doubao
      api_base: https://openspeech.bytedance.com/api/v3/tts/unidirectional
      model: seed-tts-2.0-expressive
      api_key: $security:doubao  # 支持安全引用
      extra:
        accessKeyId: ${DOUBAO_ACCESS_KEY_ID}
        secretAccessKey: ${DOUBAO_SECRET_ACCESS_KEY}
        resourceId: seed-tts-2.0
      enabled: true
```

### 5.2 凭证解析

支持三种凭证格式：
1. **明文**：`api_key: "your-actual-key"`
2. **环境变量**：`api_key: "${MINIMAX_API_KEY}"`
3. **安全引用**：`api_key: "$security:minimax"`

## 6. Architecture

### 6.1 供应商注册机制

```
init() -> RegisterProvider("minimax", factory)
init() -> RegisterProvider("doubao", factory)

Loader.Load() -> factory() -> VolcEngineTTS / MiniMaxTTS
```

### 6.2 热切换流程

```
voice_model_update (api_key change)
    -> configManager.UpdateVoiceModel()
    -> voiceLoader.SwitchModel()
        -> provider.Close()
        -> factory() 创建新 provider
        -> configManager.SaveVoiceConfig()
```

### 6.3 Synthesizer 动态 Provider 获取

```go
type Synthesizer struct {
    loader *Loader  // 持有 loader 引用
    sender *Sender
}

func (s *Synthesizer) ParseAndSynthesize(...) {
    provider := s.loader.GetProvider()  // 每次获取当前的
    ch, err := provider.Synthesize(...)
}
```

## 7. Backwards Compatibility

- **API 兼容**：新增 API，不影响现有功能
- **配置兼容**：新增 `voice` 配置节，原有配置不受影响
- **供应商兼容**：MiniMax 供应商配置格式保持兼容

## 8. Testing

### 8.1 测试场景

1. **供应商注册**：验证 init() 后供应商正确注册
2. **模型切换**：验证 voice_model_set_default 后新请求使用新模型
3. **凭证热更新**：验证 voice_model_update 更新凭证后立即生效
4. **音色列表**：验证 voice_model_get_voices 返回正确的音色

### 8.2 测试命令

```bash
# 获取语音模型列表
ws.send({"action": "voice_model_list_get", "data": {}, "request_id": "1"})

# 获取供应商音色
ws.send({"action": "voice_model_get_voices", "data": {"provider": "doubao"}, "request_id": "2"})

# 更新语音模型
ws.send({"action": "voice_model_update", "data": {"name": "doubao", "api_key": "your-key"}, "request_id": "3"})

# 切换默认模型
ws.send({"action": "voice_model_set_default", "data": {"name": "doubao"}, "request_id": "4"})
```

## 9. TODO

- [ ] 完善豆包 TTS V3 API 的错误处理
- [ ] 添加更多的豆包音色参数支持（如 emotion、emotion_scale）
- [ ] 实现语音合成的进度回调
- [ ] 添加单元测试

## 10. Changelog

### v2.7 (2026-04-23)

- feat: 添加多供应商语音合成支持
- feat: 实现语音模型管理 API（5个接口）
- feat: Synthesizer 持有 Loader 引用实现热切换
- feat: 豆包 TTS V3 API 支持
- docs: 更新 API 文档至 v2.7
