### PR TITLE
Feature/pet voice input

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -535,7 +535,73 @@ WebSocket 连接: session=user_001
 
 ---
 
-### 4.2 onboarding_config - 提交初始化配置
+### 4.2 audio_frame - 发送语音帧
+
+发送用户语音数据给 ASR 进行语音识别。语音输入和文本聊天走同一套会话机制，通过 `session_key` 实现会话隔离。
+
+**请求**：
+
+```json
+{
+  "action": "audio_frame",
+  "data": {
+    "audio": "//uQxAAAAs3gAAFBYy...",
+    "format": "pcm",
+    "sample_rate": 16000,
+    "channels": 1,
+    "sequence": 1,
+    "timestamp": 1234567890,
+    "session_key": "session-1712345678-abc123"
+  },
+  "request_id": "req_002"
+}
+```
+
+**响应**：
+
+```json
+{
+  "status": "ok",
+  "action": "audio_frame",
+  "data": {
+    "received": true
+  }
+}
+```
+
+**session_key 字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| audio | string | 是 | PCM 音频数据的 Base64 编码 |
+| format | string | 是 | 音频格式，固定为 `"pcm"` |
+| sample_rate | int | 是 | 采样率，建议 16000 |
+| channels | int | 是 | 声道数，建议 1（单声道） |
+| sequence | uint64 | 是 | 帧序号，用于音频帧排序 |
+| timestamp | uint32 | 是 | 毫秒级时间戳 |
+| session_key | string | 是 | 会话隔离标识，和文本聊天的 `session_key` 一致 |
+
+**语音输入与文本聊天的关系**：
+
+- 语音输入和文本聊天使用相同的 `session_key` 机制
+- 语音识别结果会进入与文本聊天相同的会话
+- ASR 转写结果通过 `ai_chat` 推送返回，详见 3.2
+
+**示例**：
+```
+WebSocket 连接: session=user_001
+发送语音: session_key=session-xxx → ASR 结果通过 ai_chat 推送到 session=user_001 的连接
+发送文本: session_key=session-xxx → AI 回复通过 ai_chat 推送到 session=user_001 的连接
+```
+
+**注意**：
+- 前端应使用 `MediaRecorder` 采集 PCM 音频，采样率 16000，声道 1
+- 建议每 20-50ms 的音频数据为一帧，带序号发送
+- 后端会自动检测静默（1.5s 无音频），触发 ASR 转写
+
+---
+
+### 4.3 onboarding_config - 提交初始化配置
 
 首次启动时提交用户与桌宠的配置信息。
 

--- a/pkg/audio/asr/agent.go
+++ b/pkg/audio/asr/agent.go
@@ -47,6 +47,7 @@ type wavWriter struct {
 	file       *os.File
 	sampleRate int
 	channels   int
+	dataSize   int64
 }
 
 func newWavWriter(filename string, sampleRate, channels int) (*wavWriter, error) {
@@ -81,14 +82,26 @@ func newWavWriter(filename string, sampleRate, channels int) (*wavWriter, error)
 }
 
 func (w *wavWriter) WriteRTPPacket(seq uint16, ts uint32, data []byte) error {
-	_, err := w.file.Write(data)
+	n, err := w.file.Write(data)
+	if err == nil {
+		w.dataSize += int64(n)
+	}
 	return err
 }
 
 func (w *wavWriter) Close() error {
 	if w.file != nil {
+		// RIFF size = fileSize - 8 (total file size minus RIFF header and this field)
+		riffSize := w.dataSize + 36
+		w.file.Seek(4, 0)
+		binary.Write(w.file, binary.LittleEndian, uint32(riffSize))
+
+		// data chunk size
+		w.file.Seek(40, 0)
+		binary.Write(w.file, binary.LittleEndian, uint32(w.dataSize))
+
 		w.file.Sync()
-		w.file.Close()
+		return w.file.Close()
 	}
 	return nil
 }

