### PR TITLE
fix(petclaw): stabilize onboarding flow and split console window routing

### DIFF
--- a/GoClaw-OneClickStart.bat
+++ b/GoClaw-OneClickStart.bat
@@ -4,7 +4,24 @@ setlocal
 set "SCRIPT_DIR=%~dp0"
 set "PS1=%SCRIPT_DIR%GoClaw-OneClickStart.ps1"
 
-if not exist "%PS1%" exit /b 1
+if not exist "%PS1%" (
+  echo [GoClaw] Startup script not found: "%PS1%"
+  exit /b 1
+)
 
-start "" powershell -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "%PS1%" -Mode petclaw -NoTerminalWindows
-exit /b 0
+where powershell >nul 2>nul
+if errorlevel 1 (
+  echo [GoClaw] powershell.exe not found in PATH.
+  exit /b 1
+)
+
+pushd "%SCRIPT_DIR%" >nul
+powershell -NoProfile -ExecutionPolicy Bypass -File "%PS1%" -Mode petclaw -NoTerminalWindows %*
+set "EXITCODE=%ERRORLEVEL%"
+popd >nul
+
+if not "%EXITCODE%"=="0" (
+  echo [GoClaw] Startup failed with exit code %EXITCODE%.
+)
+
+exit /b %EXITCODE%

--- a/electron-frontend/src/main.js
+++ b/electron-frontend/src/main.js
@@ -5,15 +5,19 @@ const fs = require('fs');
 
 let petWindow = null;
 let settingsWindow = null;
+let onboardingWindow = null;
 let startupWindow = null;
 let startupPollTimer = null;
 let startupCompleted = false;
+let petHoverMonitorTimer = null;
+let petHovering = false;
 
 const PET_WIDTH = 280;
 const PET_HEIGHT = 380;
 
 const userDataPath = path.join(os.homedir(), '.goclaw');
 app.setPath('userData', userDataPath);
+const onboardingStatePath = path.join(userDataPath, 'onboarding-state.json');
 
 if (!fs.existsSync(userDataPath)) {
   fs.mkdirSync(userDataPath, { recursive: true });
@@ -21,6 +25,93 @@ if (!fs.existsSync(userDataPath)) {
 
 const logFilePath = path.join(userDataPath, 'logs.txt');
 const logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+
+function loadOnboardingState() {
+  try {
+    if (!fs.existsSync(onboardingStatePath)) {
+      return null;
+    }
+    const raw = fs.readFileSync(onboardingStatePath, 'utf-8');
+    if (!raw.trim()) {
+      return null;
+    }
+    return JSON.parse(raw);
+  } catch (error) {
+    logToFile(`[ONBOARDING] failed to read onboarding state: ${String(error)}`);
+    return null;
+  }
+}
+
+function saveOnboardingState(state) {
+  try {
+    fs.writeFileSync(onboardingStatePath, JSON.stringify(state, null, 2), 'utf-8');
+  } catch (error) {
+    logToFile(`[ONBOARDING] failed to save onboarding state: ${String(error)}`);
+  }
+}
+
+function markOnboardingCompleted() {
+  saveOnboardingState({
+    completed: true,
+    completedAt: new Date().toISOString(),
+  });
+}
+
+function markOnboardingPending(reason = 'unknown') {
+  saveOnboardingState({
+    completed: false,
+    requestedAt: new Date().toISOString(),
+    reason,
+  });
+}
+
+function stopAllMediaPlayback(reason = 'unknown') {
+  logToFile(`[ONBOARDING] force-stop-media (${reason})`);
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.webContents.send('force-stop-media');
+  }
+  if (petWindow && !petWindow.isDestroyed()) {
+    petWindow.webContents.send('force-stop-media');
+  }
+}
+
+function hideRuntimeWindowsForOnboarding() {
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    settingsWindow.hide();
+  }
+  if (petWindow && !petWindow.isDestroyed()) {
+    petWindow.hide();
+  }
+}
+
+function enterOnboardingMode(reason = 'manual', { rerun = false } = {}) {
+  onboardingLocked = true;
+  markOnboardingPending(reason);
+  stopAllMediaPlayback(reason);
+  hideRuntimeWindowsForOnboarding();
+  createOnboardingWindow(buildSettingsWindowUrl({ onboarding: true, rerun }));
+}
+
+function leaveOnboardingMode({ completed } = { completed: false }) {
+  if (completed) {
+    onboardingLocked = false;
+    markOnboardingCompleted();
+  }
+
+  if (onboardingWindow && !onboardingWindow.isDestroyed()) {
+    onboardingWindow.close();
+    onboardingWindow = null;
+  }
+
+  if (petWindow && !petWindow.isDestroyed()) {
+    resetPetWindow();
+    petWindow.show();
+  }
+
+  if (completed) {
+    createSettingsWindow(buildSettingsWindowUrl());
+  }
+}
 
 function logToFile(message) {
   const timestamp = new Date().toISOString();
@@ -30,6 +121,10 @@ function logToFile(message) {
 }
 
 logToFile('Electron application started');
+
+const persistedOnboarding = loadOnboardingState();
+onboardingLocked = !(persistedOnboarding && persistedOnboarding.completed === true);
+logToFile(`[ONBOARDING] startup locked=${onboardingLocked}`);
 
 const rendererBaseUrl = (process.env.ELECTRON_RENDERER_URL || 'http://localhost:5173').trim().replace(/\/+$/, '');
 const dashboardBaseUrl = (process.env.GOCLAW_DASHBOARD_URL || 'http://127.0.0.1:3000').trim().replace(/\/+$/, '');
@@ -70,6 +165,10 @@ function shouldOpenOnboardingFromGatewayStatus(data) {
   );
 }
 
