### PR TITLE
Dev

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -1,7 +1,7 @@
 # Pet Channel API 接口文档
 
-> 版本：v2.7  
-> 日期：2026-04-23  
+> 版本：v2.8  
+> 日期：2026-04-24  
 > 协议：WebSocket + JSON
 
 ---
@@ -1867,6 +1867,263 @@ if (msg.push_type === 'audio_and_voice') {
 
 ---
 
+### 4.27 skill_list - 列出已安装的 Skills
+
+获取所有已安装的 skills 列表（包括 workspace、global、builtin 三种来源）。
+
+**请求**：
+
+```json
+{
+  "action": "skill_list",
+  "data": {}
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "skill_list",
+  "data": {
+    "skills": [
+      {
+        "name": "github-actions",
+        "description": "与 GitHub Actions 集成的 Skill",
+        "path": "/path/to/workspace/skills/github-actions/SKILL.md",
+        "source": "workspace"
+      },
+      {
+        "name": "weather",
+        "description": "查询天气的 Skill",
+        "path": "/path/to/global/skills/weather/SKILL.md",
+        "source": "global"
+      }
+    ]
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| skills | array | Skill 列表 |
+| skills[].name | string | Skill 名称 |
+| skills[].description | string | Skill 描述 |
+| skills[].path | string | SKILL.md 文件路径 |
+| skills[].source | string | 来源：`workspace`(工作区) / `global`(全局) / `builtin`(内置) |
+
+**Skill 存储位置**：
+
+| 来源 | 路径 | 说明 |
+|------|------|------|
+| workspace | `<workspace>/skills/` | 工作区级 skills，可写 |
+| global | `~/.picoclaw/skills/` | 全局 skills，可写 |
+| builtin | 环境变量或当前目录 | 内置 skills，只读 |
+
+---
+
+### 4.28 skill_search - 搜索 Skills
+
+从 registry（如 clawhub.ai）搜索可安装的 skills。
+
+**请求**：
+
+```json
+{
+  "action": "skill_search",
+  "data": {
+    "query": "github integration",
+    "limit": 10
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "skill_search",
+  "data": {
+    "results": [
+      {
+        "score": 0.95,
+        "slug": "github-actions",
+        "display_name": "GitHub Actions",
+        "summary": "与 GitHub Actions 集成，用于管理和监控 workflow",
+        "version": "1.2.3",
+        "registry_name": "clawhub"
+      }
+    ]
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| query | string | 是 | 搜索关键词 |
+| limit | int | 否 | 返回条数限制，默认 10 |
+
+**响应字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| results | array | 搜索结果列表 |
+| results[].score | float | 相关度评分 0-1 |
+| results[].slug | string | Skill 唯一标识符（用于安装） |
+| results[].display_name | string | 显示名称 |
+| results[].summary | string | Skill 描述摘要 |
+| results[].version | string | 最新版本号 |
+| results[].registry_name | string | 来源 registry 名称 |
+
+---
+
+### 4.29 skill_install - 安装 Skill
+
+从 registry 安装一个 skill 到本地。
+
+**请求**：
+
+```json
+{
+  "action": "skill_install",
+  "data": {
+    "slug": "github-actions",
+    "registry": "clawhub",
+    "version": ""
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "skill_install",
+  "data": {
+    "slug": "github-actions",
+    "version": "1.2.3",
+    "is_malware_blocked": false,
+    "is_suspicious": false,
+    "summary": "与 GitHub Actions 集成"
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| slug | string | 是 | Skill 唯一标识符 |
+| registry | string | 否 | Registry 名称，默认 `clawhub` |
+| version | string | 否 | 指定版本，为空则安装最新版本 |
+
+**响应字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| slug | string | 安装的 Skill 标识符 |
+| version | string | 安装的版本号 |
+| is_malware_blocked | bool | 是否被安全检查拦截（恶意软件） |
+| is_suspicious | bool | 是否被标记为可疑 |
+| summary | string | Skill 描述 |
+
+**安装位置**：安装到 `<workspace>/skills/<slug>/`
+
+---
+
+### 4.30 skill_remove - 删除 Skill
+
+删除已安装的 workspace skill。
+
+**请求**：
+
+```json
+{
+  "action": "skill_remove",
+  "data": {
+    "name": "github-actions"
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "skill_remove",
+  "data": {
+    "name": "github-actions"
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| name | string | 是 | 要删除的 Skill 名称 |
+
+**限制**：
+- 只能删除 `workspace` 来源的 skills
+- `global` 和 `builtin` 来源的 skills 不能通过此接口删除
+
+**错误**：`only workspace skills can be deleted` - 尝试删除非 workspace skill
+
+---
+
+### 4.31 skill_get - 获取 Skill 内容
+
+获取指定 skill 的完整内容（SKILL.md）。
+
+**请求**：
+
+```json
+{
+  "action": "skill_get",
+  "data": {
+    "name": "github-actions"
+  }
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "skill_get",
+  "data": {
+    "name": "github-actions",
+    "content": "# GitHub Actions Skill\n\nThis skill provides integration with GitHub Actions..."
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| name | string | 是 | Skill 名称 |
+
+**响应字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| name | string | Skill 名称 |
+| content | string | SKILL.md 的完整内容（Markdown 格式） |
+
+**错误**：`skill not found` - Skill 不存在
+
+---
+
 ## 五、错误码
 
 ### 5.1 WebSocket 错误 (status: error)
@@ -1895,6 +2152,13 @@ if (msg.push_type === 'audio_and_voice') {
 | `unsupported provider: xxx` | 不支持的供应商 | 供应商类型不是 `minimax` 或 `doubao` |
 | `provider is required` | 供应商必填 | 查询音色时缺少 provider 字段 |
 | `api_key is required` | API Key 必填 | 查询音色时缺少 api_key 字段 |
+| `skills manager not initialized` | Skills 管理器未初始化 | 服务未正确初始化 |
+| `query is required` | 搜索关键词必填 | 搜索 skills 时缺少 query 字段 |
+| `slug is required` | Skill slug 必填 | 安装 skill 时缺少 slug 字段 |
+| `registry .* not found` | Registry 不存在 | 指定了不存在的 registry |
+| `skill .* already exists` | Skill 已存在 | 要安装的 skill 已经存在 |
+| `skill .* not found` | Skill 不存在 | 要删除/获取的 skill 不存在 |
+| `only workspace skills can be deleted` | 只可删除 workspace skill | 尝试删除 global 或 builtin skill |
 
 ### 5.2 错误响应示例
 
@@ -2078,6 +2342,11 @@ async def send_chat(ws, text):
 | voice_model_get_voices | 获取可用音色 | 查询供应商的音色列表 |
 | voice_model_update | 更新语音模型 | 修改模型的配置（API Key、音色等） |
 | voice_model_set_default | 设置默认语音模型 | 热切换到指定模型 |
+| skill_list | 列出 Skills | 获取已安装的 skills 列表 |
+| skill_search | 搜索 Skills | 从 registry 搜索可安装的 skills |
+| skill_install | 安装 Skill | 从 registry 安装 skill 到本地 |
+| skill_remove | 删除 Skill | 删除已安装的 workspace skill |
+| skill_get | 获取 Skill 内容 | 获取 skill 的完整内容（SKILL.md） |
 
 ### 7.2 push_type 快速索引
 

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -18,6 +18,7 @@ import (
 	petconfig "github.com/sipeed/picoclaw/pkg/pet/config"
 	"github.com/sipeed/picoclaw/pkg/pet/memory"
 	"github.com/sipeed/picoclaw/pkg/pet/modelconfig"
+	"github.com/sipeed/picoclaw/pkg/pet/skills"
 	"github.com/sipeed/picoclaw/pkg/pet/userprofile"
 	"github.com/sipeed/picoclaw/pkg/pet/voice"
 	"github.com/sipeed/picoclaw/pkg/providers"
@@ -41,6 +42,7 @@ type PetService struct {
 	modelConfigManager *modelconfig.Manager
 	cronService        *cron.CronService
 	userProfileManager *userprofile.Manager
+	skillsMgr          *skills.Manager
 
 	connSessions map[string]string
 
@@ -59,29 +61,31 @@ type PetServiceConfig struct {
 
 func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	homePath := config.GetHome()
 	s := &PetService{
-		msgBus:        msgBus,
-		config:        cfg,
-		actionManager: action.NewActionManager(cfg.WorkspacePath),
-		connSessions:  make(map[string]string),
-		ctx:           ctx,
-		cancel:        cancel,
+		msgBus:       msgBus,
+		config:       cfg,
+		connSessions: make(map[string]string),
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 	workspacePath := cfg.WorkspacePath
-	if workspacePath != "" {
-		logger.Debugf("pet: workspacePath=%s", workspacePath)
-		s.configManager = petconfig.NewManager(workspacePath)
+	if homePath != "" {
+		// 优先使用 homePath 配置
+		logger.Debugf("pet: homePath=%s", homePath)
+		// 创建配置管理器
+		s.configManager = petconfig.NewManager(homePath)
 		if s.configManager == nil {
 			return nil, fmt.Errorf("failed to create config manager")
 		}
-
+		// 创建角色管理器
 		var err error
 		s.charManager, err = characters.NewManager(s.configManager.GetCharacters(), s.configManager)
 		if err != nil {
 			fmt.Printf("pet: failed to create character manager: %v\n", err)
 			return nil, err
 		}
-
+		// 创建语音加载器
 		s.voiceLoader = voice.NewLoader(s.configManager.GetVoice())
 		if err := s.voiceLoader.Load(); err != nil {
 			fmt.Printf("pet: failed to load voice: %v\n", err)
@@ -92,7 +96,11 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			fmt.Println("pet: voice provider is nil after loading")
 		}
 
-		s.memoryStore, err = memory.NewStore(cfg.WorkspacePath)
+		// 创建动作管理器
+		s.actionManager = action.NewActionManager(homePath)
+
+		// 创建记忆内存存储
+		s.memoryStore, err = memory.NewStore(homePath)
 		if err != nil {
 			fmt.Printf("pet: failed to create memory store: %v\n", err)
 		}
@@ -101,11 +109,7 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			fmt.Printf("pet: failed to load actions: %v\n", err)
 		}
 
-		defaultModelName := ""
-		if cfg.Config != nil {
-			defaultModelName = cfg.Config.Agents.Defaults.GetModelName()
-		}
-
+		// 创建对话存储
 		if s.memoryStore != nil {
 			// 获取压缩配置
 			compressionConfig := s.configManager.GetCompression()
@@ -126,7 +130,7 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			}
 
 			// 创建对话存储（使用 SQLite 持久化）
-			s.conversationStore, err = compression.NewConversationStore(cfg.WorkspacePath, threshold, callback)
+			s.conversationStore, err = compression.NewConversationStore(homePath, threshold, callback)
 			if err != nil {
 				logger.Warnf("pet: failed to create conversation store: %v", err)
 			}
@@ -135,7 +139,7 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 			var provider providers.LLMProvider
 			var modelCfg *config.ModelConfig
 			if cfg.Config != nil {
-				rawModel := defaultModelName
+				rawModel := cfg.Config.Agents.Defaults.GetModelName()
 				for _, m := range cfg.Config.ModelList {
 					if m.Model == rawModel {
 						modelCfg = m
@@ -159,31 +163,46 @@ func NewPetService(msgBus *bus.MessageBus, cfg PetServiceConfig) (*PetService, e
 
 			// 创建用户画像管理器
 			s.userProfileManager = userprofile.NewManager(
-				workspacePath,
+				homePath,
 				s.memoryStore,
 				s.charManager,
 				provider,
-				defaultModelName,
+				cfg.Config.Agents.Defaults.GetModelName(),
 			)
 		}
+		// 创建用户画像管理器
 		if s.userProfileManager == nil {
 			s.userProfileManager = userprofile.NewManager(
-				workspacePath,
+				homePath,
 				s.memoryStore,
 				s.charManager,
 				nil,
-				defaultModelName,
+				cfg.Config.Agents.Defaults.GetModelName(),
 			)
 		}
-		if cfg.ConfigPath != "" {
-			s.modelConfigManager = modelconfig.NewManager(cfg.ConfigPath)
-		}
+	}
+
+	if cfg.ConfigPath != "" {
+		s.modelConfigManager = modelconfig.NewManager(cfg.ConfigPath)
+	}
+
+	if workspacePath != "" {
 		// 初始化 cron 服务
 		cronStorePath := filepath.Join(workspacePath, "cron", "jobs.json")
 		s.cronService = cron.NewCronService(cronStorePath, nil)
 		logger.DebugCF("pet", "PetService: cron service initialized, store=", map[string]any{
 			"store_path": cronStorePath,
 		})
+		// 初始化 skills 管理器
+		if cfg.Config != nil {
+			var err error
+			s.skillsMgr, err = skills.NewManager(cfg.Config)
+			if err != nil {
+				logger.WarnCF("pet", "PetService: failed to create skills manager", map[string]any{"error": err.Error()})
+			} else {
+				logger.DebugCF("pet", "PetService: skills manager initialized", nil)
+			}
+		}
 	}
 
 	return s, nil
@@ -468,6 +487,16 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 		return s.handleVoiceModelSetDefault(sessionID, req)
 	case ActionVoiceModelGetVoices:
 		return s.handleVoiceModelGetVoices(sessionID, req)
+	case ActionSkillList:
+		return s.handleSkillList(sessionID, req)
+	case ActionSkillSearch:
+		return s.handleSkillSearch(sessionID, req)
+	case ActionSkillInstall:
+		return s.handleSkillInstall(sessionID, req)
+	case ActionSkillRemove:
+		return s.handleSkillRemove(sessionID, req)
+	case ActionSkillGet:
+		return s.handleSkillGet(sessionID, req)
 	default:
 		return s.sendError(sessionID, req.Action, fmt.Sprintf("unknown action: %s", req.Action))
 	}
@@ -1393,4 +1422,125 @@ func (s *PetService) handleVoiceModelGetVoices(sessionID string, req Request) er
 	}
 
 	return s.sendResponse(sessionID, req.Action, result)
+}
+
+func (s *PetService) handleSkillList(sessionID string, req Request) error {
+	if s.skillsMgr == nil {
+		return s.sendError(sessionID, req.Action, "skills manager not initialized")
+	}
+
+	skillsList := s.skillsMgr.ListSkills()
+	return s.sendResponse(sessionID, req.Action, map[string]interface{}{
+		"skills": skillsList,
+	})
+}
+
+func (s *PetService) handleSkillSearch(sessionID string, req Request) error {
+	if s.skillsMgr == nil {
+		return s.sendError(sessionID, req.Action, "skills manager not initialized")
+	}
+
+	var data struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Query == "" {
+		return s.sendError(sessionID, req.Action, "query is required")
+	}
+
+	if data.Limit <= 0 {
+		data.Limit = 10
+	}
+
+	results, err := s.skillsMgr.SearchSkills(s.ctx, data.Query, data.Limit)
+	if err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]interface{}{
+		"results": results,
+	})
+}
+
+func (s *PetService) handleSkillInstall(sessionID string, req Request) error {
+	if s.skillsMgr == nil {
+		return s.sendError(sessionID, req.Action, "skills manager not initialized")
+	}
+
+	var data struct {
+		Slug     string `json:"slug"`
+		Registry string `json:"registry"`
+		Version  string `json:"version"`
+	}
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Slug == "" {
+		return s.sendError(sessionID, req.Action, "slug is required")
+	}
+	if data.Registry == "" {
+		data.Registry = "clawhub"
+	}
+
+	result, err := s.skillsMgr.InstallSkill(s.ctx, data.Slug, data.Registry, data.Version)
+	if err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	return s.sendResponse(sessionID, req.Action, result)
+}
+
+func (s *PetService) handleSkillRemove(sessionID string, req Request) error {
+	if s.skillsMgr == nil {
+		return s.sendError(sessionID, req.Action, "skills manager not initialized")
+	}
+
+	var data struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Name == "" {
+		return s.sendError(sessionID, req.Action, "name is required")
+	}
+
+	if err := s.skillsMgr.RemoveSkill(data.Name); err != nil {
+		return s.sendError(sessionID, req.Action, err.Error())
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]string{"name": data.Name})
+}
+
+func (s *PetService) handleSkillGet(sessionID string, req Request) error {
+	if s.skillsMgr == nil {
+		return s.sendError(sessionID, req.Action, "skills manager not initialized")
+	}
+
+	var data struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid request data")
+	}
+
+	if data.Name == "" {
+		return s.sendError(sessionID, req.Action, "name is required")
+	}
+
+	content, ok := s.skillsMgr.GetSkillContent(data.Name)
+	if !ok {
+		return s.sendError(sessionID, req.Action, "skill not found")
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]interface{}{
+		"name":    data.Name,
+		"content": content,
+	})
 }

--- a/pkg/pet/skills/manager.go
+++ b/pkg/pet/skills/manager.go
@@ -1,0 +1,156 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/skills"
+)
+
+type PushHandler func(push Push)
+
+type Push struct {
+	Type      string      `json:"type"`
+	PushType  string      `json:"push_type"`
+	Data      interface{} `json:"data"`
+	Timestamp int64       `json:"timestamp"`
+}
+
+type Manager struct {
+	loader      *skills.SkillsLoader
+	registryMgr *skills.RegistryManager
+	installer   *skills.SkillInstaller
+	workspace   string
+	cfg         *config.Config
+	pushHandler PushHandler
+}
+
+func NewManager(cfg *config.Config) (*Manager, error) {
+	workspace := cfg.WorkspacePath()
+	globalDir := config.GetHome()
+	globalSkillsDir := filepath.Join(globalDir, "skills")
+
+	builtinDir := os.Getenv(config.EnvBuiltinSkills)
+	if builtinDir == "" {
+		wd, _ := os.Getwd()
+		builtinDir = filepath.Join(wd, "skills")
+	}
+
+	loader := skills.NewSkillsLoader(workspace, globalSkillsDir, builtinDir)
+
+	var registryMgr *skills.RegistryManager
+	if cfg != nil {
+		clawHubConfig := cfg.Tools.Skills.Registries.ClawHub
+		registryMgr = skills.NewRegistryManagerFromConfig(skills.RegistryConfig{
+			MaxConcurrentSearches: cfg.Tools.Skills.MaxConcurrentSearches,
+			ClawHub: skills.ClawHubConfig{
+				Enabled:         clawHubConfig.Enabled,
+				BaseURL:         clawHubConfig.BaseURL,
+				AuthToken:       clawHubConfig.AuthToken.String(),
+				SearchPath:      clawHubConfig.SearchPath,
+				SkillsPath:      clawHubConfig.SkillsPath,
+				DownloadPath:    clawHubConfig.DownloadPath,
+				Timeout:         clawHubConfig.Timeout,
+				MaxZipSize:      clawHubConfig.MaxZipSize,
+				MaxResponseSize: clawHubConfig.MaxResponseSize,
+			},
+		})
+	}
+
+	githubToken := ""
+	proxy := ""
+	if cfg != nil {
+		githubToken = cfg.Tools.Skills.Github.Token.String()
+		proxy = cfg.Tools.Skills.Github.Proxy
+	}
+	installer, err := skills.NewSkillInstaller(workspace, githubToken, proxy)
+	if err != nil {
+		logger.WarnCF("pet-skills", "failed to create skill installer", map[string]any{"error": err.Error()})
+	}
+
+	return &Manager{
+		loader:      loader,
+		registryMgr: registryMgr,
+		installer:   installer,
+		workspace:   workspace,
+		cfg:         cfg,
+	}, nil
+}
+
+func (m *Manager) ListSkills() []skills.SkillInfo {
+	return m.loader.ListSkills()
+}
+
+func (m *Manager) GetSkillContent(name string) (string, bool) {
+	return m.loader.LoadSkill(name)
+}
+
+func (m *Manager) SearchSkills(ctx context.Context, query string, limit int) ([]skills.SearchResult, error) {
+	if m.registryMgr == nil {
+		return nil, fmt.Errorf("registry manager not initialized")
+	}
+	return m.registryMgr.SearchAll(ctx, query, limit)
+}
+
+func (m *Manager) InstallSkill(ctx context.Context, slug, registry, version string) (*InstallResult, error) {
+	if m.registryMgr == nil {
+		return nil, fmt.Errorf("registry manager not initialized")
+	}
+
+	reg := m.registryMgr.GetRegistry(registry)
+	if reg == nil {
+		return nil, fmt.Errorf("registry %q not found", registry)
+	}
+
+	skillsRoot := filepath.Join(m.workspace, "skills")
+	targetDir := filepath.Join(skillsRoot, slug)
+
+	if _, err := os.Stat(targetDir); err == nil {
+		return nil, fmt.Errorf("skill %q already exists", slug)
+	}
+
+	if err := os.MkdirAll(skillsRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create skills directory: %w", err)
+	}
+
+	result, err := reg.DownloadAndInstall(ctx, slug, version, targetDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install skill: %w", err)
+	}
+
+	return result, nil
+}
+
+func (m *Manager) RemoveSkill(name string) error {
+	skills := m.loader.ListSkills()
+	for _, skill := range skills {
+		if skill.Name != name {
+			continue
+		}
+		if skill.Source != "workspace" {
+			return fmt.Errorf("only workspace skills can be deleted")
+		}
+		if err := os.RemoveAll(filepath.Dir(skill.Path)); err != nil {
+			return fmt.Errorf("failed to delete skill: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("skill %q not found", name)
+}
+
+func (m *Manager) GetRegistryManager() *skills.RegistryManager {
+	return m.registryMgr
+}
+
+func (m *Manager) GetInstaller() *skills.SkillInstaller {
+	return m.installer
+}
+
+type InstallResult = skills.InstallResult
+
+type SearchResult = skills.SearchResult
+type SkillInfo = skills.SkillInfo

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -46,6 +46,11 @@ const (
 	ActionVoiceModelUpdate     = "voice_model_update"      // 更新语音模型配置
 	ActionVoiceModelSetDefault = "voice_model_set_default" // 设置默认语音模型
 	ActionVoiceModelGetVoices  = "voice_model_get_voices"  // 获取供应商可用音色
+	ActionSkillList            = "skill_list"              // 列出 skills
+	ActionSkillSearch          = "skill_search"            // 搜索 skills
+	ActionSkillInstall         = "skill_install"           // 安装 skill
+	ActionSkillRemove          = "skill_remove"            // 删除 skill
+	ActionSkillGet             = "skill_get"               // 获取 skill 内容
 )
 
 // =============================================================================
@@ -271,6 +276,51 @@ type CronListResponse struct {
 type CronAddResponse struct {
 	JobID string `json:"job_id"` // 新创建的任务ID
 	Name  string `json:"name"`   // 任务名称
+}
+
+// =============================================================================
+// Skills 请求和响应定义
+// =============================================================================
+
+// SkillListRequest 列出 skills 请求数据
+type SkillListRequest struct {
+}
+
+// SkillSearchRequest 搜索 skills 请求数据
+type SkillSearchRequest struct {
+	Query string `json:"query"` // 搜索关键词
+	Limit int    `json:"limit"` // 返回条数限制
+}
+
+// SkillInstallRequest 安装 skill 请求数据
+type SkillInstallRequest struct {
+	Slug     string `json:"slug"`     // skill slug
+	Registry string `json:"registry"` // registry 名称
+	Version  string `json:"version"`  // 版本（可选）
+}
+
+// SkillRemoveRequest 删除 skill 请求数据
+type SkillRemoveRequest struct {
+	Name string `json:"name"` // skill 名称
+}
+
+// SkillGetRequest 获取 skill 内容请求数据
+type SkillGetRequest struct {
+	Name string `json:"name"` // skill 名称
+}
+
+// SkillInfo skill 信息
+type SkillInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Source      string `json:"source"`
+}
+
+// SkillDetailResponse skill 详情响应
+type SkillDetailResponse struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
 }
 
 // =============================================================================

--- a/pkg/pet/userprofile/manager.go
+++ b/pkg/pet/userprofile/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sipeed/picoclaw/pkg/pet/config"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +54,7 @@ func (m *Manager) profilePath() string {
 }
 
 func (m *Manager) statePath(charID string) string {
-	return filepath.Join(m.dataDir, charID, StateFileName)
+	return filepath.Join(m.dataDir, config.WorkspacePath, charID, StateFileName)
 }
 
 func (m *Manager) ensureUserDataDir() error {


### PR DESCRIPTION
# feat(pet): 新增 Skills 管理系统

## Summary

新增 Skills 管理系统，支持列出、搜索、安装、删除和获取 Skill 内容。

## Changes

| # | Commit | 文件 | 说明 |
|---|--------|------|------|
| 1 | feat(types): 新增 Skill action 常量和请求响应结构体 | `pkg/pet/types.go` | 5个常量+7个结构体 |
| 2 | feat(skills): 新增 PetSkillsManager 管理器 | `pkg/pet/skills/manager.go` | 新文件 |
| 3 | feat(service): PetService 新增 skills_mgr 字段和 handleSkill* 方法 | `pkg/pet/service.go` | 集成+5个handle方法 |
| 4 | fix(userprofile): 修复 statePath 路径问题 | `pkg/pet/userprofile/manager.go` | 路径修复 |
| 5 | docs(api): 更新 PET_CHANNEL_API 文档至 v2.8 | `docs/PET_CHANNEL_API.md` | API文档 |

## Changes Detail

### 1. feat(types): 新增 Skill action 常量和请求响应结构体
- `pkg/pet/types.go`:
  - 新增 Action 常量：`ActionSkillList`、`ActionSkillSearch`、`ActionSkillInstall`、`ActionSkillRemove`、`ActionSkillGet`
  - 新增请求结构体：`SkillListRequest`、`SkillSearchRequest`、`SkillInstallRequest`、`SkillRemoveRequest`、`SkillGetRequest`
  - 新增响应结构体：`SkillInfo`、`SkillDetailResponse`

### 2. feat(skills): 新增 PetSkillsManager 管理器
- `pkg/pet/skills/manager.go` (新文件):
  - `PushHandler`、`Push` 结构体
  - `Manager` 结构体：集成 skills 加载器、registry 管理器和安装器
  - `NewManager`: 创建管理器实例
  - `ListSkills`: 列出已安装的 skills
  - `SearchSkills`: 从 registry 搜索 skills
  - `InstallSkill`: 安装 skill 到 workspace
  - `RemoveSkill`: 删除 workspace skill
  - `GetSkillContent`: 获取 skill 完整内容

### 3. feat(service): PetService 新增 skills_mgr 字段和 handleSkill* 方法
- `pkg/pet/service.go`:
  - `PetService` 结构体新增 `skillsMgr` 字段
  - 重构初始化逻辑，区分 `homePath` 和 `workspacePath`
  - 新增 `handleSkillList`、`handleSkillSearch`、`handleSkillInstall`、`handleSkillRemove`、`handleSkillGet` 方法
  - `HandleRequest` 新增 `skill_*` action 处理

### 4. fix(userprofile): 修复 statePath 路径问题
- `pkg/pet/userprofile/manager.go`:
  - 修复 `statePath` 方法中多余的 `config.WorkspacePath`

### 5. docs(api): 更新 PET_CHANNEL_API 文档至 v2.8
- `docs/PET_CHANNEL_API.md`:
  - 版本号 v2.7 → v2.8
  - 新增 API 文档：
    - `skill_list` (4.27): 列出已安装的 Skills
    - `skill_search` (4.28): 搜索 Skills
    - `skill_install` (4.29): 安装 Skill
    - `skill_remove` (4.30): 删除 Skill
    - `skill_get` (4.31): 获取 Skill 内容

## Motivation

支持用户动态管理和使用 Skills，提升桌宠可扩展性。用户可以通过 API 列出、搜索、安装、删除和获取 Skill 内容。

## Test Plan

- [ ] `skill_list` 返回已安装 skills 列表（workspace/global/builtin 三种来源）
- [ ] `skill_search` 从 clawhub registry 搜索 skills
- [ ] `skill_install` 安装 skill 到 workspace
- [ ] `skill_remove` 删除 workspace skill（非 workspace 来源不可删除）
- [ ] `skill_get` 获取 skill 完整内容（SKILL.md）