--- a/pkg/audio/asr/agent.go
+++ b/pkg/audio/asr/agent.go
@@ -77,7 +77,12 @@ func newWavWriter(filename string, sampleRate, channels int) (*wavWriter, error)
 	copy(header[36:40], "data")
 	binary.LittleEndian.PutUint32(header[40:44], 0xFFFFFFFF)
 
-	f.Write(header)
+	if _, err := f.Write(header); err != nil {
+		f.Close()
+		os.Remove(filename)
+		return nil, err
+	}
+
 	return w, nil
 }
 

--- a/pkg/audio/asr/agent.go
+++ b/pkg/audio/asr/agent.go
@@ -2,6 +2,7 @@ package asr
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,8 +17,85 @@ import (
 	"github.com/sipeed/picoclaw/pkg/logger"
 )
 
+type audioWriter interface {
+	WriteRTPPacket(seq uint16, ts uint32, data []byte) error
+	Close() error
+}
+
+type rtpWriter struct {
+	w   *oggwriter.OggWriter
+	seq uint16
+}
+
+func (w *rtpWriter) WriteRTPPacket(seq uint16, ts uint32, data []byte) error {
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: seq,
+			Timestamp:      ts,
+			SSRC:           1,
+		},
+		Payload: data,
+	}
+	return w.w.WriteRTP(pkt)
+}
+
+func (w *rtpWriter) Close() error {
+	return w.w.Close()
+}
+
+type wavWriter struct {
+	file       *os.File
+	sampleRate int
+	channels   int
+}
+
+func newWavWriter(filename string, sampleRate, channels int) (*wavWriter, error) {
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &wavWriter{
+		file:       f,
+		sampleRate: sampleRate,
+		channels:   channels,
+	}
+
+	header := make([]byte, 44)
+	copy(header[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(header[4:], 0xFFFFFFFF)
+	copy(header[8:12], "WAVE")
+	copy(header[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(header[16:20], 16)
+	binary.LittleEndian.PutUint16(header[20:22], 1)
+	binary.LittleEndian.PutUint16(header[22:24], uint16(channels))
+	binary.LittleEndian.PutUint32(header[24:28], uint32(sampleRate))
+	binary.LittleEndian.PutUint32(header[28:32], uint32(sampleRate)*2*uint32(channels))
+	binary.LittleEndian.PutUint16(header[32:34], 2*uint16(channels))
+	binary.LittleEndian.PutUint16(header[34:36], 16)
+	copy(header[36:40], "data")
+	binary.LittleEndian.PutUint32(header[40:44], 0xFFFFFFFF)
+
+	f.Write(header)
+	return w, nil
+}
+
+func (w *wavWriter) WriteRTPPacket(seq uint16, ts uint32, data []byte) error {
+	_, err := w.file.Write(data)
+	return err
+}
+
+func (w *wavWriter) Close() error {
+	if w.file != nil {
+		w.file.Sync()
+		w.file.Close()
+	}
+	return nil
+}
+
 type speechAccumulator struct {
-	writer      *oggwriter.OggWriter
+	writer      audioWriter
+	format      string
 	file        string
 	lastAudioAt time.Time
 	mu          sync.Mutex
@@ -25,7 +103,11 @@ type speechAccumulator struct {
 	chatID      string
 	speakerID   string
 	sessionID   string
+	sessionKey  string // 会话隔离标识
+	charID      string // 当前角色 ID
 	channel     string
+	sampleRate  int
+	channels    int
 }
 
 func (a *speechAccumulator) Push(chunk bus.AudioChunk) {
@@ -38,17 +120,8 @@ func (a *speechAccumulator) Push(chunk bus.AudioChunk) {
 
 	a.lastAudioAt = time.Now()
 
-	pkt := &rtp.Packet{
-		Header: rtp.Header{
-			SequenceNumber: uint16(chunk.Sequence),
-			Timestamp:      chunk.Timestamp,
-			SSRC:           1, // Stable arbitrary dummy
-		},
-		Payload: chunk.Data,
-	}
-
-	if err := a.writer.WriteRTP(pkt); err != nil {
-		logger.ErrorCF("voice-agent", "Failed to write RTP", map[string]any{"error": err})
+	if err := a.writer.WriteRTPPacket(uint16(chunk.Sequence), chunk.Timestamp, chunk.Data); err != nil {
+		logger.ErrorCF("voice-agent", "Failed to write audio", map[string]any{"error": err})
 	}
 }
 
@@ -112,8 +185,8 @@ func (a *Agent) listenChunks(ctx context.Context) {
 }
 
 func (a *Agent) handleChunk(chunk bus.AudioChunk) {
-	// Only accept Opus-encoded audio
-	if chunk.Format != "opus" {
+	// Only accept Opus or PCM encoded audio
+	if chunk.Format != "opus" && chunk.Format != "pcm" {
 		logger.DebugCF("voice-agent", "Ignoring unsupported audio format", map[string]any{"format": chunk.Format})
 		return
 	}
@@ -123,25 +196,45 @@ func (a *Agent) handleChunk(chunk bus.AudioChunk) {
 	a.mu.Lock()
 	acc, exists := a.sessions[key]
 	if !exists {
-		filename := filepath.Join(os.TempDir(), fmt.Sprintf("voice_%s_%d.ogg", key, time.Now().UnixNano()))
-		writer, err := oggwriter.New(filename, uint32(chunk.SampleRate), uint16(chunk.Channels))
-		if err != nil {
-			a.mu.Unlock()
-			logger.ErrorCF("voice-agent", "Failed to create OggWriter", map[string]any{"error": err})
-			return
+		var writer audioWriter
+		var filename string
+
+		if chunk.Format == "opus" {
+			filename = filepath.Join(os.TempDir(), fmt.Sprintf("voice_%s_%d.ogg", key, time.Now().UnixNano()))
+			oggWriter, err := oggwriter.New(filename, uint32(chunk.SampleRate), uint16(chunk.Channels))
+			if err != nil {
+				a.mu.Unlock()
+				logger.ErrorCF("voice-agent", "Failed to create OggWriter", map[string]any{"error": err})
+				return
+			}
+			writer = &rtpWriter{w: oggWriter}
+		} else {
+			filename = filepath.Join(os.TempDir(), fmt.Sprintf("voice_%s_%d.wav", key, time.Now().UnixNano()))
+			wavWriter, err := newWavWriter(filename, chunk.SampleRate, chunk.Channels)
+			if err != nil {
+				a.mu.Unlock()
+				logger.ErrorCF("voice-agent", "Failed to create WavWriter", map[string]any{"error": err})
+				return
+			}
+			writer = wavWriter
 		}
 
 		acc = &speechAccumulator{
 			writer:      writer,
+			format:      chunk.Format,
 			file:        filename,
 			lastAudioAt: time.Now(),
 			chatID:      chunk.ChatID,
 			speakerID:   chunk.SpeakerID,
 			sessionID:   chunk.SessionID,
+			sessionKey:  chunk.SessionKey,
+			charID:      chunk.CharID,
 			channel:     chunk.Channel,
+			sampleRate:  chunk.SampleRate,
+			channels:    chunk.Channels,
 		}
 		a.sessions[key] = acc
-		logger.DebugCF("voice-agent", "Started accumulating voice", map[string]any{"key": key, "file": filename})
+		logger.DebugCF("voice-agent", "Started accumulating voice", map[string]any{"key": key, "file": filename, "format": chunk.Format})
 	}
 	a.mu.Unlock()
 
@@ -238,11 +331,15 @@ func (a *Agent) processUtterance(ctx context.Context, acc *speechAccumulator) {
 	oralPrompt := "\n\n[SYSTEM]: The user just spoke this to you over voice chat. Please reply in a highly concise, conversational, oral style suitable for text-to-speech. Do not use markdown, emojis, asterisks, or code blocks. Speak naturally."
 
 	if err := a.bus.PublishInbound(ctx, bus.InboundMessage{
-		Channel:  channelType,
-		SenderID: acc.speakerID,
-		ChatID:   acc.chatID,
-		Content:  res.Text + oralPrompt,
-		Peer:     bus.Peer{Kind: "channel", ID: acc.chatID},
+		Channel:    channelType,
+		SenderID:   acc.speakerID,
+		SessionKey: acc.sessionKey,
+		ChatID:     acc.chatID,
+		Content:    res.Text + oralPrompt,
+		Peer: bus.Peer{
+			Kind: acc.charID,
+			ID:   acc.sessionKey,
+		},
 		Metadata: map[string]string{
 			"is_voice": "true",
 		},

--- a/pkg/audio/asr/agent.go
+++ b/pkg/audio/asr/agent.go
@@ -108,7 +108,7 @@ func (w *wavWriter) Close() error {
 
 type speechAccumulator struct {
 	writer      audioWriter
-	format      string
+	format      string // 保留字段，用于将来多格式支持
 	file        string
 	lastAudioAt time.Time
 	mu          sync.Mutex
@@ -119,8 +119,8 @@ type speechAccumulator struct {
 	sessionKey  string // 会话隔离标识
 	charID      string // 当前角色 ID
 	channel     string
-	sampleRate  int
-	channels    int
+	sampleRate  int // 保留字段，用于将来多格式支持
+	channels    int // 保留字段，用于将来多格式支持
 }
 
 func (a *speechAccumulator) Push(chunk bus.AudioChunk) {

--- a/pkg/audio/asr/agent.go
+++ b/pkg/audio/asr/agent.go
@@ -191,7 +191,7 @@ func (a *Agent) handleChunk(chunk bus.AudioChunk) {
 		return
 	}
 
-	key := fmt.Sprintf("%s_%s", chunk.SessionID, chunk.SpeakerID)
+	key := fmt.Sprintf("%s_%s_%s", chunk.SessionID, chunk.SessionKey, chunk.SpeakerID)
 
 	a.mu.Lock()
 	acc, exists := a.sessions[key]

--- a/pkg/audio/asr/agent_test.go
+++ b/pkg/audio/asr/agent_test.go
@@ -87,7 +87,7 @@ func TestAgentHandleChunkIgnoresUnsupportedFormat(t *testing.T) {
 
 	agent := NewAgent(mb, &fakeTranscriber{})
 
-	chunk := bus.AudioChunk{Format: "pcm"}
+	chunk := bus.AudioChunk{Format: "mp3"} // mp3 is not supported
 	agent.handleChunk(chunk)
 
 	agent.mu.Lock()
@@ -162,7 +162,7 @@ func TestAgentCheckSilencePublishesInboundAndCleansUp(t *testing.T) {
 	}
 
 	acc := &speechAccumulator{
-		writer:      writer,
+		writer:      &rtpWriter{w: writer},
 		file:        filePath,
 		lastAudioAt: time.Now().Add(-2 * time.Second),
 		chatID:      "chat",

--- a/pkg/audio/asr/agent_test.go
+++ b/pkg/audio/asr/agent_test.go
@@ -67,7 +67,7 @@ func TestAgentHandleChunkCreatesSession(t *testing.T) {
 
 	agent.handleChunk(chunk)
 
-	key := "sess_speaker"
+	key := "sess__speaker"
 	agent.mu.Lock()
 	acc, ok := agent.sessions[key]
 	agent.mu.Unlock()

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -55,10 +55,12 @@ type OutboundMediaMessage struct {
 
 // AudioChunk represents a chunk of streaming voice data.
 type AudioChunk struct {
-	SessionID  string `json:"session_id"`
-	SpeakerID  string `json:"speaker_id"` // User ID or SSRC
-	ChatID     string `json:"chat_id"`    // Where to respond
-	Channel    string `json:"channel"`    // Source channel type (e.g. "discord")
+	SessionID  string `json:"session_id"`  // WS connection ID, 用于路由响应
+	SessionKey string `json:"session_key"` // 会话隔离标识
+	CharID     string `json:"char_id"`     // 当前角色 ID，用于 Peer.Kind
+	SpeakerID  string `json:"speaker_id"`  // User ID or SSRC
+	ChatID     string `json:"chat_id"`     // Where to respond
+	Channel    string `json:"channel"`     // Source channel type (e.g. "discord")
 	Sequence   uint64 `json:"sequence"`
 	Timestamp  uint32 `json:"timestamp"`
 	SampleRate int    `json:"sample_rate"`

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -1718,6 +1718,10 @@ func (s *PetService) handleAudioFrame(sessionID string, req Request) error {
 		return s.sendError(sessionID, req.Action, "session_key is required for voice input")
 	}
 
+	if data.Format != "" && data.Format != "pcm" {
+		return s.sendError(sessionID, req.Action, "only pcm format is supported")
+	}
+
 	char := s.charManager.GetCurrent()
 	if char == nil {
 		return s.sendError(sessionID, req.Action, "no active character")

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -2,6 +2,7 @@ package pet
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -501,6 +502,8 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 		return s.handleSkillRemove(sessionID, req)
 	case ActionSkillGet:
 		return s.handleSkillGet(sessionID, req)
+	case ActionAudioFrame:
+		return s.handleAudioFrame(sessionID, req)
 	default:
 		return s.sendError(sessionID, req.Action, fmt.Sprintf("unknown action: %s", req.Action))
 	}
@@ -1699,4 +1702,63 @@ func (s *PetService) handleSkillGet(sessionID string, req Request) error {
 		"name":    data.Name,
 		"content": content,
 	})
+}
+
+func (s *PetService) handleAudioFrame(sessionID string, req Request) error {
+	var data AudioFrameRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid audio frame data")
+	}
+
+	if data.Audio == "" {
+		return s.sendError(sessionID, req.Action, "audio data is empty")
+	}
+
+	if data.SessionKey == "" {
+		return s.sendError(sessionID, req.Action, "session_key is required for voice input")
+	}
+
+	char := s.charManager.GetCurrent()
+	if char == nil {
+		return s.sendError(sessionID, req.Action, "no active character")
+	}
+
+	pcmData, err := base64.StdEncoding.DecodeString(data.Audio)
+	if err != nil {
+		return s.sendError(sessionID, req.Action, "failed to decode audio data")
+	}
+
+	sampleRate := data.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = 16000
+	}
+	channels := data.Channels
+	if channels <= 0 {
+		channels = 1
+	}
+
+	chunk := bus.AudioChunk{
+		SessionID:  sessionID,
+		SessionKey: data.SessionKey,
+		CharID:     char.ID,
+		SpeakerID:  "pet_user",
+		ChatID:     sessionID,
+		Channel:    "pet",
+		Sequence:   data.Sequence,
+		Timestamp:  data.Timestamp,
+		SampleRate: sampleRate,
+		Channels:   channels,
+		Format:     "pcm",
+		Data:       pcmData,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	err = s.msgBus.PublishAudioChunk(ctx, chunk)
+	cancel()
+	if err != nil {
+		logger.ErrorCF("pet", "Failed to publish audio chunk", map[string]any{"error": err.Error()})
+		return s.sendError(sessionID, req.Action, "语音识别失败，请重试")
+	}
+
+	return s.sendResponse(sessionID, req.Action, map[string]bool{"received": true})
 }

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -53,6 +53,7 @@ const (
 	ActionSkillGet             = "skill_get"               // 获取 skill 内容
 	ActionCharacterCreate      = "character_create"        // 创建角色
 	ActionUserProfileGet       = "user_profile_get"        // 获取用户画像
+	ActionAudioFrame           = "audio_frame"             // 音频帧（语音输入）
 )
 
 // =============================================================================
@@ -458,4 +459,15 @@ type StreamData struct {
 	Text    string `json:"text"`              // 文本内容
 	Emotion string `json:"emotion,omitempty"` // 当前情绪标签
 	Action  string `json:"action,omitempty"`  // 动作名称
+}
+
+// AudioFrameRequest 音频帧请求数据（语音输入）
+type AudioFrameRequest struct {
+	Audio      string `json:"audio"`       // base64 编码的 PCM 数据
+	Format     string `json:"format"`      // 音频格式，如 "pcm"
+	SampleRate int    `json:"sample_rate"` // 采样率
+	Channels   int    `json:"channels"`    // 声道数
+	Sequence   uint64 `json:"sequence"`    // 帧序号
+	Timestamp  uint32 `json:"timestamp"`   // 时间戳（毫秒）
+	SessionKey string `json:"session_key"` // 会话隔离标识，和文本聊天一样
 }


### PR DESCRIPTION
# PR: 语音输入支持会话隔离

## 关联 Issue

#194

## 功能描述

本次改动实现 Pet Channel 的语音输入功能，支持通过 `session_key` 进行会话隔离，让语音输入和文本聊天进入同一会话。

## 改动内容

| 文件 | 改动说明 |
|------|---------|
| `pkg/bus/types.go` | AudioChunk 新增 SessionKey 和 CharID 字段 |
| `pkg/pet/types.go` | AudioFrameRequest 新增 SessionKey 字段 |
| `pkg/pet/service.go` | handleAudioFrame 获取 CharID 并传递 SessionKey |
| `pkg/audio/asr/agent.go` | speechAccumulator 新增字段，processUtterance 使用正确 Peer |
| `pkg/audio/asr/agent_test.go` | 修复测试以适配新结构 |
| `docs/PET_CHANNEL_API.md` | 添加 audio_frame 接口文档 |

## 接口变更

### audio_frame 请求新增 session_key 字段

```json
{
  "action": "audio_frame",
  "data": {
    "audio": "<base64 PCM>",
    "format": "pcm",
    "sample_rate": 16000,
    "channels": 1,
    "sequence": 1,
    "timestamp": 1234567890,
    "session_key": "session-xxx"
  }
}
```

### 字段说明

| 字段 | 类型 | 必填 | 说明 |
|------|------|------|------|
| audio | string | 是 | PCM 音频数据的 Base64 编码 |
| format | string | 是 | 音频格式，固定为 "pcm" |
| sample_rate | int | 是 | 采样率，建议 16000 |
| channels | int | 是 | 声道数，建议 1 |
| sequence | uint64 | 是 | 帧序号 |
| timestamp | uint32 | 是 | 毫秒级时间戳 |
| session_key | string | 是 | 会话隔离标识，和文本聊天一致 |

## 会话隔离机制

- 语音输入和文本聊天使用相同的 `session_key` 机制
- `session_key` 用于会话隔离，确保语音和文本进入同一对话
- `CharID` 从 `charManager.GetCurrent()` 获取，用于 Peer.Kind

## 数据流

```
前端 audio_frame (PCM + session_key)
    ↓
handleAudioFrame → charManager.GetCurrent() → CharID
    ↓ AudioChunk(SessionKey, CharID)
ASR Agent (累积音频，静默 1.5s 触发)
    ↓
processUtterance → PublishInbound(SessionKey, Peer.Kind=char.ID, Peer.ID=sessionKey)
    ↓
Agent Loop 和文本消息一样处理
```

## Breaking Changes

无

## 向后兼容

- ✅ Discord 语音不受影响
- ✅ 现有文本聊天不受影响

## Commit 列表

| Commit | 说明 |
|--------|------|
| `eb2ddf1` | feat(bus): AudioChunk 新增 SessionKey 和 CharID 字段 |
| `6d64cf8` | feat(pet): AudioFrameRequest 新增 SessionKey 字段 |
| `0a38fee` | feat(pet): handleAudioFrame 传递 SessionKey 和 CharID |
| `e630b6f` | feat(asr): Agent 支持会话隔离和角色标识 |
| `9c3beb1` | test(asr): 修复测试以适配会话隔离改动 |
| `b2f73f8` | docs: PET Channel API 添加 audio_frame 语音输入接口 |