+function isOnboardingUrl(targetUrl) {
+  return /\/onboarding(?:[/?]|$)|[?&]onboarding=1\b|[?&]mode=rerun\b/i.test(targetUrl || '');
+}
+
 function getPetBounds() {
   const display = screen.getPrimaryDisplay();
   const area = display.workArea;
@@ -79,6 +178,58 @@ function getPetBounds() {
     width: PET_WIDTH,
     height: PET_HEIGHT,
   };
+}
+
+function setPetWindowClickThrough(enabled) {
+  if (!petWindow || petWindow.isDestroyed()) {
+    return;
+  }
+
+  try {
+    if (enabled) {
+      petWindow.setIgnoreMouseEvents(true, { forward: true });
+    } else {
+      petWindow.setIgnoreMouseEvents(false);
+    }
+  } catch (error) {
+    logToFile(`[PET WINDOW] setIgnoreMouseEvents failed: ${String(error)}`);
+  }
+}
+
+function startPetHoverMonitor() {
+  if (petHoverMonitorTimer) {
+    return;
+  }
+
+  petHoverMonitorTimer = setInterval(() => {
+    if (!petWindow || petWindow.isDestroyed()) {
+      stopPetHoverMonitor();
+      return;
+    }
+
+    const cursor = screen.getCursorScreenPoint();
+    const bounds = petWindow.getBounds();
+    const hoveringNow =
+      cursor.x >= bounds.x &&
+      cursor.x <= bounds.x + bounds.width &&
+      cursor.y >= bounds.y &&
+      cursor.y <= bounds.y + bounds.height;
+
+    if (hoveringNow === petHovering) {
+      return;
+    }
+
+    petHovering = hoveringNow;
+    setPetWindowClickThrough(!hoveringNow);
+  }, 120);
+}
+
+function stopPetHoverMonitor() {
+  if (petHoverMonitorTimer) {
+    clearInterval(petHoverMonitorTimer);
+    petHoverMonitorTimer = null;
+  }
+  petHovering = false;
 }
 
 function updateStartupPercent() {
@@ -160,10 +311,15 @@ function createPetWindow() {
   });
 
   petWindow.once('ready-to-show', () => {
-    petWindow.show();
+    setPetWindowClickThrough(true);
+    startPetHoverMonitor();
+    if (!onboardingLocked) {
+      petWindow.show();
+    }
   });
 
   petWindow.on('closed', () => {
+    stopPetHoverMonitor();
     petWindow = null;
     app.quit();
   });
