### PR TITLE
fix(pet/voice): store voiceID in MinimaxTTS and use it in Synthesize

### DIFF
--- a/pkg/pet/voice/minimax.go
+++ b/pkg/pet/voice/minimax.go
@@ -20,6 +20,7 @@ type MinimaxTTS struct {
 	apiBase    string       // API地址
 	apiKey     string       // API密钥
 	model      string       // 使用的模型名称
+	voiceID    string       // 音色ID
 	httpClient *http.Client // HTTP客户端，包含60秒超时
 }
 
@@ -31,11 +32,15 @@ func newMinimaxTTS(apiBase, apiKey, model, voiceID string, extra map[string]any)
 	if model == "" {
 		model = "speech-2.8-hd"
 	}
+	if voiceID == "" {
+		voiceID = "male-qn-qingse"
+	}
 
 	return &MinimaxTTS{
 		apiBase: apiBase,
 		apiKey:  apiKey,
 		model:   model,
+		voiceID: voiceID,
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second,
 		},
@@ -66,7 +71,7 @@ func (t *MinimaxTTS) Synthesize(text string, params VoiceParams) (<-chan AudioCh
 			"exclude_aggregated_audio": true,
 		},
 		"voice_setting": map[string]any{
-			"voice_id": "male-qn-qingse", // 使用默认音色
+			"voice_id": t.voiceID,
 			"speed":    params.Speed,
 			"vol":      params.Vol,
 			"pitch":    params.Pitch,


### PR DESCRIPTION
# PR: Fix MiniMax voiceID Not Being Used in Synthesis

> **关联 Issue**: https://github.com/1024XEngineer/GoClaw/issues/173

## 1. Summary

修复 MiniMax TTS 供应商中 voiceID 配置不生效的问题。

## 2. Problem

`voice_model_update` API 允许用户更新 `voice_id` 字段，但在实际语音合成时仍然使用硬编码的 `male-qn-qingse` 音色。

### 问题原因

1. `MinimaxTTS` 结构体没有 `voiceID` 字段
2. `newMinimaxTTS` 函数忽略了传入的 `voiceID` 参数
3. `Synthesize` 方法在请求体中硬编码了 `"voice_id": "male-qn-qingse"`

## 3. Solution

1. 在 `MinimaxTTS` 结构体中添加 `voiceID` 字段
2. 在 `newMinimaxTTS` 中存储 `voiceID` 参数
3. 当 `voiceID` 为空时，使用 `male-qn-qingse` 作为默认值
4. 在 `Synthesize` 中使用 `t.voiceID` 替代硬编码值

## 4. Changes

```diff
type MinimaxTTS struct {
    apiBase    string
    apiKey     string
    model      string
+   voiceID    string       // 新增
    httpClient *http.Client
}

func newMinimaxTTS(...) *MinimaxTTS {
+   if voiceID == "" {
+       voiceID = "male-qn-qingse"
+   }
    return &MinimaxTTS{
+       voiceID: voiceID,
    }
}

"voice_setting": {
-   "voice_id": "male-qn-qingse", // 硬编码
+   "voice_id": t.voiceID,         // 使用存储的值
}
```

## 5. Verification

### 测试流程

1. 获取 MiniMax 可用音色列表：
```json
{"action": "voice_model_get_voices", "data": {"provider": "minimax"}}
```

2. 更新 voice_id：
```json
{"action": "voice_model_update", "data": {"name": "minimax", "voice_id": "<voice_id_from_list>"}}
```

3. 触发语音合成，确认使用新的音色

## 6. Files Changed

| 文件 | 变更 |
|------|------|
| `pkg/pet/voice/minimax.go` | 添加 voiceID 存储和使用 |

## 7. Branch

- `fix/minimax-voice-id` - 基于 `feat/voice-provider-refactor`
