### PR TITLE
fix：桌宠气泡交互修复、聊天流式状态体验优化、配置页信息架构升级（含语音模型管理）

### DIFF
--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -23,6 +23,7 @@ interface BubbleData {
   animationHints?: string[]
   audio?: string
   audio_mime?: string
+  duration_ms?: number
 }
 
 function normalizeAudioMimeType(mime?: string): string | null {
@@ -322,12 +323,16 @@ export default function DesktopPetPage() {
 
         tryPlayWithMime(0)
       } else {
+        const hintedDuration = Number(data.duration_ms)
+        const fallbackMs = Number.isFinite(hintedDuration) && hintedDuration > 0
+          ? Math.min(Math.max(hintedDuration + 300, 1200), 20000)
+          : 10000
         bubbleTimerRef.current = setTimeout(() => {
           if (bubbleId === currentAudioIdRef.current) {
             setBubble("")
             transitionTo("standby")
           }
-        }, 10000)
+        }, fallbackMs)
       }
 }
 

--- a/clawpet-frontend/clawpet/components/chat-area.tsx
+++ b/clawpet-frontend/clawpet/components/chat-area.tsx
@@ -161,7 +161,19 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
                 )}
 
                 <div className="mt-4 space-y-4">
-                  {messages.map((msg) => (
+                  {(() => {
+                    let lastAssistantIndex = -1
+                    for (let i = messages.length - 1; i >= 0; i -= 1) {
+                      if (messages[i]?.role === "assistant") {
+                        lastAssistantIndex = i
+                        break
+                      }
+                    }
+
+                    return messages.map((msg, index) => {
+                      const isLastAssistant =
+                        msg.role === "assistant" && lastAssistantIndex === index
+                      return (
                     <div
                       key={msg.id}
                       className={cn(
@@ -180,29 +192,22 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
                         <p className="whitespace-pre-wrap leading-7">
                           {msg.content}
                         </p>
-                        {msg.streaming && (
-                          <span className="ml-1 inline-block h-4 w-2 animate-pulse bg-current align-middle" />
+                        {isLastAssistant && msg.streaming && isTyping && (
+                          <div className="mt-1 text-xs text-[#7a5a3d]/70">思考中</div>
                         )}
                       </div>
                     </div>
-                  ))}
+                      )
+                    })
+                  })()}
 
                   {isTyping && !messages.some((msg) => msg.streaming) && (
                     <div className="flex justify-start">
                       <div className="rounded-[1.4rem] border border-white/75 bg-white/82 px-4 py-3 shadow-sm">
-                        <div className="flex items-center gap-1.5">
-                          <span
-                            className="h-2 w-2 rounded-full bg-[#d08a3a] animate-bounce"
-                            style={{ animationDelay: "0ms" }}
-                          />
-                          <span
-                            className="h-2 w-2 rounded-full bg-[#d08a3a] animate-bounce"
-                            style={{ animationDelay: "150ms" }}
-                          />
-                          <span
-                            className="h-2 w-2 rounded-full bg-[#d08a3a] animate-bounce"
-                            style={{ animationDelay: "300ms" }}
-                          />
+                        <div className="relative h-3 w-3">
+                          <span className="absolute inset-0 rounded-full bg-[#d08a3a]/25 animate-ping" />
+                          <span className="absolute inset-0 rounded-full bg-[#d08a3a]/20 animate-ping [animation-delay:600ms]" />
+                          <span className="absolute inset-[2px] rounded-full bg-[#d08a3a]" />
                         </div>
                       </div>
                     </div>

--- a/clawpet-frontend/clawpet/components/config-page.tsx
+++ b/clawpet-frontend/clawpet/components/config-page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   AlertTriangle,
   Code,
   Cpu,
   Eye,
-  Globe,
+  Mic,
   RotateCcw,
   Save,
   Settings,
@@ -28,10 +28,12 @@ import {
   getWebSocketInstance,
   type CharacterProfileData,
   type Config,
+  type VoiceModelData,
 } from "@/lib/api"
 import { openOnboardingPopup } from "@/lib/onboarding"
 import { cn } from "@/lib/utils"
 import { ModelsPanel } from "./models-panel"
+import { VoiceModelsPanel } from "./voice-models-panel"
 
 type ConfigTab = "visual" | "raw"
 
@@ -54,6 +56,12 @@ interface PersonalityFormState {
   emotionEnabled: boolean
 }
 
+interface VoiceConfigState {
+  voiceEnabled: boolean
+  asrEnabled: boolean
+  defaultVoiceModel: string
+}
+
 const emptyPersonalityForm: PersonalityFormState = {
   petId: "",
   petName: "",
@@ -71,6 +79,12 @@ const emptyFormState: ConfigFormState = {
   cronEnabled: true,
   publicAccess: false,
   port: 18790,
+}
+
+const emptyVoiceState: VoiceConfigState = {
+  voiceEnabled: false,
+  asrEnabled: false,
+  defaultVoiceModel: "",
 }
 
 function getErrorMessage(error: unknown): string {
@@ -115,6 +129,7 @@ export function ConfigPage() {
   const [rawJson, setRawJson] = useState("")
   const [hasChanges, setHasChanges] = useState(false)
   const [showModelsPanel, setShowModelsPanel] = useState(false)
+  const [showVoiceModelsPanel, setShowVoiceModelsPanel] = useState(false)
   const [actionState, setActionState] = useState<{
     type: "error" | "success"
     message: string
@@ -135,6 +150,13 @@ export function ConfigPage() {
   const [personalityLoading, setPersonalityLoading] = useState(false)
   const [personalitySaving, setPersonalitySaving] = useState(false)
   const [personalityState, setPersonalityState] = useState<{
+    type: "error" | "success"
+    message: string
+  } | null>(null)
+  const [voiceModels, setVoiceModels] = useState<VoiceModelData[]>([])
+  const [voiceConfig, setVoiceConfig] = useState<VoiceConfigState>(emptyVoiceState)
+  const [voiceLoading, setVoiceLoading] = useState(false)
+  const [voiceState, setVoiceState] = useState<{
     type: "error" | "success"
     message: string
   } | null>(null)
@@ -193,6 +215,47 @@ export function ConfigPage() {
     }
   }, [])
 
+  const loadVoiceConfig = useCallback(async () => {
+    setVoiceLoading(true)
+    setVoiceState(null)
+    try {
+      const ws = getWebSocketInstance()
+      const [voiceResp, petConfigResp] = await Promise.all([
+        ws.getVoiceModelList(),
+        ws.getPetConfig(),
+      ])
+
+      const models = voiceResp.data?.models ?? []
+      const defaultVoiceModel =
+        voiceResp.data?.default ||
+        models.find((item) => item.is_default)?.name ||
+        models[0]?.name ||
+        ""
+
+      setVoiceModels(models)
+
+      setVoiceConfig({
+        ...emptyVoiceState,
+        voiceEnabled: Boolean(petConfigResp.data?.voice_enabled),
+        asrEnabled: Boolean(
+          (petConfigResp.data as { asr_enabled?: boolean } | undefined)?.asr_enabled,
+        ),
+        defaultVoiceModel,
+      })
+    } catch (loadError) {
+      setVoiceState({
+        type: "error",
+        message: `加载语音配置失败：${getErrorMessage(loadError)}`,
+      })
+    } finally {
+      setVoiceLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadVoiceConfig()
+  }, [loadVoiceConfig])
+
   const gatewaySummary = useMemo(() => {
     if (!gatewayStatus) {
       return {
@@ -249,6 +312,16 @@ export function ConfigPage() {
     }))
     setPersonalityDirty(true)
     setPersonalityState(null)
+  }
+
+  function handleVoiceConfigChange(
+    field: keyof VoiceConfigState,
+    value: string | boolean,
+  ) {
+    setVoiceConfig((prev) => ({ ...prev, [field]: value }))
+    setHasChanges(true)
+    setActionState(null)
+    setVoiceState(null)
   }
 
   async function handleSavePersonality() {
@@ -336,6 +409,16 @@ export function ConfigPage() {
             publicAccess: formData.publicAccess,
           },
         })
+
+        const ws = getWebSocketInstance()
+        await ws.updatePetConfig({
+          voice_enabled: voiceConfig.voiceEnabled,
+          asr_enabled: voiceConfig.asrEnabled,
+        })
+
+        if (voiceConfig.defaultVoiceModel) {
+          await ws.setDefaultVoiceModel(voiceConfig.defaultVoiceModel)
+        }
       }
 
       const refreshed = await mutate()
@@ -371,15 +454,9 @@ export function ConfigPage() {
     },
     {
       icon: Shield,
-      title: "自动化闸门",
-      description: "控制命令执行和定时任务权限，决定桌宠能做多深。",
+      title: "运行边界",
+      description: "统一管理命令、定时任务、端口与局域网接入边界。",
       shell: "from-violet-100 via-purple-50 to-white border-violet-200/80",
-    },
-    {
-      icon: Globe,
-      title: "启动器表面",
-      description: "管理端口、可见性以及其他设备如何接入桌宠。",
-      shell: "from-sky-100 via-cyan-50 to-white border-sky-200/80",
     },
   ]
 
@@ -402,7 +479,7 @@ export function ConfigPage() {
                 调校桌宠的行为与边界
               </h1>
               <p className="mt-3 max-w-3xl text-base leading-8 text-[#816451]">
-                这里不再是普通后台表单，而是桌宠的控制舱。模型、自动化闸门和启动器表面都在同一套驾驶台里完成。
+                这里不再是普通后台表单，而是桌宠的控制舱。模型、语音与运行边界都在同一套驾驶台里完成。
               </p>
             </div>
 
@@ -431,7 +508,7 @@ export function ConfigPage() {
             </div>
           </div>
 
-          <div className="mt-8 grid gap-3 md:grid-cols-3">
+          <div className="mt-8 grid gap-3 md:grid-cols-2">
             {visualCards.map((card) => {
               const Icon = card.icon
               return (
@@ -572,17 +649,118 @@ export function ConfigPage() {
                     已移除默认模型与系统提示词编辑入口。请在模型管理中统一配置可用模型。
                   </div>
                 </div>
+
+                <div className="mt-4 rounded-[1.4rem] border border-white/75 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(255,247,238,0.82))] p-4 shadow-sm">
+                  <div className="flex items-center gap-2">
+                    <Mic className="h-4.5 w-4.5 text-amber-600" />
+                    <p className="text-sm font-semibold text-[#4f3725]">语音中枢</p>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-[#816451]">
+                    配置桌宠如何开口（TTS）与如何听懂你（ASR/STT）。
+                  </p>
+
+                  {voiceState && (
+                    <div
+                      className={cn(
+                        "mt-3 rounded-[1rem] border px-3 py-2 text-xs",
+                        voiceState.type === "error"
+                          ? "border-rose-200 bg-rose-50 text-rose-700"
+                          : "border-emerald-200 bg-emerald-50 text-emerald-700",
+                      )}
+                    >
+                      {voiceState.message}
+                    </div>
+                  )}
+
+                  {voiceLoading ? (
+                    <div className="mt-4 flex items-center gap-2 text-xs text-[#816451]">
+                      <Spinner className="h-3.5 w-3.5 text-amber-600" />
+                      正在加载语音配置...
+                    </div>
+                  ) : (
+                    <div className="mt-4 space-y-3">
+                      <div className="dashboard-card flex items-center justify-between gap-4 rounded-[1rem] border border-white/80 bg-white/82 px-3 py-3">
+                        <div>
+                          <p className="text-sm font-semibold text-[#4f3725]">TTS（文字转语音）</p>
+                          <p className="mt-1 text-xs text-[#816451]">控制桌宠是否播报语音回复。</p>
+                        </div>
+                        <button
+                          type="button"
+                          aria-pressed={voiceConfig.voiceEnabled}
+                          onClick={() =>
+                            handleVoiceConfigChange("voiceEnabled", !voiceConfig.voiceEnabled)
+                          }
+                          className={cn(
+                            "relative h-7 w-14 rounded-full transition",
+                            voiceConfig.voiceEnabled ? "bg-emerald-500" : "bg-[#e7ddd3]",
+                          )}
+                          title="TTS 开关"
+                        >
+                          <span
+                            className={cn(
+                              "absolute left-1 top-1 h-5 w-5 rounded-full bg-white transition-transform",
+                              voiceConfig.voiceEnabled ? "translate-x-7" : "translate-x-0",
+                            )}
+                          />
+                        </button>
+                      </div>
+
+                      <div className="dashboard-card rounded-[1rem] border border-white/80 bg-white/82 px-3 py-3">
+                        <p className="text-sm font-semibold text-[#4f3725]">默认语音模型</p>
+                        <p className="mt-1 text-xs text-[#816451]">
+                          {voiceConfig.defaultVoiceModel || "未设置默认模型"}
+                        </p>
+                        <p className="mt-1 text-xs text-[#9b7b62]">
+                          可用模型：{voiceModels.length} 个
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => setShowVoiceModelsPanel(true)}
+                          className="mt-3 rounded-[1rem] border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700 transition hover:bg-amber-100"
+                        >
+                          管理语音模型
+                        </button>
+                      </div>
+
+                      <div className="dashboard-card flex items-center justify-between gap-4 rounded-[1rem] border border-white/80 bg-white/82 px-3 py-3">
+                        <div>
+                          <p className="text-sm font-semibold text-[#4f3725]">ASR / STT（语音转文字）</p>
+                          <p className="mt-1 text-xs text-[#816451]">控制桌宠是否启用语音识别输入。</p>
+                        </div>
+                        <button
+                          type="button"
+                          aria-pressed={voiceConfig.asrEnabled}
+                          onClick={() =>
+                            handleVoiceConfigChange("asrEnabled", !voiceConfig.asrEnabled)
+                          }
+                          className={cn(
+                            "relative h-7 w-14 rounded-full transition",
+                            voiceConfig.asrEnabled ? "bg-emerald-500" : "bg-[#e7ddd3]",
+                          )}
+                          title="ASR 开关"
+                        >
+                          <span
+                            className={cn(
+                              "absolute left-1 top-1 h-5 w-5 rounded-full bg-white transition-transform",
+                              voiceConfig.asrEnabled ? "translate-x-7" : "translate-x-0",
+                            )}
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </article>
 
               <article className="dashboard-enter dashboard-card rounded-[1.8rem] border border-white/75 bg-[linear-gradient(145deg,rgba(255,252,247,0.94),rgba(255,247,242,0.88))] p-5 shadow-[0_20px_42px_-32px_rgba(116,80,42,0.34)]">
                 <div className="flex items-center gap-2">
                   <Shield className="h-5 w-5 text-violet-600" />
                   <h2 className="text-xl font-semibold text-[#4f3725]">
-                    自动化闸门
+                    运行边界
                   </h2>
                 </div>
                 <p className="mt-2 text-sm leading-6 text-[#816451]">
-                  决定桌宠能否运行命令，以及是否允许它使用定时自动化。
+                  统一管理命令执行、自动化任务与启动器接入边界。
                 </p>
 
                 <div className="mt-5 space-y-4">
@@ -635,21 +813,7 @@ export function ConfigPage() {
                       </button>
                     </div>
                   ))}
-                </div>
-              </article>
 
-              <article className="dashboard-enter dashboard-card rounded-[1.8rem] border border-white/75 bg-[linear-gradient(145deg,rgba(255,252,247,0.94),rgba(255,247,242,0.88))] p-5 shadow-[0_20px_42px_-32px_rgba(116,80,42,0.34)]">
-                <div className="flex items-center gap-2">
-                  <Globe className="h-5 w-5 text-sky-600" />
-                  <h2 className="text-xl font-semibold text-[#4f3725]">
-                    启动器表面
-                  </h2>
-                </div>
-                <p className="mt-2 text-sm leading-6 text-[#816451]">
-                  管理启动器端口，以及是否允许其他设备访问这个桌宠入口。
-                </p>
-
-                <div className="mt-5 space-y-4">
                   <div>
                     <label className="mb-1.5 block text-sm font-medium text-[#5d4430]">
                       端口
@@ -669,9 +833,7 @@ export function ConfigPage() {
 
                   <div className="dashboard-card flex items-center justify-between gap-4 rounded-[1.2rem] border border-white/80 bg-white/82 px-4 py-4">
                     <div>
-                      <p className="text-sm font-semibold text-[#4f3725]">
-                        局域网访问
-                      </p>
+                      <p className="text-sm font-semibold text-[#4f3725]">局域网访问</p>
                       <p className="mt-1 text-xs leading-5 text-[#816451]">
                         允许同一网络内的其他设备访问这个启动器。
                       </p>
@@ -684,18 +846,14 @@ export function ConfigPage() {
                       }
                       className={cn(
                         "relative h-7 w-14 rounded-full transition",
-                        formData.publicAccess
-                          ? "bg-emerald-500"
-                          : "bg-[#e7ddd3]",
+                        formData.publicAccess ? "bg-emerald-500" : "bg-[#e7ddd3]",
                       )}
                       title="局域网访问"
                     >
                       <span
                         className={cn(
                           "absolute left-1 top-1 h-5 w-5 rounded-full bg-white transition-transform",
-                          formData.publicAccess
-                            ? "translate-x-7"
-                            : "translate-x-0",
+                          formData.publicAccess ? "translate-x-7" : "translate-x-0",
                         )}
                       />
                     </button>
@@ -944,6 +1102,16 @@ export function ConfigPage() {
 
       {showModelsPanel && (
         <ModelsPanel onClose={() => setShowModelsPanel(false)} onDefaultModelChange={handleDefaultModelChange} />
+      )}
+
+      {showVoiceModelsPanel && (
+        <VoiceModelsPanel
+          onClose={() => setShowVoiceModelsPanel(false)}
+          onChanged={() => {
+            void loadVoiceConfig()
+            setHasChanges(true)
+          }}
+        />
       )}
     </section>
   )

--- a/clawpet-frontend/clawpet/components/voice-models-panel.tsx
+++ b/clawpet-frontend/clawpet/components/voice-models-panel.tsx
@@ -1,0 +1,425 @@
+import { useCallback, useEffect, useState, type ChangeEvent, type FormEvent } from "react"
+
+import { getWebSocketInstance, type VoiceModelData, type VoiceModelListData } from "@/lib/api"
+
+interface VoiceModelsPanelProps {
+  onClose: () => void
+  onChanged?: () => void
+}
+
+interface VoiceModelFormState {
+  name: string
+  provider: string
+  api_base: string
+  model: string
+  voice_id: string
+  api_key: string
+  enabled: boolean
+}
+
+const emptyVoiceModelForm: VoiceModelFormState = {
+  name: "",
+  provider: "minimax",
+  api_base: "",
+  model: "",
+  voice_id: "",
+  api_key: "",
+  enabled: true,
+}
+
+export function VoiceModelsPanel({ onClose, onChanged }: VoiceModelsPanelProps) {
+  const [models, setModels] = useState<VoiceModelData[]>([])
+  const [defaultModel, setDefaultModel] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [addingModel, setAddingModel] = useState(false)
+  const [editingModel, setEditingModel] = useState<VoiceModelData | null>(null)
+
+  const fetchModels = useCallback(async () => {
+    try {
+      const ws = getWebSocketInstance()
+      const resp = await ws.getVoiceModelList()
+      const data = resp.data as VoiceModelListData | undefined
+      const list = data?.models ?? []
+      const defaultName = data?.default || list.find((item) => item.is_default)?.name || ""
+      setDefaultModel(defaultName)
+      setModels(
+        [...list].sort((a, b) => {
+          if (a.name === defaultName && b.name !== defaultName) return -1
+          if (a.name !== defaultName && b.name === defaultName) return 1
+          return a.name.localeCompare(b.name)
+        }),
+      )
+      setError(null)
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "加载语音模型失败")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchModels()
+  }, [fetchModels])
+
+  const handleSetDefault = async (modelName: string) => {
+    if (modelName === defaultModel) {
+      return
+    }
+    try {
+      const ws = getWebSocketInstance()
+      await ws.setDefaultVoiceModel(modelName)
+      await fetchModels()
+      onChanged?.()
+    } catch (setDefaultError) {
+      setError(setDefaultError instanceof Error ? setDefaultError.message : "设置默认语音模型失败")
+    }
+  }
+
+  const handleModelSaved = async () => {
+    setAddingModel(false)
+    setEditingModel(null)
+    await fetchModels()
+    onChanged?.()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 backdrop-blur-[1px]">
+      <div className="w-full max-w-3xl max-h-[84vh] overflow-hidden rounded-[1.2rem] border border-white/80 bg-[linear-gradient(145deg,rgba(255,250,245,0.98),rgba(255,244,236,0.95))] shadow-[0_24px_50px_-28px_rgba(110,75,42,0.45)]">
+        <div className="flex items-center justify-between border-b border-white/80 px-5 py-4">
+          <h2 className="text-4 font-semibold text-[#3c2a1f]">语音模型管理</h2>
+          <button onClick={onClose} className="text-[#8b6a4d] transition hover:text-[#3c2a1f]">
+            ✕
+          </button>
+        </div>
+
+        <div className="max-h-[58vh] overflow-y-auto p-4">
+          {loading ? (
+            <div className="py-8 text-center text-[#7a5f49]">加载中...</div>
+          ) : (
+            <>
+              {error && (
+                <div className="mb-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                  {error}
+                </div>
+              )}
+              {notice && (
+                <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                  {notice}
+                </div>
+              )}
+
+              <div className="space-y-3">
+                {models.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-[#d7c7b8] bg-[#f7ede5] px-4 py-8 text-center text-sm text-[#7a5f49]">
+                    暂无语音模型，请添加
+                  </div>
+                ) : (
+                  models.map((model) => (
+                    <div key={model.name} className="rounded-[1rem] border border-white/80 bg-white/82 px-4 py-4 shadow-sm">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            {model.name === defaultModel && <span title="默认模型">⭐</span>}
+                            <p className="truncate text-2xl font-semibold text-[#3d2a1f]">{model.name}</p>
+                          </div>
+                          <p className="mt-1 truncate text-sm text-[#6f5642]">
+                            {model.provider}/{model.model}
+                          </p>
+                          <p className="mt-2 text-sm text-[#6f5642]">
+                            API: {model.api_base || "未配置"} · {model.enabled ? "已启用" : "已停用"}
+                          </p>
+                        </div>
+
+                        <div className="flex shrink-0 items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setNotice(null)
+                              setEditingModel(model)
+                            }}
+                            className="rounded-[0.7rem] bg-[#ebe4de] px-3 py-2 text-sm text-[#3d2a1f] transition hover:bg-[#e2d7ce]"
+                          >
+                            编辑
+                          </button>
+                          {model.name !== defaultModel && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setNotice(null)
+                                void handleSetDefault(model.name)
+                              }}
+                              className="rounded-[0.7rem] bg-[#ebe4de] px-3 py-2 text-sm text-[#3d2a1f] transition hover:bg-[#e2d7ce]"
+                            >
+                              设为默认
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => setNotice("删除语音模型暂不可用，后续版本开放。")}
+                            className="rounded-[0.7rem] bg-rose-100 px-3 py-2 text-sm text-rose-600 transition hover:bg-rose-200"
+                          >
+                            删除
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-white/80 px-5 py-4">
+          <button
+            type="button"
+            onClick={() => {
+              setNotice(null)
+              setAddingModel(true)
+            }}
+            className="rounded-[0.8rem] bg-[#ea6b2d] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#dd5e20]"
+          >
+            添加模型
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-[0.8rem] bg-[#e8e2dc] px-4 py-2 text-sm font-medium text-[#3d2a1f] transition hover:bg-[#ddd4cb]"
+          >
+            关闭
+          </button>
+        </div>
+
+        {addingModel && (
+          <VoiceModelDialog
+            title="添加语音模型"
+            initial={emptyVoiceModelForm}
+            existingNames={models.map((item) => item.name)}
+            onClose={() => setAddingModel(false)}
+            onSaved={handleModelSaved}
+          />
+        )}
+
+        {editingModel && (
+          <VoiceModelDialog
+            title={`编辑语音模型: ${editingModel.name}`}
+            initial={{
+              name: editingModel.name,
+              provider: editingModel.provider,
+              api_base: editingModel.api_base,
+              model: editingModel.model,
+              voice_id: editingModel.voice_id,
+              api_key: "",
+              enabled: editingModel.enabled,
+            }}
+            editing
+            existingNames={models.map((item) => item.name)}
+            onClose={() => setEditingModel(null)}
+            onSaved={handleModelSaved}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface VoiceModelDialogProps {
+  title: string
+  initial: VoiceModelFormState
+  existingNames: string[]
+  editing?: boolean
+  onClose: () => void
+  onSaved: () => void
+}
+
+function VoiceModelDialog({
+  title,
+  initial,
+  existingNames,
+  editing = false,
+  onClose,
+  onSaved,
+}: VoiceModelDialogProps) {
+  const [form, setForm] = useState<VoiceModelFormState>(initial)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleChange = (
+    key: keyof VoiceModelFormState,
+    value: string | boolean,
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+    setError(null)
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!form.name.trim() || !form.provider.trim() || !form.model.trim()) {
+      setError("模型名称、供应商、模型 ID 为必填项")
+      return
+    }
+
+    const normalizedName = form.name.trim()
+    if (!editing && existingNames.includes(normalizedName)) {
+      setError("模型名称已存在")
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      const ws = getWebSocketInstance()
+      await ws.updateVoiceModel({
+        name: normalizedName,
+        api_base: form.api_base.trim() || undefined,
+        model: form.model.trim(),
+        voice_id: form.voice_id.trim() || undefined,
+        api_key: form.api_key.trim() || undefined,
+        enabled: form.enabled,
+        extra: {
+          provider: form.provider.trim(),
+        },
+      })
+      onSaved()
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "保存语音模型失败")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-xl rounded-[1rem] border border-white/80 bg-[linear-gradient(145deg,rgba(255,249,243,0.98),rgba(255,241,231,0.95))] shadow-[0_24px_50px_-30px_rgba(110,75,42,0.45)]">
+        <div className="border-b border-white/80 px-5 py-4">
+          <h3 className="text-lg font-semibold text-[#3d2a1f]">{title}</h3>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 p-5">
+          {error && (
+            <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+              {error}
+            </div>
+          )}
+
+          <label className="block text-sm text-[#5c4331]">
+            模型名称 *
+            <input
+              type="text"
+              value={form.name}
+              disabled={editing}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("name", event.target.value)
+              }
+              placeholder="如：minimax"
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300 disabled:cursor-not-allowed disabled:bg-[#f0e8df]"
+            />
+          </label>
+
+          <label className="block text-sm text-[#5c4331]">
+            供应商 *
+            <input
+              type="text"
+              list="voice-provider-suggestions"
+              value={form.provider}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("provider", event.target.value)
+              }
+              placeholder="如：minimax / doubao / volcengine"
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300"
+            />
+            <datalist id="voice-provider-suggestions">
+              <option value="minimax" />
+              <option value="doubao" />
+              <option value="volcengine" />
+              <option value="custom" />
+            </datalist>
+            <p className="mt-1 text-xs text-[#8a6a52]">可自由输入未预置的供应商标识。</p>
+          </label>
+
+          <label className="block text-sm text-[#5c4331]">
+            模型 ID *
+            <input
+              type="text"
+              value={form.model}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("model", event.target.value)
+              }
+              placeholder="如：speech-2.8-hd"
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300"
+            />
+          </label>
+
+          <label className="block text-sm text-[#5c4331]">
+            API 地址
+            <input
+              type="text"
+              value={form.api_base}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("api_base", event.target.value)
+              }
+              placeholder="如：https://api.minimaxi.com/v1/t2a_v2"
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300"
+            />
+          </label>
+
+          <label className="block text-sm text-[#5c4331]">
+            API Key
+            <input
+              type="password"
+              value={form.api_key}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("api_key", event.target.value)
+              }
+              placeholder="sk-..."
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300"
+            />
+          </label>
+
+          <label className="block text-sm text-[#5c4331]">
+            音色 ID
+            <input
+              type="text"
+              value={form.voice_id}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("voice_id", event.target.value)
+              }
+              placeholder="如：danya_xuejie"
+              className="mt-1 w-full rounded border border-[#dbcbbd] bg-white px-3 py-2 text-sm text-[#3d2a1f] outline-none focus:border-amber-300"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-sm text-[#5c4331]">
+            <input
+              type="checkbox"
+              checked={form.enabled}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                handleChange("enabled", event.target.checked)
+              }
+            />
+            启用该语音模型
+          </label>
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-[0.8rem] bg-[#e8e2dc] px-4 py-2 text-sm text-[#3d2a1f] transition hover:bg-[#ddd4cb]"
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-[0.8rem] bg-[#ea6b2d] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#dd5e20] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving ? "保存中..." : "保存"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -526,6 +526,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       text,
       emotion: lastEmotionRef.current,
       audio,
+      duration_ms: durationMs,
     })
   }, [])
 
@@ -597,7 +598,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       if (window.electronAPI?.showBubble) {
         // Keep bubble text sync, but always play audio via HTMLAudio to ensure
         // deterministic ordered playback in chat runtime.
-        showBubble(bubbleText ?? (lastAssistantTextRef.current || null))
+        showBubble(bubbleText ?? (lastAssistantTextRef.current || null), undefined, durationMs)
       }
 
       const decoded = decodeBase64Chunk(audioBase64)
@@ -825,17 +826,45 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
   useEffect(() => {
     const ws = wsRef.current
 
+    const finalizeStreamingAssistantMessages = () => {
+      updateSessionMessages(activeSessionIdRef.current, (prev) => {
+        let changed = false
+        const next = prev.map((msg) => {
+          if (msg.role === "assistant" && msg.streaming) {
+            changed = true
+            return {
+              ...msg,
+              streaming: false,
+            }
+          }
+          return msg
+        })
+        return changed ? next : prev
+      })
+      clearStreamingGuardTimer()
+    }
+
+    const refreshStreamingGuard = () => {
+      clearStreamingGuardTimer()
+      streamingGuardTimerRef.current = setTimeout(() => {
+        setIsTyping(false)
+        finalizeStreamingAssistantMessages()
+      }, 1800)
+    }
+
     const handleEvent = (event: WSEvent) => {
       switch (event.type) {
         case "connected":
           setIsConnected(true)
           setError(null)
+          clearStreamingGuardTimer()
           optionsRef.current.onConnectionChange?.(true)
           break
 
         case "disconnected":
           setIsConnected(false)
           setIsTyping(false)
+          finalizeStreamingAssistantMessages()
           optionsRef.current.onConnectionChange?.(false)
           break
 
@@ -846,6 +875,11 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
               mergeMessage(prev, message),
             )
             setIsTyping(message.streaming ?? false)
+            if (message.role === "assistant" && message.streaming) {
+              refreshStreamingGuard()
+            } else if (message.role === "assistant" && !message.streaming) {
+              clearStreamingGuardTimer()
+            }
             if (message.role === "assistant" && !message.streaming) {
               lastAssistantTextRef.current = message.content
               scheduleAssistantBubble(message.content)
@@ -910,9 +944,17 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         }
 
         case "typing":
-          setIsTyping(
-            typeof event.data === "string" ? event.data === "true" : true,
-          )
+          {
+            const typing =
+              typeof event.data === "string" ? event.data === "true" : true
+            setIsTyping(typing)
+
+            if (!typing) {
+              finalizeStreamingAssistantMessages()
+            } else {
+              refreshStreamingGuard()
+            }
+          }
           break
 
         case "error": {
@@ -920,6 +962,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
             typeof event.data === "string" ? event.data : "Unknown error"
           setError(errorMsg)
           setIsTyping(false)
+          finalizeStreamingAssistantMessages()
           optionsRef.current.onError?.(errorMsg)
           break
         }
@@ -927,6 +970,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         case "reconnecting":
           setError("正在重新连接...")
           setIsTyping(false)
+          finalizeStreamingAssistantMessages()
           break
 
         case "emotion_change":
@@ -950,6 +994,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     })
 
     return () => {
+      clearStreamingGuardTimer()
       unsubscribe()
       ws.disconnect()
       resetAudioQueue()

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -55,6 +55,7 @@ export interface PetConfigData {
   proactive_care?: boolean
   proactive_interval_minutes?: number
   voice_enabled?: boolean
+  asr_enabled?: boolean
   language?: string
 }
 


### PR DESCRIPTION
本次迭代主要完成了三块：桌宠气泡交互修复、聊天流式状态体验优化、配置页信息架构升级（含语音模型管理）。

1) 桌宠气泡与语音同步
修复桌宠气泡定位逻辑，调整为稳定显示在桌宠上方，并支持长文本向上扩展与滚动。
清理调试代码，恢复为真实 bubble 驱动的显示/隐藏逻辑。
新增 duration_ms 透传与消费：
聊天侧在展示气泡时附带音频时长提示。
桌宠页在无直接音频播放场景下，优先按 duration_ms 控制气泡消失（带缓冲），不再仅依赖固定 10s。
目标效果：气泡生命周期更贴近语音播放节奏，减少“语音还在播但气泡先消失”或“语音结束很久气泡还在”的割裂感。

2) 聊天区“思考中”与流式状态收尾优化
将 assistant 消息尾部黑色方块光标替换为“思考中”文案。
修复“思考中残留不消失”问题：
增加 typing=false 时的 streaming 强制收尾兜底。
在 disconnected/error/reconnecting 场景同步收尾，避免异常链路残留。
增加 streaming guard 定时器，处理时序竞态导致的尾状态卡住。
全局 typing 样式由三跳点改为波纹小点，视觉更轻、更统一。

3) 配置页重构：运行边界 + 语音中枢
将原“自动化闸门 + 启动器表面”合并为单一模块：运行边界。
集中管理：命令执行、定时任务、端口、局域网访问。
在“桌宠大脑”新增 语音中枢。
外层仅保留：TTS 开关、ASR 开关、默认模型摘要、管理语音模型 入口（去臃肿化）。
新增独立语音模型管理弹窗（风格对齐模型管理）：
支持模型列表、设为默认、编辑、添加。
保留“删除”按钮，当前点击提示“暂不可用”。
添加语音模型表单改为引导式（类似大模型添加）：
单列结构 + 示例 placeholder。
供应商由下拉改为“可输入 + 建议（datalist）”，兼顾引导和扩展性。
前端类型补充 asr_enabled，并接入语音配置加载/保存链路。