### PR TITLE
fix（skills）： 声明 student-ppt-pet 运行时依赖

### DIFF
--- a/workspace/skills/student-ppt-pet/SKILL.md
+++ b/workspace/skills/student-ppt-pet/SKILL.md
@@ -20,6 +20,7 @@ You are a toxic but caring desk pet and an excellent academic presentation exper
 - Keep all generated files inside the workspace. Do not write to Desktop by default in this setup.
 - Write the structured plan JSON to `ppt-plan.json` in the workspace root.
 - Write the generated PPTX file to `generated/student-ppt-pet/My_Academic_Presentation.pptx` inside the workspace.
+- Install the Python runtime dependency with `python -m pip install -r skills\student-ppt-pet\requirements.txt` before running the generator in a clean environment.
 - Use `write_file` for the JSON plan.
 - Use the `exec` tool to run the Python generator script after the JSON file is saved.
 
@@ -133,7 +134,19 @@ Use this structure:
 }
 ```
 
-### Step 4: Execute PPT Generation
+### Step 4: Install Runtime Dependency
+
+Before running the generator in a clean environment:
+
+1. Run this command from the workspace root:
+
+```powershell
+python -m pip install -r skills\student-ppt-pet\requirements.txt
+```
+
+2. Continue only after the dependency install succeeds.
+
+### Step 5: Execute PPT Generation
 
 After `ppt-plan.json` is saved successfully:
 
@@ -151,7 +164,7 @@ python skills\student-ppt-pet\scripts\generate.py --plan-file ppt-plan.json --ou
 7. Then offer the mock defense option:
    - `如果你怕答辩被导师拷打，回复【来拷打我】，我立刻化身魔鬼评委挑你这 PPT 里的刺。`
 
-### Step 5: Mock Defense
+### Step 6: Mock Defense
 
 If the user replies `来拷打我`:
 

--- a/workspace/skills/student-ppt-pet/requirements.txt
+++ b/workspace/skills/student-ppt-pet/requirements.txt
@@ -1,0 +1,1 @@
+python-pptx>=1.0,<2

--- a/workspace/skills/student-ppt-pet/scripts/generate.py
+++ b/workspace/skills/student-ppt-pet/scripts/generate.py
@@ -2,13 +2,22 @@ import argparse
 import json
 from pathlib import Path
 
-from pptx import Presentation
-from pptx.chart.data import ChartData
-from pptx.dml.color import RGBColor
-from pptx.enum.chart import XL_CHART_TYPE, XL_LABEL_POSITION
-from pptx.enum.shapes import MSO_AUTO_SHAPE_TYPE
-from pptx.enum.text import MSO_ANCHOR, PP_ALIGN
-from pptx.util import Inches, Pt
+try:
+    from pptx import Presentation
+    from pptx.chart.data import ChartData
+    from pptx.dml.color import RGBColor
+    from pptx.enum.chart import XL_CHART_TYPE, XL_LABEL_POSITION
+    from pptx.enum.shapes import MSO_AUTO_SHAPE_TYPE
+    from pptx.enum.text import MSO_ANCHOR, PP_ALIGN
+    from pptx.util import Inches, Pt
+except ModuleNotFoundError as exc:
+    if exc.name == "pptx":
+        raise SystemExit(
+            "Missing dependency 'python-pptx'. "
+            "Install it with: python -m pip install -r "
+            "skills\\student-ppt-pet\\requirements.txt"
+        ) from exc
+    raise
 
 
 SLIDE_W = Inches(13.333)


### PR DESCRIPTION
## 摘要

此 PR 修复了先前合并的 `student-ppt-pet` 技能中的运行时依赖问题。

生成器脚本依赖于 `python-pptx`，但在原始更改中未声明该依赖项，导致在干净检出时技能失败。

## 更改内容

- 添加了 `workspace/skills/student-ppt-pet/requirements.txt`
- 在 `SKILL.md` 中记录了依赖项安装步骤
- 在 `scripts/generate.py` 中添加了更清晰的运行时错误，当 `python-pptx` 缺失时

## 原因

原始技能可能立即失败，显示错误信息：

`ModuleNotFoundError: No module named 'pptx'`

此 PR 使依赖项明确化，并为代理提供了一个可靠的已检入引导路径。

## 风险

低风险。

这是一个仅限于新技能资源的后续修复，不会改变核心运行时逻辑。