### PR TITLE
修复语音不播放bug

### DIFF
--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -22,6 +22,25 @@ interface BubbleData {
   animation?: string
   animationHints?: string[]
   audio?: string
+  audio_mime?: string
+}
+
+function normalizeAudioMimeType(mime?: string): string | null {
+  if (!mime) return null
+  const normalized = mime.trim().toLowerCase()
+  switch (normalized) {
+    case "audio/mp3":
+    case "audio/mpeg3":
+      return "audio/mpeg"
+    case "audio/mpeg":
+    case "audio/wav":
+    case "audio/x-wav":
+    case "audio/ogg":
+    case "audio/flac":
+      return normalized === "audio/x-wav" ? "audio/wav" : normalized
+    default:
+      return null
+  }
 }
 
 function decodeBase64Audio(value: string): Uint8Array | null {
@@ -177,6 +196,10 @@ export default function DesktopPetPage() {
       if (data.audio) {
         const rawAudio = data.audio.trim()
         const bytes = decodeBase64Audio(rawAudio)
+        const mimeType = normalizeAudioMimeType(data.audio_mime) || "audio/mpeg"
+        const byteHead = bytes
+          ? Array.from(bytes.slice(0, 12)).map((v) => v.toString(16).padStart(2, "0"))
+          : []
         let audioUrl = rawAudio
 
         if (audioObjectUrlRef.current) {
@@ -184,29 +207,86 @@ export default function DesktopPetPage() {
           audioObjectUrlRef.current = null
         }
 
-        if (bytes && bytes.length > 0) {
-          const blob = new Blob([bytes], { type: "audio/mpeg" })
-          audioUrl = URL.createObjectURL(blob)
-          audioObjectUrlRef.current = audioUrl
-        } else if (!audioUrl.startsWith("data:") && !audioUrl.startsWith("http")) {
-          audioUrl = `data:audio/mp3;base64,${audioUrl}`
+        if (!bytes || bytes.length === 0) {
+          console.error("[petclaw] desktop audio decode failed", {
+            mimeType,
+            audioLength: rawAudio.length,
+            audioPrefix: rawAudio.slice(0, 64),
+          })
+          setBubble("")
+          transitionTo("standby")
+          return
+        }
+
+        if (!audioUrl.startsWith("data:") && !audioUrl.startsWith("http")) {
+          audioUrl = `data:${mimeType};base64,${audioUrl}`
         }
 
         if (audioRef.current) {
           audioRef.current.pause()
         }
-        audioRef.current = new Audio(audioUrl)
-        audioRef.current.onerror = (errorEvent) => {
-          console.warn("[petclaw] desktop audio element error", errorEvent)
+        const rawCandidates = Array.from(
+          new Set([mimeType, "audio/mpeg", "audio/ogg", "audio/wav"]),
+        )
+        const probeAudio = document.createElement("audio")
+        const supportedCandidates = rawCandidates.filter(
+          (candidate) => probeAudio.canPlayType(candidate) !== "",
+        )
+        const mimeCandidates =
+          supportedCandidates.length > 0 ? supportedCandidates : rawCandidates
+
+        const tryPlayWithMime = (index: number) => {
+          if (index >= mimeCandidates.length) {
+            console.error("[petclaw] desktop exhausted audio mime candidates", {
+              mimeCandidates,
+              byteHead,
+              audioLength: rawAudio.length,
+            })
+            setBubble("")
+            transitionTo("standby")
+            return
+          }
+          const attemptMime = mimeCandidates[index]
+          const blob = new Blob([bytes], { type: attemptMime })
+          audioUrl = URL.createObjectURL(blob)
+          audioObjectUrlRef.current = audioUrl
+
+          const audio = new Audio(audioUrl)
+          audioRef.current = audio
+          audio.onended = () => {
+            setBubble("")
+            transitionTo("standby")
+          }
+          audio.onerror = (errorEvent) => {
+            const mediaError = audio.error
+            console.warn("[petclaw] desktop audio element error", {
+              errorEvent,
+              attemptMime,
+              mediaErrorCode: mediaError?.code,
+              mediaErrorMessage: mediaError?.message,
+              byteHead,
+            })
+            if (audioObjectUrlRef.current) {
+              URL.revokeObjectURL(audioObjectUrlRef.current)
+              audioObjectUrlRef.current = null
+            }
+            tryPlayWithMime(index + 1)
+          }
+          audio.play().catch((playbackError) => {
+            console.warn("[petclaw] desktop failed to play audio", {
+              playbackError,
+              attemptMime,
+              byteHead,
+            })
+            if (audioObjectUrlRef.current) {
+              URL.revokeObjectURL(audioObjectUrlRef.current)
+              audioObjectUrlRef.current = null
+            }
+            tryPlayWithMime(index + 1)
+          })
         }
-        audioRef.current.onended = () => {
-          setBubble("")
-          transitionTo("standby")
-        }
-        audioRef.current.play().catch((playbackError) => {
-          console.warn("[petclaw] desktop failed to play audio", playbackError)
-          setBubble("")
-        })
+
+        tryPlayWithMime(0)
       } else {
         bubbleTimerRef.current = setTimeout(() => {
           setBubble("")

--- a/clawpet-frontend/clawpet/electron/preload.js
+++ b/clawpet-frontend/clawpet/electron/preload.js
@@ -208,3 +208,44 @@ contextBridge.exposeInMainWorld('electronAPI', {
    */
   getStartupState: () => ipcRenderer.invoke('startup-state')
 });
+
+function serializeForMainLog(value) {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch {
+      return String(value);
+    }
+  }
+
+  return value;
+}
+
+const forwardedConsoleLevels = ['log', 'info', 'warn', 'error'];
+for (const level of forwardedConsoleLevels) {
+  const original = console[level];
+  if (typeof original !== 'function') {
+    continue;
+  }
+
+  console[level] = (...args) => {
+    try {
+      ipcRenderer.send('renderer-log', {
+        level,
+        args: args.map(serializeForMainLog),
+      });
+    } catch {
+      // Ignore forwarding failures and keep console behavior unchanged.
+    }
+
+    original.apply(console, args);
+  };
+}

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -57,6 +57,7 @@ interface AudioPushData {
   type?: string
   text?: string
   audio?: string
+  audio_mime?: string
   duration?: number
   seq?: number
   error?: string
@@ -68,7 +69,13 @@ interface AudioSegmentItem {
   seq: number
   text: string
   audioBase64: string
+  audioMime?: string
   durationMs: number
+}
+
+interface ResolvedAudioChunkPayload {
+  audioBase64: string
+  audioMime?: string
 }
 
 const EMPTY_SESSION_TITLE = "新对话"
@@ -271,6 +278,48 @@ function inferAudioMimeType(bytes: Uint8Array | null): string {
   return "audio/mpeg"
 }
 
+function normalizeAudioMimeType(mime?: string): string | undefined {
+  if (!mime) {
+    return undefined
+  }
+  const normalized = mime.trim().toLowerCase()
+  if (!normalized) {
+    return undefined
+  }
+  switch (normalized) {
+    case "audio/mp3":
+    case "audio/mpeg3":
+      return "audio/mpeg"
+    case "audio/mpeg":
+    case "audio/wav":
+    case "audio/x-wav":
+    case "audio/ogg":
+    case "audio/flac":
+      return normalized === "audio/x-wav" ? "audio/wav" : normalized
+    default:
+      return undefined
+  }
+}
+
+function parseDataAudioURL(value: string): { format: string; data: string } | null {
+  if (!value.startsWith("data:audio/")) {
+    return null
+  }
+  const payload = value.slice("data:audio/".length)
+  const commaIndex = payload.indexOf(",")
+  if (commaIndex < 0) {
+    return null
+  }
+  const meta = payload.slice(0, commaIndex).trim()
+  const data = payload.slice(commaIndex + 1).trim()
+  const semicolonIndex = meta.indexOf(";")
+  const format = (semicolonIndex >= 0 ? meta.slice(0, semicolonIndex) : meta).trim()
+  if (!format || !data) {
+    return null
+  }
+  return { format, data }
+}
+
 function isLikelyBase64Audio(value: string): boolean {
   const normalized = value.replace(/^data:audio\/[^;]+;base64,/, "").replace(/\s+/g, "")
   if (normalized.length < 64) {
@@ -282,17 +331,47 @@ function isLikelyBase64Audio(value: string): boolean {
   return /^[A-Za-z0-9+/=]+$/.test(normalized)
 }
 
-function resolveAudioChunkPayload(data: AudioPushData): string {
+function resolveAudioChunkPayload(data: AudioPushData): ResolvedAudioChunkPayload | null {
+  const explicitMime = normalizeAudioMimeType(data.audio_mime)
+
   if (typeof data.audio === "string" && data.audio.trim()) {
-    return data.audio
+    const audioValue = data.audio.trim()
+    const parsed = parseDataAudioURL(audioValue)
+    if (parsed) {
+      return {
+        audioBase64: parsed.data,
+        audioMime: explicitMime || normalizeAudioMimeType(`audio/${parsed.format}`),
+      }
+    }
+    return {
+      audioBase64: audioValue,
+      audioMime: explicitMime,
+    }
   }
-  if (data.type === "audio" && typeof data.text === "string") {
-    return data.text
+
+  if (data.type === "audio" && typeof data.text === "string" && data.text.trim()) {
+    const textValue = data.text.trim()
+    const parsed = parseDataAudioURL(textValue)
+    if (parsed) {
+      return {
+        audioBase64: parsed.data,
+        audioMime: explicitMime || normalizeAudioMimeType(`audio/${parsed.format}`),
+      }
+    }
+    return {
+      audioBase64: textValue,
+      audioMime: explicitMime,
+    }
   }
+
   if (typeof data.text === "string" && isLikelyBase64Audio(data.text)) {
-    return data.text
+    return {
+      audioBase64: data.text,
+      audioMime: explicitMime,
+    }
   }
-  return ""
+
+  return null
 }
 
 export function useChat(options: UseChatOptions = {}): UseChatResult {
@@ -451,6 +530,8 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     (
       audioBase64: string,
       bubbleText?: string | null,
+      audioMimeHint?: string,
+      seq?: number,
       durationMs?: number,
       onSettled?: () => void,
     ) => {
@@ -479,47 +560,118 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       }
 
       const decoded = decodeBase64Chunk(audioBase64)
-      const mimeType = inferAudioMimeType(decoded)
-      let audioUrl = `data:${mimeType};base64,${audioBase64}`
+      const mimeType = normalizeAudioMimeType(audioMimeHint) || inferAudioMimeType(decoded)
+      if (!decoded || decoded.length === 0) {
+        console.error("[petclaw] audio decode failed", {
+          seq,
+          mimeType,
+          base64Length: audioBase64.length,
+          audioPrefix: audioBase64.slice(0, 64),
+        })
+        onSettled?.()
+        return
+      }
+      const byteHead = Array.from(decoded.slice(0, 12)).map((v) =>
+        v.toString(16).padStart(2, "0"),
+      )
+      const rawCandidates = Array.from(
+        new Set(
+          [
+            normalizeAudioMimeType(audioMimeHint),
+            mimeType,
+            "audio/mpeg",
+            "audio/ogg",
+            "audio/wav",
+          ].filter((v): v is string => Boolean(v)),
+        ),
+      )
+      const probeAudio = document.createElement("audio")
+      const supportedCandidates = rawCandidates.filter(
+        (candidate) => probeAudio.canPlayType(candidate) !== "",
+      )
+      const mimeCandidates =
+        supportedCandidates.length > 0 ? supportedCandidates : rawCandidates
 
       if (currentAudioUrlRef.current) {
         URL.revokeObjectURL(currentAudioUrlRef.current)
         currentAudioUrlRef.current = null
       }
-
-      if (decoded && decoded.length > 0) {
-        const blob = new Blob([decoded], { type: mimeType })
-        audioUrl = URL.createObjectURL(blob)
-        currentAudioUrlRef.current = audioUrl
-      }
-
       if (currentAudioRef.current) {
         currentAudioRef.current.pause()
       }
-      currentAudioRef.current = new Audio(audioUrl)
-      currentAudioRef.current.onended = () => {
-        if (currentAudioUrlRef.current) {
-          URL.revokeObjectURL(currentAudioUrlRef.current)
-          currentAudioUrlRef.current = null
+
+      let settled = false
+      const settleOnce = () => {
+        if (!settled) {
+          settled = true
+          onSettled?.()
         }
-        onSettled?.()
       }
-      currentAudioRef.current.onerror = (errorEvent) => {
-        console.warn("[petclaw] audio element error", {
-          errorEvent,
-          mimeType,
-          base64Length: audioBase64.length,
+
+      const tryPlayWithMime = (index: number) => {
+        if (index >= mimeCandidates.length) {
+          console.error("[petclaw] exhausted audio mime candidates", {
+            seq,
+            mimeHint: audioMimeHint,
+            inferredMime: mimeType,
+            mimeCandidates,
+            base64Length: audioBase64.length,
+            byteHead,
+          })
+          settleOnce()
+          return
+        }
+
+        const attemptMime = mimeCandidates[index]
+        const blob = new Blob([decoded], { type: attemptMime })
+        const audioUrl = URL.createObjectURL(blob)
+        currentAudioUrlRef.current = audioUrl
+        const audio = new Audio(audioUrl)
+        currentAudioRef.current = audio
+
+        audio.onended = () => {
+          if (currentAudioUrlRef.current) {
+            URL.revokeObjectURL(currentAudioUrlRef.current)
+            currentAudioUrlRef.current = null
+          }
+          settleOnce()
+        }
+
+        audio.onerror = (errorEvent) => {
+          const mediaError = audio.error
+          console.warn("[petclaw] audio element error", {
+            errorEvent,
+            seq,
+            attemptMime,
+            base64Length: audioBase64.length,
+            mediaErrorCode: mediaError?.code,
+            mediaErrorMessage: mediaError?.message,
+            byteHead,
+          })
+          if (currentAudioUrlRef.current) {
+            URL.revokeObjectURL(currentAudioUrlRef.current)
+            currentAudioUrlRef.current = null
+          }
+          tryPlayWithMime(index + 1)
+        }
+
+        void audio.play().catch((playbackError) => {
+          console.warn("[petclaw] failed to play audio", {
+            playbackError,
+            seq,
+            attemptMime,
+            base64Length: audioBase64.length,
+            byteHead,
+          })
+          if (currentAudioUrlRef.current) {
+            URL.revokeObjectURL(currentAudioUrlRef.current)
+            currentAudioUrlRef.current = null
+          }
+          tryPlayWithMime(index + 1)
         })
-        onSettled?.()
       }
-      void currentAudioRef.current.play().catch((playbackError) => {
-        console.warn("[petclaw] failed to play audio", {
-          playbackError,
-          mimeType,
-          base64Length: audioBase64.length,
-        })
-        onSettled?.()
-      })
+
+      tryPlayWithMime(0)
     },
     [clearAudioAdvanceTimer, showBubble],
   )
@@ -565,6 +717,8 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     playAudioBase64(
       nextSegment.audioBase64,
       nextSegment.text || null,
+      nextSegment.audioMime,
+      nextSegment.seq,
       nextSegment.durationMs,
       () => {
         audioIsPlayingRef.current = false
@@ -707,8 +861,17 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
               chatId: incomingChatId,
               seq,
               text: typeof data.text === "string" ? data.text : "",
-              audioBase64: audioChunkPayload,
+              audioBase64: audioChunkPayload.audioBase64,
+              audioMime: audioChunkPayload.audioMime,
               durationMs,
+            })
+          } else {
+            console.warn("[petclaw] audio payload unresolved", {
+              seq,
+              type: data.type,
+              hasAudio: Boolean(typeof data.audio === "string" && data.audio.trim()),
+              hasText: Boolean(typeof data.text === "string" && data.text.trim()),
+              audioMime: data.audio_mime,
             })
           }
 

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -12,6 +12,7 @@ const CHAT_ACTION = "chat"
 const PUSH_TYPE_AI_CHAT = "ai_chat"
 const PUSH_TYPE_AUDIO = "audio"
 const PUSH_TYPE_AUDIO_AND_VOICE = "audio_and_voice"
+const PUSH_TYPE_TEXT_AND_AUDIO = "text_and_audio"
 const PUSH_TYPE_EMOTION_CHANGE = "emotion_change"
 const PUSH_TYPE_ACTION_TRIGGER = "action_trigger"
 
@@ -447,6 +448,7 @@ export class PicoClawWebSocket {
         break
       case PUSH_TYPE_AUDIO:
       case PUSH_TYPE_AUDIO_AND_VOICE:
+      case PUSH_TYPE_TEXT_AND_AUDIO:
         this.handleAudioPush(data, Boolean(push.is_final))
         break
       case PUSH_TYPE_EMOTION_CHANGE:

--- a/clawpet-frontend/clawpet/next.config.mjs
+++ b/clawpet-frontend/clawpet/next.config.mjs
@@ -15,6 +15,7 @@ const nextConfig = {
       "object-src 'none'",
       "frame-ancestors 'none'",
       "img-src 'self' data: blob:",
+      "media-src 'self' data: blob:",
       "font-src 'self' data:",
       "style-src 'self' 'unsafe-inline'",
       `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -49,6 +49,25 @@ func parsePureText(raw string) string {
 	return sb.String()
 }
 
+func inferAudioMimeFromBytes(raw []byte) string {
+	if len(raw) >= 3 && raw[0] == 0x49 && raw[1] == 0x44 && raw[2] == 0x33 {
+		return "audio/mpeg"
+	}
+	if len(raw) >= 2 && raw[0] == 0xFF && (raw[1]&0xE0) == 0xE0 {
+		return "audio/mpeg"
+	}
+	if len(raw) >= 4 && raw[0] == 0x52 && raw[1] == 0x49 && raw[2] == 0x46 && raw[3] == 0x46 {
+		return "audio/wav"
+	}
+	if len(raw) >= 4 && raw[0] == 0x4F && raw[1] == 0x67 && raw[2] == 0x67 && raw[3] == 0x53 {
+		return "audio/ogg"
+	}
+	if len(raw) >= 4 && raw[0] == 0x66 && raw[1] == 0x4C && raw[2] == 0x61 && raw[3] == 0x43 {
+		return "audio/flac"
+	}
+	return ""
+}
+
 func isLocalhostOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	if err != nil || u.Host == "" {
@@ -1182,20 +1201,47 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 			"error": seg.Error,
 		})
 		data := map[string]any{
-			"seq":      seg.Seq,
-			"text":     seg.Text,
-			"audio":    "",
-			"duration": 0,
-			"is_final": isFinal,
-			"error":    seg.Error,
-			"emotion":  "",
+			"seq":        seg.Seq,
+			"text":       seg.Text,
+			"audio":      "",
+			"audio_mime": "audio/mpeg",
+			"duration":   0,
+			"is_final":   isFinal,
+			"error":      seg.Error,
+			"emotion":    "",
 		}
 		_ = s.channel.sendVoicePush(s.sessionID, "audio_and_voice", data)
 		return
 	}
 
 	// Base64编码音频
+	if len(seg.AudioData) == 0 {
+		logger.WarnCF("pet", "sendAudioSegmentAsync: empty audio payload", map[string]any{
+			"seq":  seg.Seq,
+			"text": seg.Text,
+		})
+		data := map[string]any{
+			"seq":        seg.Seq,
+			"text":       seg.Text,
+			"audio":      "",
+			"audio_mime": "audio/mpeg",
+			"duration":   0,
+			"is_final":   isFinal,
+			"error":      "empty audio payload",
+			"emotion":    "",
+		}
+		_ = s.channel.sendVoicePush(s.sessionID, "audio_and_voice", data)
+		return
+	}
 	encoded := base64.StdEncoding.EncodeToString(seg.AudioData)
+	mimeType := inferAudioMimeFromBytes(seg.AudioData)
+	if mimeType == "" {
+		logger.WarnCF("pet", "sendAudioSegmentAsync: unknown audio signature", map[string]any{
+			"seq":         seg.Seq,
+			"audio_bytes": len(seg.AudioData),
+		})
+		mimeType = "audio/mpeg"
+	}
 
 	// 获取当前情绪
 	emotion := ""
@@ -1204,12 +1250,13 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 	}
 
 	data := map[string]any{
-		"seq":      seg.Seq,
-		"text":     seg.Text,
-		"audio":    encoded,
-		"duration": seg.Duration,
-		"is_final": isFinal,
-		"emotion":  emotion,
+		"seq":        seg.Seq,
+		"text":       seg.Text,
+		"audio":      encoded,
+		"audio_mime": mimeType,
+		"duration":   seg.Duration,
+		"is_final":   isFinal,
+		"emotion":    emotion,
 	}
 
 	logger.DebugCF("pet", "sendAudioSegmentAsync", map[string]any{

--- a/pkg/pet/voice/sender.go
+++ b/pkg/pet/voice/sender.go
@@ -6,32 +6,73 @@ import (
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
-// Sender 消息发送者
-// 负责将语音数据发送到客户端
+// Sender forwards synthesized voice payloads to clients.
 type Sender struct {
 	sendFunc func(sessionID string, pushType string, data any) error
 }
 
-// NewSender 创建Sender实例
-// sendFunc: 实际执行发送的回调函数
+func inferAudioMimeFromBytes(raw []byte) string {
+	if len(raw) >= 3 && raw[0] == 0x49 && raw[1] == 0x44 && raw[2] == 0x33 {
+		return "audio/mpeg"
+	}
+	if len(raw) >= 2 && raw[0] == 0xFF && (raw[1]&0xE0) == 0xE0 {
+		return "audio/mpeg"
+	}
+	if len(raw) >= 4 && raw[0] == 0x52 && raw[1] == 0x49 && raw[2] == 0x46 && raw[3] == 0x46 {
+		return "audio/wav"
+	}
+	if len(raw) >= 4 && raw[0] == 0x4F && raw[1] == 0x67 && raw[2] == 0x67 && raw[3] == 0x53 {
+		return "audio/ogg"
+	}
+	if len(raw) >= 4 && raw[0] == 0x66 && raw[1] == 0x4C && raw[2] == 0x61 && raw[3] == 0x43 {
+		return "audio/flac"
+	}
+	return ""
+}
+
+// NewSender creates a sender with a transport callback.
 func NewSender(sendFunc func(sessionID string, pushType string, data any) error) *Sender {
 	return &Sender{sendFunc: sendFunc}
 }
 
-// SendAudioChunk 发送音频块到客户端
-// 音频数据会被Base64编码后发送
+// SendAudioChunk serializes one audio chunk into WS push payload.
 func (s *Sender) SendAudioChunk(sessionID string, chatID int64, chunk AudioChunk) error {
 	if s.sendFunc == nil {
 		return nil
 	}
+	if len(chunk.Data) == 0 && !chunk.IsLast {
+		logger.WarnCF("pet-voice", "skip empty non-final audio chunk", map[string]any{
+			"session_id": sessionID,
+			"chat_id":    chatID,
+		})
+		return nil
+	}
 
 	encoded := base64.StdEncoding.EncodeToString(chunk.Data)
+	audioMime := inferAudioMimeFromBytes(chunk.Data)
+	if audioMime == "" {
+		audioMime = "audio/mpeg"
+	}
+	if chunk.Info != nil {
+		switch chunk.Info.Format {
+		case "wav":
+			audioMime = "audio/wav"
+		case "ogg", "opus":
+			audioMime = "audio/ogg"
+		case "flac":
+			audioMime = "audio/flac"
+		default:
+			audioMime = "audio/mpeg"
+		}
+	}
 
 	data := map[string]any{
-		"chat_id":  chatID,
-		"type":     "audio",
-		"text":     encoded,      // Base64编码音频
-		"is_final": chunk.IsLast, // 标记是否为最后一块
+		"chat_id":    chatID,
+		"type":       "audio",
+		"audio":      encoded, // Primary payload for newer clients.
+		"audio_mime": audioMime,
+		"text":       encoded, // Legacy clients still read audio from text.
+		"is_final":   chunk.IsLast,
 	}
 
 	if err := s.sendFunc(sessionID, "audio", data); err != nil {
@@ -54,7 +95,7 @@ func (s *Sender) SendAudioChunk(sessionID string, chatID int64, chunk AudioChunk
 	return nil
 }
 
-// SendError 发送错误信息到客户端
+// SendError pushes a voice-channel error payload.
 func (s *Sender) SendError(sessionID string, chatID int64, errMsg string) error {
 	if s.sendFunc == nil {
 		return nil


### PR DESCRIPTION
1. 复现问题  
前端能收到 `audio` base64，但播放时报错：`Refused to load media from 'blob:...' because it violates Content Security Policy ("default-src 'self'")`。

2. 定位根因  
语音播放用的是 `URL.createObjectURL(blob)`，而项目 CSP 只配了 `default-src/img-src`，没有允许媒体源 `blob:`，导致 `Audio` 元素被浏览器/Electron 拦截。

3. 修复 CSP  
在 [clawpet-frontend/clawpet/next.config.mjs](D:/opencode/clawpet/GoClaw/clawpet-frontend/clawpet/next.config.mjs) 的 CSP 增加：  
`media-src 'self' data: blob:`

4. 增强日志  
在 [clawpet-frontend/clawpet/electron/preload.js](D:/opencode/clawpet/GoClaw/clawpet-frontend/clawpet/electron/preload.js) 增加渲染进程 `console.log/info/warn/error` 转发到主进程 `renderer-log`，统一落盘到 `C:\Users\86159\.goclaw\logs.txt`，便于后续排查音频解码/格式问题。

5. 验证  
重启 Next + Electron 后再次播放语音，确认不再出现 CSP 拦截且音频可正常播放。