### PR TITLE
refactor(pet): unify PushType constants across channel and hooks

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -288,7 +288,7 @@ LLM 解析到动作标签时推送。
 
 ---
 
-### 3.7 audio_and_voice - 语音流式合成音频
+### 3.7 text_and_audio - 语音流式合成音频
 
 当 `voice_enabled` 启用时，AI 回复会触发语音流式合成。后端将文本按标点符号和 `[text:]` 标签分割成多个片段，异步合成音频后按顺序推送给前端播放。
 
@@ -297,7 +297,7 @@ LLM 解析到动作标签时推送。
 ```json
 {
   "type": "push",
-  "push_type": "audio_and_voice",
+  "push_type": "text_and_audio",
   "data": {
     "seq": 1,
     "text": "你好呀，很高兴见到你",
@@ -316,7 +316,7 @@ LLM 解析到动作标签时推送。
 ```json
 {
   "type": "push",
-  "push_type": "audio_and_voice",
+  "push_type": "text_and_audio",
   "data": {
     "seq": 2,
     "text": "你好",
@@ -335,7 +335,7 @@ LLM 解析到动作标签时推送。
 ```json
 {
   "type": "push",
-  "push_type": "audio_and_voice",
+  "push_type": "text_and_audio",
   "data": {
     "seq": 0,
     "text": "",
@@ -374,8 +374,8 @@ LLM 解析到动作标签时推送。
 **前端处理逻辑**：
 
 ```javascript
-// 接收 audio_and_voice 推送
-if (msg.push_type === 'audio_and_voice') {
+// 接收 text_and_audio 推送
+if (msg.push_type === 'text_and_audio') {
     const data = msg.data;
     
     if (data.is_final) {
@@ -2357,7 +2357,7 @@ async def send_chat(ws, text):
 | emotion_change | 情绪变化时 | 推送情绪状态更新 |
 | action_trigger | LLM 解析到动作时 | 推送动作触发 |
 | character_switch | 角色切换后 | 推送切换后的角色ID |
-| audio_and_voice | 语音流式合成 | 流式推送语音音频片段，按顺序播放 |
+| text_and_audio | 语音流式合成 | 流式推送语音音频片段，按顺序播放 |
 | heartbeat | 每 30 秒 | 保活检测 |
 
 ---

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -877,7 +877,7 @@ func (c *PetChannel) sendStreamChunk(sessionID string, chatID int64, contentType
 		if pc.sessionID == sessionID || sessionID == "broadcast" {
 			pc.writeJSON(PetStreamResponse{
 				Type:      "push",
-				PushType:  "ai_chat",
+				PushType:  pet.PushTypeAIChat,
 				Data:      dataBytes,
 				IsFinal:   isFinal,
 				Timestamp: time.Now().Unix(),
@@ -1191,7 +1191,7 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 			"error":    seg.Error,
 			"emotion":  "",
 		}
-		_ = s.channel.sendVoicePush(s.sessionID, "audio_and_voice", data)
+		_ = s.channel.sendVoicePush(s.sessionID, pet.PushTypeTextAndAudio, data)
 		return
 	}
 
@@ -1220,7 +1220,7 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 		"duration":  seg.Duration,
 	})
 
-	_ = s.channel.sendVoicePush(s.sessionID, "audio_and_voice", data)
+	_ = s.channel.sendVoicePush(s.sessionID, pet.PushTypeTextAndAudio, data)
 
 	logger.DebugCF("pet", "sent audio segment async", map[string]any{
 		"seq":      seg.Seq,

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -452,7 +452,7 @@ func (h *PetHook) pushActionTrigger(act *action.Action) {
 
 	h.petService.Push(Push{
 		Type:     "push",
-		PushType: "action_trigger",
+		PushType: PushTypeActionTrigger,
 		Data:     data,
 	})
 }
@@ -482,7 +482,7 @@ func (h *PetHook) pushEmotionChange(push emotion.EmotionPush) {
 
 	h.petService.Push(Push{
 		Type:     "push",
-		PushType: "emotion_change",
+		PushType: PushTypeEmotionChange,
 		Data:     data,
 	})
 }

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -67,6 +67,7 @@ const (
 	PushTypeHeartbeat       = "heartbeat"        // 心跳保活
 	PushTypeCharacterSwitch = "character_switch" // 角色切换
 	PushTypeAudio           = "audio"            // 音频播放
+	PushTypeTextAndAudio    = "text_and_audio"   // 文本和音频同时推送
 )
 
 // =============================================================================


### PR DESCRIPTION
# PR: 统一 pet 模块 PushType 常量

## 概述

将 `pet` 模块中硬编码的 push_type 字符串替换为统一的 `pet.PushType*` 常量，提升代码一致性和可维护性。

## 改动文件

### pkg/channels/pet/channel.go

| 行号 | 改动内容 |
|------|----------|
| 880 | `"ai_chat"` → `pet.PushTypeAIChat` |
| 1194 | `"audio_and_voice"` → `pet.PushTypeTextAndAudio` |
| 1223 | `"audio_and_voice"` → `pet.PushTypeTextAndAudio` |

### pkg/pet/hooks.go

| 行号 | 改动内容 |
|------|----------|
| 455 | `"action_trigger"` → `PushTypeActionTrigger` |
| 485 | `"emotion_change"` → `PushTypeEmotionChange` |

## PushType 常量定义 (pkg/pet/types.go)

| 常量 | 值 | 说明 |
|------|-----|------|
| `PushTypeAIChat` | `"ai_chat"` | AI 聊天回复 |
| `PushTypeEmotionChange` | `"emotion_change"` | 情绪变化 |
| `PushTypeActionTrigger` | `"action_trigger"` | 动作触发 |
| `PushTypeInitStatus` | `"init_status"` | 初始化状态 |
| `PushTypeHeartbeat` | `"heartbeat"` | 心跳保活 |
| `PushTypeCharacterSwitch` | `"character_switch"` | 角色切换 |
| `PushTypeAudio` | `"audio"` | 音频播放 |
| `PushTypeTextAndAudio` | `"text_and_audio"` | 文本和音频同时推送 |

## 影响范围

- WebSocket 推送类型统一
- 前端需适配新的 push_type 值（特别是 `text_and_audio` 替代 `audio_and_voice`）

## 测试建议

1. 连接桌面客户端验证心跳推送
2. 测试 AI 聊天推送类型
3. 测试情绪变化推送
4. 测试动作触发推送
5. 测试语音合成推送（text_and_audio）
6. 测试角色切换推送