@@ -178,17 +334,18 @@ function resetPetWindow() {
   petWindow.setAlwaysOnTop(true);
   petWindow.setSkipTaskbar(true);
   petWindow.setBounds(getPetBounds(), true);
+  setPetWindowClickThrough(true);
+  startPetHoverMonitor();
 }
 
 function withLauncherToken(rawUrl) {
-  if (!launcherToken) {
-    return rawUrl;
-  }
-
   try {
     const parsed = new URL(rawUrl);
+    parsed.searchParams.set('ui_rev', '20260420_3');
     if (!parsed.searchParams.has('token')) {
-      parsed.searchParams.set('token', launcherToken);
+      if (launcherToken) {
+        parsed.searchParams.set('token', launcherToken);
+      }
     }
     return parsed.toString();
   } catch {
@@ -210,10 +367,10 @@ function buildDashboardUrl(pathname = '') {
   return withLauncherToken(resolved);
 }
 
-function buildSettingsWindowUrl({ onboarding = false } = {}) {
+function buildSettingsWindowUrl({ onboarding = false, rerun = false } = {}) {
   return onboarding
-    ? buildDashboardUrl('/onboarding?mode=rerun')
-    : buildDashboardUrl();
+    ? buildDashboardUrl(rerun ? '/onboarding?mode=rerun' : '/onboarding')
+    : buildDashboardUrl('/?surface=console');
 }
 
 async function resolveInitialSettingsTargetUrl() {
@@ -223,9 +380,6 @@ async function resolveInitialSettingsTargetUrl() {
     if (response.ok) {
       const data = await response.json();
       needsFirstTimeOnboarding = shouldOpenOnboardingFromGatewayStatus(data);
-      if (needsFirstTimeOnboarding) {
-        return buildSettingsWindowUrl({ onboarding: true });
-      }
     }
   } catch {
     // Keep default panel route when status is temporarily unavailable.
@@ -249,14 +403,15 @@ function createSettingsWindow(targetUrl = buildSettingsWindowUrl()) {
   }
 
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-  const settingsWidth = Math.round(width * 0.7);
-  const settingsHeight = Math.round(height * 0.7);
+  const settingsWidth = Math.round(width * 0.72);
+  const settingsHeight = Math.round(height * 0.76);
 
   settingsWindow = new BrowserWindow({
     width: settingsWidth,
     height: settingsHeight,
     minWidth: 600,
     minHeight: 400,
+    center: true,
     show: false,
     frame: false,
     transparent: false,
@@ -295,6 +450,72 @@ function createSettingsWindow(targetUrl = buildSettingsWindowUrl()) {
 
   settingsWindow.on('closed', () => {
     settingsWindow = null;
+  });
+}
+
+function createOnboardingWindow(targetUrl = buildSettingsWindowUrl({ onboarding: true })) {
+  if (onboardingWindow && !onboardingWindow.isDestroyed()) {
+    if (targetUrl && onboardingWindow.webContents.getURL() !== targetUrl) {
+      onboardingWindow.loadURL(targetUrl).catch((err) => {
+        logToFile(`[ONBOARDING WINDOW] reload failed: ${String(err)}`);
+      });
+    }
+    if (onboardingWindow.isMinimized()) {
+      onboardingWindow.restore();
+    }
+    onboardingWindow.show();
+    onboardingWindow.focus();
+    return;
+  }
+
+  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+  const onboardingWidth = Math.round(width * 0.82);
+  const onboardingHeight = Math.round(height * 0.86);
+
+  onboardingWindow = new BrowserWindow({
+    width: onboardingWidth,
+    height: onboardingHeight,
+    minWidth: 980,
+    minHeight: 680,
+    center: true,
+    show: false,
+    frame: false,
+    transparent: false,
+    backgroundColor: '#f7ecdf',
+    alwaysOnTop: false,
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  const onboardingUrl = targetUrl || buildSettingsWindowUrl({ onboarding: true });
+  logToFile(`[ONBOARDING WINDOW] opening ${onboardingUrl}`);
+
+  onboardingWindow.webContents.on('did-fail-load', (_event, code, desc, url) => {
+    logToFile(`[ONBOARDING WINDOW] did-fail-load code=${code} desc=${desc} url=${url}`);
+  });
+
+  onboardingWindow.webContents.on('did-finish-load', () => {
+    logToFile('[ONBOARDING WINDOW] did-finish-load');
+  });
+
+  onboardingWindow.loadURL(onboardingUrl).catch((err) => {
+    logToFile(`[ONBOARDING WINDOW] loadURL failed: ${String(err)}`);
+  });
+
+  onboardingWindow.once('ready-to-show', () => {
+    onboardingWindow.show();
+    onboardingWindow.focus();
+    if (shouldOpenDevTools) {
+      onboardingWindow.webContents.openDevTools({ mode: 'detach' });
+    }
+  });
+
+  onboardingWindow.on('closed', () => {
+    onboardingWindow = null;
   });
 }
 
@@ -359,9 +580,7 @@ function completeStartupAndShowDesktop() {
     }
     const finish = async () => {
       if (openPanelOnReady) {
-        const targetUrl = needsFirstTimeOnboarding
-          ? buildSettingsWindowUrl({ onboarding: true })
-          : await resolveInitialSettingsTargetUrl();
+        const targetUrl = await resolveInitialSettingsTargetUrl();
         createSettingsWindow(targetUrl);
       }
       if (startupWindow && !startupWindow.isDestroyed()) {
@@ -442,17 +661,33 @@ ipcMain.on('open-settings', async () => {
 
 ipcMain.on('open-onboarding', () => {
   logToFile('[IPC] open-onboarding');
-  createSettingsWindow(buildSettingsWindowUrl({ onboarding: true }));
+  enterOnboardingMode('manual-rerun', { rerun: true });
 });
 
 ipcMain.on('set-onboarding-mode', (event, enabled) => {
   logToFile(`[IPC] set-onboarding-mode ${Boolean(enabled)}`);
-  const target = BrowserWindow.fromWebContents(event.sender);
-  if (target === petWindow) {
-    resetPetWindow();
+  if (enabled) {
+    const currentUrl = event.sender.getURL();
+    enterOnboardingMode('renderer-request', {
+      rerun: /[?&]mode=rerun\b/i.test(currentUrl),
+    });
+    const target = BrowserWindow.fromWebContents(event.sender);
+    if (target === onboardingWindow && onboardingWindow && !onboardingWindow.isDestroyed()) {
+      onboardingWindow.focus();
+    }
     return;
   }
-  logToFile('[IPC] set-onboarding-mode ignored for non-pet window');
+  logToFile('[IPC] set-onboarding-mode false ignored (completion required)');
+});
+
+ipcMain.on('complete-onboarding', () => {
+  logToFile('[IPC] complete-onboarding');
+  leaveOnboardingMode({ completed: true });
+});
+
+ipcMain.on('set-pet-click-through', (_event, enabled) => {
+  logToFile(`[IPC] set-pet-click-through ${Boolean(enabled)}`);
+  setPetWindowClickThrough(Boolean(enabled));
 });
 
 ipcMain.on('window-minimize', (event) => {
@@ -531,6 +766,20 @@ ipcMain.on('chat-history', (_event, history) => {
 });
 
 ipcMain.on('show-bubble', (_event, data) => {
+  const audio = typeof data?.audio === 'string' ? data.audio.trim() : '';
+  const text = typeof data?.text === 'string' ? data.text.trim() : '';
+  const emotion = typeof data?.emotion === 'string' ? data.emotion.trim() : '';
+  const fingerprint = `${audio}|${text}|${emotion}`;
+  const now = Date.now();
+
+  if (fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {
+    logToFile('[IPC] show-bubble dropped duplicated payload');
+    return;
+  }
+
+  lastBubbleFingerprint = fingerprint;
+  lastBubbleAt = now;
+
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('bubble-show', data);
   }
@@ -551,6 +800,9 @@ app.whenReady().then(() => {
     return;
   }
   createPetWindow();
+  if (onboardingLocked) {
+    enterOnboardingMode('first-run');
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/petclaw/app/page.tsx
+++ b/petclaw/app/page.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic"
 import { useEffect, useState } from "react"
 
+import { onboardingApi, type OnboardingStatusData } from "@/lib/api"
 import { cn } from "@/lib/utils"
 
 import { ChatArea } from "@/components/chat-area"
@@ -42,7 +43,7 @@ type LayoutMode = "full" | "compact" | "ultra"
 export default function Home() {
   const [activeNav, setActiveNav] = useState("聊天")
   const [bootState, setBootState] = useState<"checking" | "onboarding" | "ready">(
-    "ready",
+    "checking",
   )
   const [uiMood, setUiMood] = useState<
     "low" | "medium" | "high" | "critical"
@@ -72,23 +73,75 @@ export default function Home() {
   }, [])
 
   useEffect(() => {
-    try {
-      const hasForcedOnboarding =
-        new URLSearchParams(window.location.search).get("onboarding") === "1"
-      if (hasForcedOnboarding) {
-        setBootState("onboarding")
-        return
-      }
+    let cancelled = false
 
-      const onboardingState = loadOnboardingState()
-      if (onboardingState?.completed) {
-        applyMoodFromOnboardingState()
-        setBootState("ready")
-        return
+    const bootstrap = async () => {
+      try {
+        const searchParams = new URLSearchParams(window.location.search)
+        const hasForcedOnboarding = searchParams.get("onboarding") === "1"
+        const isConsoleSurface = searchParams.get("surface") === "console"
+
+        if (isConsoleSurface) {
+          const onboardingState = loadOnboardingState()
+          if (onboardingState?.completed) {
+            applyMoodFromOnboardingState()
+          }
+          if (!cancelled) {
+            setBootState("ready")
+          }
+          return
+        }
+
+        if (hasForcedOnboarding) {
+          if (!cancelled) {
+            setBootState("onboarding")
+          }
+          return
+        }
+
+        const raw = await onboardingApi.status()
+        if (cancelled) {
+          return
+        }
+
+        const status: OnboardingStatusData =
+          "data" in (raw as Record<string, unknown>) &&
+          (raw as { data?: OnboardingStatusData }).data
+            ? (raw as { data: OnboardingStatusData }).data
+            : (raw as OnboardingStatusData)
+
+        if (status.completed) {
+          const level = status.payload?.studentInsights?.pressurePlan?.level
+          if (
+            level === "low" ||
+            level === "medium" ||
+            level === "high" ||
+            level === "critical"
+          ) {
+            setUiMood(level)
+          } else {
+            applyMoodFromOnboardingState()
+          }
+          setBootState("ready")
+          return
+        }
+
+        setBootState("onboarding")
+      } catch {
+        const onboardingState = loadOnboardingState()
+        if (onboardingState?.completed) {
+          applyMoodFromOnboardingState()
+          setBootState("ready")
+          return
+        }
+        setBootState("onboarding")
       }
-      setBootState("onboarding")
-    } catch {
-      setBootState("ready")
+    }
+
+    void bootstrap()
+
+    return () => {
+      cancelled = true
     }
   }, [])
 

--- a/petclaw/components/onboarding-wizard.tsx
+++ b/petclaw/components/onboarding-wizard.tsx
@@ -22,8 +22,15 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Progress } from "@/components/ui/progress"
-import { API_ENDPOINTS, getApiBaseUrl } from "@/lib/api"
+import {
+  API_ENDPOINTS,
+  getApiBaseUrl,
+  onboardingApi,
+  type OnboardingPayloadV1,
+  type OnboardingStatusData,
+} from "@/lib/api"
 import { fetchWithAuthRetry } from "@/lib/api/auth-bootstrap"
+import { getWebSocketInstance } from "@/lib/api/websocket"
 import { saveOnboardingState, SCHEDULE_ICS_NAME_STORAGE_KEY } from "@/lib/onboarding"
 import { buildLearningRhythm, buildPressurePlan } from "@/lib/student-insights"
 
@@ -88,6 +95,21 @@ const showcaseLines = [
   "把状态调到舒服区，桌宠会更懂你的小情绪。",
 ]
 const MIN_SUMMON_LOADING_MS = 6200
+const ONBOARDING_SESSION_ID_STORAGE_KEY = "petclaw.onboarding.sessionId"
+
+function normalizeLanguageCode(input: string): string {
+  const value = input.trim().toLowerCase()
+  if (!value) {
+    return "zh-CN"
+  }
+  if (value === "中文" || value === "简体中文" || value === "zh" || value === "zh-cn") {
+    return "zh-CN"
+  }
+  if (value === "english" || value === "en" || value === "en-us") {
+    return "en-US"
+  }
+  return input.trim()
+}
 
 function pickRandomIndex(size: number, current?: number): number {
   if (size <= 1) return 0
@@ -96,6 +118,20 @@ function pickRandomIndex(size: number, current?: number): number {
     next = Math.floor(Math.random() * size)
   }
   return next
+}
+
+function createOnboardingSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `onb-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return "请求失败，请稍后重试"
 }
 
 function withStatus(tasks: SetupTask[], id: string, status: SetupStatus): SetupTask[] {
@@ -149,14 +185,190 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
   const [isMajorMenuOpen, setIsMajorMenuOpen] = useState(false)
   const [displayProgress, setDisplayProgress] = useState(0)
   const [isFinishing, setIsFinishing] = useState(false)
+  const [statusLoading, setStatusLoading] = useState(true)
+  const [draftSyncError, setDraftSyncError] = useState<string | null>(null)
+  const [onboardingSessionId, setOnboardingSessionId] = useState("")
   const displayProgressRef = useRef(0)
   const majorMenuRef = useRef<HTMLDivElement | null>(null)
 
   const hasElectronApi = typeof window !== "undefined" && Boolean(window.electronAPI)
 
+  const isRerunMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("mode") === "rerun"
+
+  const resolveSessionId = () => {
+    if (onboardingSessionId) {
+      return onboardingSessionId
+    }
+
+    let id = ""
+    try {
+      id = window.localStorage.getItem(ONBOARDING_SESSION_ID_STORAGE_KEY) || ""
+    } catch {
+    }
+
+    if (!id) {
+      id = createOnboardingSessionId()
+      try {
+        window.localStorage.setItem(ONBOARDING_SESSION_ID_STORAGE_KEY, id)
+      } catch {
+      }
+    }
+
+    setOnboardingSessionId(id)
+    return id
+  }
+
+  const hydrateFromPayload = (payload: OnboardingPayloadV1) => {
+    setProfile((prev) => ({
+      ...prev,
+      displayName: payload.profile.displayName || prev.displayName,
+      role: payload.profile.role || prev.role,
+      language: payload.profile.language || prev.language,
+    }))
+
+    setApp({
+      autoConnectOnLaunch: payload.app.autoConnectOnLaunch,
+      enableDesktopBubble: payload.app.enableDesktopBubble,
+      openConsoleOnPetClick: payload.app.openConsoleOnPetClick,
+    })
+
+    const petName = payload.pet.petName?.trim() || ""
+    if (petName) {
+      setNickname(petName)
+      setCustomNickname(petName)
+    }
+
+    if (
+      payload.pet.personality === "阴阳怪气" ||
+      payload.pet.personality === "抽象发疯" ||
+      payload.pet.personality === "甜心夹子"
+    ) {
+      setPersonalityTone(payload.pet.personality)
+    }
+
+    setActivityLevel(payload.pet.voiceStyle === "活泼碎碎念" ? 70 : 58)
+  }
+
+  const getPayloadForStep = (nextStep: number): OnboardingPayloadV1 => {
+    const finalNickname = customNickname.trim() || nickname
+    const voiceStyle = activityLevel >= 65 ? "活泼碎碎念" : "温和陪伴型"
+
+    return {
+      schemaVersion: 1,
+      onboardingId: resolveSessionId(),
+      step: (Math.min(Math.max(nextStep, 0), 2) + 1) as 1 | 2 | 3,
+      profile: {
+        displayName: profile.displayName.trim() || finalNickname,
+        role: profile.role,
+        language: profile.language,
+      },
+      pet: {
+        petName: finalNickname,
+        personality: personalityTone,
+        voiceStyle,
+      },
+      app: {
+        ...app,
+        enableDesktopBubble: permissions.popupReminder,
+      },
+      studentInsights: {
+        learningRhythm: learningRhythmInsight,
+        pressurePlan: pressurePlanInsight,
+      },
+    }
+  }
+
+  const saveDraft = async (nextStep: number, silent = false): Promise<boolean> => {
+    try {
+      await onboardingApi.saveDraft(getPayloadForStep(nextStep))
+      setDraftSyncError(null)
+      return true
+    } catch (error) {
+      if (!silent) {
+        setDraftSyncError(`草稿保存失败：${getErrorMessage(error)}`)
+      }
+      return false
+    }
+  }
+
   useEffect(() => {
     displayProgressRef.current = displayProgress
   }, [displayProgress])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setStatusLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const bootstrap = async () => {
+      const localId = resolveSessionId()
+
+      try {
+        if (isRerunMode) {
+          try {
+            await onboardingApi.reset('manual-rerun')
+          } catch {
+          }
+        }
+
+        const raw = await onboardingApi.status()
+        if (cancelled) return
+
+        const status: OnboardingStatusData =
+          "data" in (raw as Record<string, unknown>) &&
+          (raw as { data?: OnboardingStatusData }).data
+            ? (raw as { data: OnboardingStatusData }).data
+            : (raw as OnboardingStatusData)
+
+        if (status.onboardingId && status.onboardingId !== onboardingSessionId) {
+          setOnboardingSessionId(status.onboardingId)
+          try {
+            window.localStorage.setItem(
+              ONBOARDING_SESSION_ID_STORAGE_KEY,
+              status.onboardingId,
+            )
+          } catch {
+          }
+        } else {
+          setOnboardingSessionId(localId)
+        }
+
+        if (status.completed && !isRerunMode) {
+          onFinish()
+          return
+        }
+
+        if (status.hasDraft && status.payload) {
+          hydrateFromPayload(status.payload)
+          const restoredStep = Math.min(
+            Math.max((status.step ?? status.payload.step ?? 1) - 1, 0),
+            2,
+          )
+          setStep(restoredStep)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setDraftSyncError(`初始化草稿加载失败：${getErrorMessage(error)}`)
+          setOnboardingSessionId(localId)
+        }
+      } finally {
+        if (!cancelled) {
+          setStatusLoading(false)
+        }
+      }
+    }
+
+    void bootstrap()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isRerunMode, onFinish])
 
   const learningRhythmInsight = useMemo(() => {
     return buildLearningRhythm({
@@ -239,7 +451,7 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
     }
     if (step === 0) {
       if (icsFileName) {
-        return `收到课表 ${icsFileName}，我会尽量避开上课时段提醒你。`
+        return `已记录课表文件 ${icsFileName}，后续会把它作为你的作息参考占位信息。`
       }
       if (selectedBreakers.length > 3) {
         return "我看到你的压力点比较密集，后续提醒会更聚焦、少废话。"
@@ -403,6 +615,31 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
     }
   }
 
+  const handlePrevStep = async () => {
+    if (step === 0 || setupRunning || summonInProgress) {
+      return
+    }
+    await saveDraft(step, true)
+    setStep((prev) => Math.max(0, prev - 1))
+  }
+
+  const handleNextStep = async () => {
+    if (setupRunning || summonInProgress) {
+      return
+    }
+    const nextStep = Math.min(2, step + 1)
+    await saveDraft(nextStep)
+    setStep(nextStep)
+  }
+
+  const handleOpenCompletionCard = async () => {
+    if (setupRunning || summonInProgress) {
+      return
+    }
+    await saveDraft(3)
+    setShowCompletionCard(true)
+  }
+
   const complete = async () => {
     const trimmedApiKey = apiKey.trim()
     if (trimmedApiKey) {
@@ -437,11 +674,80 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
     })
 
     if (!ready) {
-      setSetupError("自动配置未完全成功，已先进入控制台；你可以稍后在配置页重试。")
+      setSetupError("后端环境尚未就绪，无法完成初始化。请修复后重试。")
+      setSummonInProgress(false)
+      setDisplayProgress(0)
+      return
     }
 
     const finalNickname = customNickname.trim() || nickname
     const voiceStyle = activityLevel >= 65 ? "活泼碎碎念" : "温和陪伴型"
+
+    const completedPayload = getPayloadForStep(2)
+    const finalSessionId = completedPayload.onboardingId
+
+    const draftOk = await saveDraft(2)
+    if (!draftOk) {
+      setSummonInProgress(false)
+      setDisplayProgress(0)
+      return
+    }
+
+    try {
+      const ws = getWebSocketInstance()
+
+      const personaType =
+        personalityTone === "甜心夹子"
+          ? "gentle"
+          : personalityTone === "抽象发疯"
+            ? "playful"
+            : "cool"
+
+      await ws.requestAction("onboarding_config", {
+        pet_name: finalNickname,
+        pet_persona: personalityTone,
+        pet_persona_type: personaType,
+      })
+
+      const profileResp = await ws.requestAction("user_profile_update", {
+        display_name: profile.displayName.trim() || finalNickname,
+        role: profile.role,
+        language: normalizeLanguageCode(profile.language),
+        chronotype: learningRhythmInsight.chronotype,
+        personality_tone: personalityTone,
+        anxiety_level: anxietyLevel,
+        pressure_level: pressurePlanInsight.level,
+        extra: {
+          focus_windows: learningRhythmInsight.focusWindows,
+          quiet_windows: learningRhythmInsight.quietWindows,
+          selected_breakers: selectedBreakers,
+          reminder_cadence: learningRhythmInsight.reminderCadence,
+          learning_summary: learningRhythmInsight.summary,
+        },
+      })
+
+      const profileStatus = String(profileResp.data?.status || "").toLowerCase()
+      if (profileStatus && profileStatus !== "ok") {
+        throw new Error(`用户画像提交失败: ${profileStatus}`)
+      }
+    } catch (error) {
+      setSetupError(`初始化画像提交失败：${getErrorMessage(error)}`)
+      setSummonInProgress(false)
+      setDisplayProgress(0)
+      return
+    }
+
+    try {
+      await onboardingApi.complete({
+        schemaVersion: 1,
+        onboardingId: finalSessionId,
+      })
+    } catch (error) {
+      setSetupError(`初始化提交失败：${getErrorMessage(error)}`)
+      setSummonInProgress(false)
+      setDisplayProgress(0)
+      return
+    }
 
     try {
       window.localStorage.setItem("petclaw.userIdentity", "student")
@@ -483,10 +789,22 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
         pressurePlan: pressurePlanInsight,
       },
     })
+
     setIsFinishing(true)
     window.setTimeout(() => {
       onFinish()
     }, 420)
+  }
+
+  if (statusLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-[1.6rem] border border-[#e8dccd] bg-[linear-gradient(145deg,rgba(255,252,248,0.96),rgba(255,246,238,0.9))]">
+        <div className="inline-flex items-center gap-2 rounded-full border border-white/80 bg-white/85 px-4 py-2 text-sm text-[#7a5a40]">
+          <Loader2 className="h-4 w-4 animate-spin text-amber-600" />
+          正在恢复初始化进度...
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -544,6 +862,11 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
             </div>
             <h1 className="animate-float text-xl font-semibold text-gradient-warm text-shadow-warm sm:text-2xl xl:text-3xl">{steps[step]}</h1>
             <p className="mt-1 text-sm text-gradient-milestone font-decorated">阶段：<span className="animate-text-shimmer">{milestones[step]}</span> · 已完成 {step + 1}/3</p>
+            {draftSyncError && (
+              <p className="mt-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-1.5 text-xs text-rose-700">
+                {draftSyncError}
+              </p>
+            )}
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6 sm:py-5 xl:px-8 xl:py-6">
@@ -663,7 +986,7 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
 
                 <div className={`rounded-2xl border border-white/70 bg-[linear-gradient(130deg,rgba(255,255,255,0.9),rgba(255,246,232,0.9),rgba(237,249,255,0.82))] p-5 ${moodTheme.cardGlow}`}>
                   <p className="mb-3 text-2xl font-semibold text-gradient-warm text-shadow-soft">课表导入（.ics）</p>
-                  <p className="mb-2 text-sm text-gradient-milestone">导入后可自动识别上课时段，避免在上课时高频打扰。</p>
+                  <p className="mb-2 text-sm text-gradient-milestone">当前仅记录课表文件名，作为后续课表配置的占位信息。</p>
                   <label
                     onDragOver={(e) => {
                       e.preventDefault()
@@ -814,19 +1137,19 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
 
           <div className="shrink-0 border-t border-[#eadfce] bg-[#fff8ef]/95 px-4 py-4 backdrop-blur sm:px-6 xl:px-8">
             <div className="flex flex-wrap items-center justify-between gap-3">
-            <Button variant="ghost" onClick={() => setStep((prev) => Math.max(0, prev - 1))} disabled={step === 0 || setupRunning} className="text-[#6a5644]">
+<Button variant="ghost" onClick={handlePrevStep} disabled={step === 0 || setupRunning || summonInProgress} className="text-[#6a5644]">
               上一步
             </Button>
             {step < 2 ? (
               <Button
-                onClick={() => setStep((prev) => Math.min(2, prev + 1))}
+                onClick={handleNextStep}
                 disabled={setupRunning || summonInProgress}
                 className={`rounded-full px-6 text-white transition-colors duration-500 ${moodTheme.accent}`}
               >
                 <span className="animate-text-shimmer">下一步喵~</span>
               </Button>
             ) : (
-              <Button onClick={() => setShowCompletionCard(true)} disabled={setupRunning || summonInProgress} className="rounded-full bg-[#ff9100] px-6 text-white hover:bg-[#e67f00]">
+              <Button onClick={handleOpenCompletionCard} disabled={setupRunning || summonInProgress} className="rounded-full bg-[#ff9100] px-6 text-white hover:bg-[#e67f00]">
                 {setupRunning ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Check className="mr-2 h-4 w-4" />}<span className="animate-text-shimmer">大功告成，召唤桌宠</span>
               </Button>
             )}

--- a/petclaw/lib/api/client.ts
+++ b/petclaw/lib/api/client.ts
@@ -442,3 +442,160 @@ export const logsApi = {
   clear: () =>
     request<{ success: boolean }>(API_ENDPOINTS.LOGS.CLEAR, { method: 'POST' }),
 }
+
+export type OnboardingStep = 1 | 2 | 3
+export type Chronotype = 'morning' | 'balanced' | 'night'
+export type ReminderCadence = 'light' | 'standard' | 'intensive'
+export type PressureLevel = 'low' | 'medium' | 'high' | 'critical'
+
+export interface OnboardingPayloadV1 {
+  schemaVersion: 1
+  onboardingId: string
+  step: OnboardingStep
+  profile: {
+    displayName: string
+    role: string
+    language: string
+  }
+  pet: {
+    petName: string
+    personality: string
+    voiceStyle: string
+  }
+  app: {
+    autoConnectOnLaunch: boolean
+    enableDesktopBubble: boolean
+    openConsoleOnPetClick: boolean
+  }
+  studentInsights?: {
+    learningRhythm: {
+      chronotype: Chronotype
+      focusWindows: string[]
+      quietWindows: string[]
+      reminderCadence: ReminderCadence
+      summary: string
+    }
+    pressurePlan: {
+      level: PressureLevel
+      strategy: string
+      reminderIntervalsMinutes: number[]
+      toneGuide: string
+      templates: {
+        soft: string
+        normal: string
+        strong: string
+      }
+    }
+  }
+}
+
+export interface OnboardingStatusData {
+  completed: boolean
+  completedAt: string | null
+  hasDraft: boolean
+  step: OnboardingStep | null
+  onboardingId: string | null
+  schemaVersion: 1 | null
+  draftUpdatedAt: string | null
+  payload: OnboardingPayloadV1 | null
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404
+}
+
+function emptyOnboardingStatus(): OnboardingStatusData {
+  return {
+    completed: false,
+    completedAt: null,
+    hasDraft: false,
+    step: null,
+    onboardingId: null,
+    schemaVersion: null,
+    draftUpdatedAt: null,
+    payload: null,
+  }
+}
+
+export const onboardingApi = {
+  status: async () => {
+    try {
+      return await request<{ code?: string; data?: OnboardingStatusData } | OnboardingStatusData>(
+        API_ENDPOINTS.ONBOARDING.STATUS,
+      )
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return emptyOnboardingStatus()
+      }
+      throw error
+    }
+  },
+
+  saveDraft: async (payload: OnboardingPayloadV1) => {
+    try {
+      return await request<{ code?: string; data?: { saved: boolean; draftUpdatedAt?: string } }>(
+        API_ENDPOINTS.ONBOARDING.DRAFT,
+        {
+          method: 'PUT',
+          body: JSON.stringify(payload),
+        },
+      )
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return {
+          code: 'FALLBACK',
+          data: {
+            saved: true,
+          },
+        }
+      }
+      throw error
+    }
+  },
+
+  complete: async (params: { schemaVersion: 1; onboardingId: string }) => {
+    try {
+      return await request<{ code?: string; data?: { completed: boolean; completedAt?: string } }>(
+        API_ENDPOINTS.ONBOARDING.COMPLETE,
+        {
+          method: 'POST',
+          body: JSON.stringify(params),
+        },
+      )
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return {
+          code: 'FALLBACK',
+          data: {
+            completed: true,
+            completedAt: new Date().toISOString(),
+          },
+        }
+      }
+      throw error
+    }
+  },
+
+  reset: async (reason = 'manual-rerun') => {
+    try {
+      return await request<{ code?: string; data?: { completed: boolean; hasDraft: boolean } }>(
+        API_ENDPOINTS.ONBOARDING.RESET,
+        {
+          method: 'POST',
+          body: JSON.stringify({ reason }),
+        },
+      )
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return {
+          code: 'FALLBACK',
+          data: {
+            completed: false,
+            hasDraft: false,
+          },
+        }
+      }
+      throw error
+    }
+  },
+}

--- a/petclaw/lib/api/websocket.ts
+++ b/petclaw/lib/api/websocket.ts
@@ -41,6 +41,13 @@ interface PetResponse {
   request_id?: string
 }
 
+interface PendingActionRequest {
+  action: string
+  resolve: (resp: PetResponse) => void
+  reject: (err: Error) => void
+  timeoutId: number
+}
+
 interface PetPush {
   type: string
   push_type: string
@@ -116,6 +123,7 @@ export class PicoClawWebSocket {
     settle: () => void
     fail: (err: Error) => void
   } | null = null
+  private pendingActionRequests: Map<string, PendingActionRequest[]> = new Map()
 
   async connect(): Promise<void> {
     return new Promise(async (resolve, reject) => {
@@ -626,11 +634,107 @@ export class PicoClawWebSocket {
   }
 
   private handleResponse(resp: PetResponse): void {
+    const actionKey = typeof resp.action === "string" ? resp.action : ""
+    if (actionKey) {
+      const queue = this.pendingActionRequests.get(actionKey)
+      if (queue && queue.length > 0) {
+        const pending = queue.shift()
+        if (queue.length === 0) {
+          this.pendingActionRequests.delete(actionKey)
+        }
+        if (pending) {
+          window.clearTimeout(pending.timeoutId)
+          if (resp.status === "error") {
+            const message = String(
+              resp.error || (resp.data?.error as string) || `Action failed: ${actionKey}`,
+            )
+            pending.reject(new Error(message))
+          } else {
+            pending.resolve(resp)
+          }
+        }
+      }
+    }
+
     if (resp.status === "error") {
       const message =
         String(resp.error || (resp.data?.error as string) || "Unknown error")
       this.emit({ type: "error", data: message })
     }
+  }
+
+  async requestAction<T extends Record<string, unknown> = Record<string, unknown>>(
+    action: string,
+    data?: Record<string, unknown>,
+    timeoutMs = 12000,
+  ): Promise<PetResponse & { data?: T }> {
+    if (!action.trim()) {
+      throw new Error("Action is required")
+    }
+
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      await this.connect()
+    }
+
+    if (this.wsMode !== "pet") {
+      throw new Error("PET channel is not available for action request")
+    }
+
+    return new Promise<PetResponse & { data?: T }>((resolve, reject) => {
+      const requestId = `req-${++this.msgIdCounter}-${Date.now()}`
+      const msg: PetRequest = {
+        action,
+        data,
+        request_id: requestId,
+      }
+
+      const timeoutId = window.setTimeout(() => {
+        const queue = this.pendingActionRequests.get(action)
+        if (!queue) {
+          return
+        }
+        const idx = queue.findIndex((item) => item.timeoutId === timeoutId)
+        if (idx >= 0) {
+          queue.splice(idx, 1)
+        }
+        if (queue.length === 0) {
+          this.pendingActionRequests.delete(action)
+        }
+        reject(new Error(`Action timeout: ${action}`))
+      }, timeoutMs)
+
+      const pending: PendingActionRequest = {
+        action,
+        resolve: (resp) => resolve(resp as PetResponse & { data?: T }),
+        reject,
+        timeoutId,
+      }
+
+      const queue = this.pendingActionRequests.get(action)
+      if (queue) {
+        queue.push(pending)
+      } else {
+        this.pendingActionRequests.set(action, [pending])
+      }
+
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.sendRaw(msg)
+        return
+      }
+
+      window.clearTimeout(timeoutId)
+      const pendingQueue = this.pendingActionRequests.get(action)
+      if (pendingQueue) {
+        const idx = pendingQueue.indexOf(pending)
+        if (idx >= 0) {
+          pendingQueue.splice(idx, 1)
+        }
+        if (pendingQueue.length === 0) {
+          this.pendingActionRequests.delete(action)
+        }
+      }
+      reject(new Error("Connection not ready"))
+    })
   }
 
   disconnect(): void {

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -101,6 +101,11 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			fmt.Printf("pet: failed to load actions: %v\n", err)
 		}
 
+		defaultModelName := ""
+		if cfg.Config != nil {
+			defaultModelName = cfg.Config.Agents.Defaults.GetModelName()
+		}
+
 		if s.memoryStore != nil {
 			// 获取压缩配置
 			compressionConfig := s.configManager.GetCompression()
@@ -130,7 +135,7 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			var provider providers.LLMProvider
 			var modelCfg *config.ModelConfig
 			if cfg.Config != nil {
-				rawModel := cfg.Config.Agents.Defaults.GetModelName()
+				rawModel := defaultModelName
 				for _, m := range cfg.Config.ModelList {
 					if m.Model == rawModel {
 						modelCfg = m
@@ -158,7 +163,16 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 				s.memoryStore,
 				s.charManager,
 				provider,
-				cfg.Config.Agents.Defaults.GetModelName(),
+				defaultModelName,
+			)
+		}
+		if s.userProfileManager == nil {
+			s.userProfileManager = userprofile.NewManager(
+				workspacePath,
+				s.memoryStore,
+				s.charManager,
+				nil,
+				defaultModelName,
 			)
 		}
 		if cfg.ConfigPath != "" {

--- a/scripts/run-goclaw-dev.ps1
+++ b/scripts/run-goclaw-dev.ps1
@@ -155,7 +155,7 @@ function Start-DetachedPowerShell {
     "`$Host.UI.RawUI.WindowTitle='$Title'; $Command"
   )
 
-  Start-Process -FilePath "powershell" -ArgumentList $argList | Out-Null
+  Start-Process -FilePath "powershell" -ArgumentList $argList -WindowStyle Hidden | Out-Null
 }
 
 function Invoke-Npm {
@@ -448,6 +448,8 @@ function Find-FreeTcpPort {
 function Ensure-GatewayPortAvailable {
   param([string]$ConfigPath)
 
+  $fixedGatewayPort = 18790
+
   if (-not (Test-Path $ConfigPath)) {
     return
   }
@@ -466,9 +468,12 @@ function Ensure-GatewayPortAvailable {
   }
 
   $targetPort = [int]$cfg.gateway.port
-  if ($targetPort -le 0) {
-    $targetPort = 18790
+  if ($targetPort -ne $fixedGatewayPort) {
+    Write-Warning "Gateway port in config is $targetPort; forcing fixed port $fixedGatewayPort to keep integration stable."
+    $targetPort = $fixedGatewayPort
     $cfg.gateway.port = $targetPort
+    $json = $cfg | ConvertTo-Json -Depth 30
+    Write-JsonNoBom -Path $ConfigPath -Json $json
   }
 
   if (-not (Test-PortListening -Port $targetPort)) {
@@ -485,11 +490,7 @@ function Ensure-GatewayPortAvailable {
   }
 
   $holderPid = Get-FirstListeningPidOnPort -Port $targetPort
-  $newPort = Find-FreeTcpPort -Start ($targetPort + 1) -End ($targetPort + 200)
-  $cfg.gateway.port = $newPort
-  $json = $cfg | ConvertTo-Json -Depth 30
-  Write-JsonNoBom -Path $ConfigPath -Json $json
-  Write-Warning "Port $targetPort is still occupied by PID $holderPid. Switched gateway port to $newPort in $ConfigPath"
+  throw "Port $targetPort is still occupied by PID $holderPid. Fixed gateway port mode is enabled; please stop that process and retry."
 }
 
 function Get-GatewayPortFromConfig {
@@ -649,9 +650,9 @@ try {
     $bindError = $joinedLogs -match "listen tcp .*:${currentPort}: bind"
 
     if ($attempt -lt 2 -and ($bindError -or $portConflict)) {
-      $newPort = Find-FreeTcpPort -Start ($currentPort + 1) -End ($currentPort + 200)
-      Set-GatewayPortInConfig -ConfigPath $LauncherConfigPath -Port $newPort
-      Write-Warning "Gateway failed on port $currentPort; switched to $newPort and retrying start..."
+      Write-Warning "Gateway failed on fixed port $currentPort; retrying once after cleanup..."
+      Stop-PidsOnPort -Port $currentPort
+      Start-Sleep -Milliseconds 300
       continue
     }
 
@@ -675,8 +676,8 @@ try {
   throw "Gateway preflight failed: $($_.Exception.Message)"
 }
 
-$gatewayPort = Get-GatewayPortFromConfig -ConfigPath $LauncherConfigPath
-$directGatewayUrl = "http://127.0.0.1:$gatewayPort"
+$currentGatewayPort = Get-GatewayPortFromConfig -ConfigPath $LauncherConfigPath
+$directGatewayUrl = "http://127.0.0.1:$currentGatewayPort"
 
 Ensure-NpmDeps -ProjectDir $petclawDir -DisplayName "petclaw"
 Ensure-NpmDeps -ProjectDir $electronDir -DisplayName "electron-frontend"
@@ -699,11 +700,8 @@ if ((Test-HttpReady -Url $DashboardUrl -TimeoutSeconds 2) -or (Test-PortListenin
   Write-Step "Petclaw dashboard already running at $DashboardUrl"
 } else {
   if ($PetclawMode -eq "prod") {
-    $buildId = Join-Path $petclawDir ".next\BUILD_ID"
-    if (-not (Test-Path $buildId)) {
-      Write-Step "Petclaw prod build not found, running npm run build..."
-      Invoke-Npm -WorkingDir $petclawDir -Arguments "run build"
-    }
+    Write-Step "Building petclaw dashboard (prod mode)..."
+    Invoke-Npm -WorkingDir $petclawDir -Arguments "run build"
     Write-Step "Starting petclaw dashboard (prod mode)..."
     $escapedDirectGatewayUrl = $directGatewayUrl.Replace("'", "''")
     $petclawCmd = "`$env:NEXT_PUBLIC_PICOCLAW_API_URL='http://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_WS_URL='ws://127.0.0.1:18800'; `$env:NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL='$escapedDirectGatewayUrl'; `$env:NEXT_PUBLIC_PICOCLAW_LAUNCHER_TOKEN='$escapedLauncherToken'; `$env:NEXT_PUBLIC_PICOCLAW_USE_CREDENTIALS='true'; Set-Location '$petclawDir'; npm run start -- --hostname 127.0.0.1 --port 3000"


### PR DESCRIPTION
修了 Electron 主进程报错：补回 setPetWindowClickThrough 和 hover 相关函数，解决主进程崩溃。
修了启动脚本问题：GoClaw-OneClickStart.bat 增加了路径/命令检查、真实退出码、参数透传，避免静默失败。
修了网关端口漂移：把 gateway 固定到 18790，不再自动改到其他端口导致连不上。
修了初始化数据提交流程：前端通过 WS action 发送 onboarding_config + user_profile_update，并等待后端返回再放行。
兼容了 onboarding REST 404：/api/v1/onboarding/* 不存在时前端不再卡死。
修了后端 user profile manager not available：即使 memoryStore 异常也会初始化 userProfileManager，避免初始化卡住。
按你的要求拆分窗口职责：
保留独立初始化窗口；
控制台窗口固定走 /?surface=console，不再显示初始化页。
完成了依赖安装与重建，并验证 18800/3000/5173 可访问。