### PR TITLE
fix:加入快捷键穿透切换，修复桌宠无法靠近顶层bug

### DIFF
--- a/clawpet-frontend/clawpet/app/desktop-pet-bubble/bubble.css
+++ b/clawpet-frontend/clawpet/app/desktop-pet-bubble/bubble.css
@@ -1,0 +1,39 @@
+.bubble-app {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  pointer-events: none;
+  user-select: none;
+}
+
+.bubble-root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.bubble-root--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bubble-card {
+  max-width: min(290px, calc(100vw - 20px));
+  margin-bottom: 8px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(199, 134, 73, 0.45);
+  background: rgba(255, 251, 245, 0.96);
+  box-shadow: 0 8px 20px rgba(89, 55, 20, 0.18);
+  color: #5b3920;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/clawpet-frontend/clawpet/app/desktop-pet-bubble/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet-bubble/page.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import "./bubble.css"
+
+interface BubbleData {
+  text: string | null
+  duration_ms?: number
+}
+
+const DEFAULT_DURATION_MS = 6000
+
+export default function DesktopPetBubblePage() {
+  const [text, setText] = useState("")
+  const [visible, setVisible] = useState(false)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cardRef = useRef<HTMLDivElement | null>(null)
+
+  const clearHideTimer = () => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    const stop = window.electronAPI?.onForceStopMedia?.(() => {
+      clearHideTimer()
+      setVisible(false)
+      setText("")
+    })
+
+    return () => {
+      stop?.()
+    }
+  }, [])
+
+  useEffect(() => {
+    const target = cardRef.current
+    if (!target) {
+      return
+    }
+
+    const reportSize = () => {
+      const rect = target.getBoundingClientRect()
+      const width = Math.ceil(rect.width + 18)
+      const height = Math.ceil(rect.height + 18)
+      window.electronAPI?.reportBubbleWindowSize?.({ width, height })
+    }
+
+    reportSize()
+
+    const observer = new ResizeObserver(() => {
+      reportSize()
+    })
+    observer.observe(target)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [text])
+
+  useEffect(() => {
+    const handleBubbleShow = (payload: BubbleData) => {
+      const nextText = typeof payload?.text === "string" ? payload.text.trim() : ""
+      if (!nextText) {
+        clearHideTimer()
+        setVisible(false)
+        setText("")
+        return
+      }
+
+      clearHideTimer()
+      setText(nextText)
+      setVisible(true)
+
+      const duration =
+        typeof payload?.duration_ms === "number" && payload.duration_ms > 0
+          ? payload.duration_ms
+          : DEFAULT_DURATION_MS
+
+      hideTimerRef.current = setTimeout(() => {
+        setVisible(false)
+      }, duration)
+    }
+
+    window.electronAPI?.onBubbleShow?.(handleBubbleShow)
+
+    return () => {
+      clearHideTimer()
+    }
+  }, [])
+
+  const classes = useMemo(
+    () => `bubble-root ${visible ? "bubble-root--visible" : ""}`,
+    [visible],
+  )
+
+  return (
+    <div className="bubble-app" aria-hidden={!visible}>
+      <div className={classes}>
+        <div ref={cardRef} className="bubble-card">{text}</div>
+      </div>
+    </div>
+  )
+}

--- a/clawpet-frontend/clawpet/app/desktop-pet/desktop-pet.css
+++ b/clawpet-frontend/clawpet/app/desktop-pet/desktop-pet.css
@@ -23,13 +23,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   z-index: 80;
   pointer-events: auto;
 }
 
 .desktop-pet-controls {
-  position: static;
+  position: relative;
+  top: 6px;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -37,14 +38,14 @@
   pointer-events: none;
   -webkit-app-region: no-drag;
   opacity: 0;
-  transform: translateY(-6px);
+  transform: translateY(-2px);
   transition: opacity 160ms ease, transform 160ms ease;
 }
 
 .desktop-pet-controls--visible {
   pointer-events: auto;
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(6px);
 }
 
 .desktop-pet-btn {

--- a/clawpet-frontend/clawpet/electron.d.ts
+++ b/clawpet-frontend/clawpet/electron.d.ts
@@ -28,6 +28,7 @@ declare global {
         (payload: BubblePayload): void
         (text: string | null, emotion: string, audio?: string): void
       }
+      reportBubbleWindowSize?: (size: { width: number; height: number }) => void
       onSettingsUpdate?: (callback: (settings: unknown) => void) => void
       onBubbleShow?: (callback: (payload: BubblePayload) => void) => void
       onForceStopMedia?: (callback: () => void) => () => void

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -1400,6 +1400,7 @@ ipcMain.on('show-bubble', (_event, data) => {
   const emotion = typeof data?.emotion === 'string' ? data.emotion.trim() : '';
   const fingerprint = `${audio}|${text}|${emotion}`;
   const now = Date.now();
+  const hasDetachedBubbleWindow = bubbleWindow && !bubbleWindow.isDestroyed();
 
   if (fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {
     logToFile('[IPC] show-bubble dropped duplicated payload');
@@ -1409,11 +1410,11 @@ ipcMain.on('show-bubble', (_event, data) => {
   lastBubbleFingerprint = fingerprint;
   lastBubbleAt = now;
 
-  if (petWindow && !petWindow.isDestroyed()) {
+  if (!hasDetachedBubbleWindow && petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('bubble-show', data);
   }
 
-  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+  if (hasDetachedBubbleWindow) {
     syncBubbleWindowToPet({ show: true });
     bubbleWindow.webContents.send('bubble-show', data);
   }

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -14,7 +14,7 @@
  * - 前端面板：通过环境变量 GOCLAW_DASHBOARD_URL 连接（默认 3000）
  */
 
-const { app, BrowserWindow, ipcMain, screen } = require('electron');
+const { app, BrowserWindow, ipcMain, screen, globalShortcut } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -22,6 +22,7 @@ const { spawn } = require('child_process');
 
 // 全局窗口引用
 let petWindow = null;              // 桌宠窗口
+let bubbleWindow = null;           // 气泡窗口
 let settingsWindow = null;         // 设置窗口
 let onboardingWindow = null;       // 初始化窗口
 let startupWindow = null;          // 启动进度窗口
@@ -31,6 +32,10 @@ let petRendererRetryCount = 0;     // pet renderer retry count
 let startupCompleted = false;      // startup completed flag
 let petHoverMonitorTimer = null;
 let petHovering = false;
+let petClickThroughEnabled = false;
+let petTopClampApplying = false;
+let petDragActive = false;
+let petTopCorrectionTimer = null;
 let onboardingLocked = false;
 let lastBubbleFingerprint = '';
 let lastBubbleAt = 0;
@@ -39,12 +44,21 @@ let lastBubbleAt = 0;
 let gatewayProcess = null;         // Gateway 进程
 let launcherProcess = null;        // Launcher 进程
 
-// 桌宠窗口尺寸（宽度280px，高度380px）
-const PET_WIDTH = 280;
-const PET_HEIGHT = 380;
+// 桌宠窗口尺寸（缩小：宽度150px，高度180px）
+const PET_WIDTH = 150;
+const PET_HEIGHT = 180;
 const PET_WINDOW_MARGIN = 16;
 const PET_RENDERER_RETRY_DELAY_MS = 1200;
 const PET_RENDERER_MAX_RETRIES = 60;
+const BUBBLE_WINDOW_DEFAULT_WIDTH = 320;
+const BUBBLE_WINDOW_DEFAULT_HEIGHT = 140;
+const BUBBLE_WINDOW_MIN_WIDTH = 140;
+const BUBBLE_WINDOW_MAX_WIDTH = 420;
+const BUBBLE_WINDOW_MIN_HEIGHT = 72;
+const BUBBLE_WINDOW_MAX_HEIGHT = 220;
+const BUBBLE_PET_OVERLAP = 14;
+let bubbleWindowWidth = BUBBLE_WINDOW_DEFAULT_WIDTH;
+let bubbleWindowHeight = BUBBLE_WINDOW_DEFAULT_HEIGHT;
 
 /**
  * 设置 Electron 用户数据目录
@@ -112,6 +126,9 @@ function stopAllMediaPlayback(reason = 'unknown') {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('force-stop-media');
   }
+  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+    bubbleWindow.webContents.send('force-stop-media');
+  }
 }
 
 function hideRuntimeWindowsForOnboarding() {
@@ -120,6 +137,9 @@ function hideRuntimeWindowsForOnboarding() {
   }
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.hide();
+  }
+  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+    bubbleWindow.hide();
   }
 }
 
@@ -336,11 +356,13 @@ function setPetWindowClickThrough(enabled) {
   }
 
   try {
+    petClickThroughEnabled = Boolean(enabled);
     if (enabled) {
       petWindow.setIgnoreMouseEvents(true, { forward: true });
     } else {
       petWindow.setIgnoreMouseEvents(false);
     }
+    logToFile(`[PET WINDOW] click-through ${petClickThroughEnabled ? 'enabled' : 'disabled'}`);
   } catch (error) {
     logToFile(`[PET WINDOW] setIgnoreMouseEvents failed: ${String(error)}`);
   }
@@ -380,6 +402,57 @@ function stopPetHoverMonitor() {
     petHoverMonitorTimer = null;
   }
   petHovering = false;
+}
+
+function clearPetTopCorrectionTimer() {
+  if (petTopCorrectionTimer) {
+    clearTimeout(petTopCorrectionTimer);
+    petTopCorrectionTimer = null;
+  }
+}
+
+function clampPetWindowTopEdge() {
+  if (!petWindow || petWindow.isDestroyed() || petTopClampApplying) {
+    return;
+  }
+
+  const bounds = petWindow.getBounds();
+  const nearestDisplay = screen.getDisplayNearestPoint({
+    x: bounds.x + Math.floor(bounds.width / 2),
+    y: bounds.y + Math.floor(bounds.height / 2),
+  });
+  const minY = nearestDisplay.bounds.y;
+  if (bounds.y >= minY) {
+    return;
+  }
+
+  petTopClampApplying = true;
+  try {
+    petWindow.setPosition(bounds.x, minY, true);
+  } finally {
+    petTopClampApplying = false;
+  }
+}
+
+function schedulePetTopClamp(delayMs = 80) {
+  clearPetTopCorrectionTimer();
+  petTopCorrectionTimer = setTimeout(() => {
+    clampPetWindowTopEdge();
+    petTopCorrectionTimer = null;
+  }, delayMs);
+}
+
+function registerPetClickThroughShortcut() {
+  const accelerator = 'CommandOrControl+Shift+P';
+  const registered = globalShortcut.register(accelerator, () => {
+    setPetWindowClickThrough(!petClickThroughEnabled);
+  });
+
+  if (!registered) {
+    logToFile(`[SHORTCUT] failed to register ${accelerator}`);
+    return;
+  }
+  logToFile(`[SHORTCUT] registered ${accelerator}`);
 }
 
 function updateStartupPercent() {
@@ -472,6 +545,10 @@ function getRendererUrl() {
   return buildDashboardUrl(pathname);
 }
 
+function getBubbleRendererUrl() {
+  return buildDashboardUrl('/desktop-pet-bubble');
+}
+
 /**
  * 检查桌宠渲染页面是否就绪
  * @returns {Promise<boolean>}
@@ -486,6 +563,112 @@ async function isRendererReady() {
  */
 function loadPetRenderer(targetWindow) {
   return targetWindow.loadURL(getRendererUrl());
+}
+
+function loadBubbleRenderer(targetWindow) {
+  return targetWindow.loadURL(getBubbleRendererUrl());
+}
+
+function clampBubbleSize(width, height) {
+  const safeWidth = Number.isFinite(width) ? Math.round(width) : BUBBLE_WINDOW_DEFAULT_WIDTH;
+  const safeHeight = Number.isFinite(height) ? Math.round(height) : BUBBLE_WINDOW_DEFAULT_HEIGHT;
+  return {
+    width: Math.max(BUBBLE_WINDOW_MIN_WIDTH, Math.min(BUBBLE_WINDOW_MAX_WIDTH, safeWidth)),
+    height: Math.max(BUBBLE_WINDOW_MIN_HEIGHT, Math.min(BUBBLE_WINDOW_MAX_HEIGHT, safeHeight)),
+  };
+}
+
+function computeBubbleWindowPosition() {
+  if (!petWindow || petWindow.isDestroyed()) {
+    return null;
+  }
+
+  const petBounds = petWindow.getBounds();
+  const centerPoint = {
+    x: petBounds.x + Math.floor(petBounds.width / 2),
+    y: petBounds.y + Math.floor(petBounds.height / 2),
+  };
+  const display = screen.getDisplayNearestPoint(centerPoint);
+  const area = display.workArea;
+
+  let x = Math.round(petBounds.x + (petBounds.width - bubbleWindowWidth) / 2);
+  let y = Math.round(petBounds.y - bubbleWindowHeight + BUBBLE_PET_OVERLAP);
+
+  const minX = area.x;
+  const maxX = area.x + area.width - bubbleWindowWidth;
+  const minY = area.y;
+  const maxY = area.y + area.height - bubbleWindowHeight;
+
+  x = Math.max(minX, Math.min(maxX, x));
+  y = Math.max(minY, Math.min(maxY, y));
+
+  return { x, y };
+}
+
+function syncBubbleWindowToPet({ show = false } = {}) {
+  if (!bubbleWindow || bubbleWindow.isDestroyed()) {
+    return;
+  }
+
+  const position = computeBubbleWindowPosition();
+  if (!position) {
+    return;
+  }
+
+  bubbleWindow.setBounds({
+    x: position.x,
+    y: position.y,
+    width: bubbleWindowWidth,
+    height: bubbleWindowHeight,
+  }, false);
+
+  if (show && petWindow && !petWindow.isDestroyed() && petWindow.isVisible()) {
+    bubbleWindow.showInactive();
+  }
+}
+
+function hideBubbleWindow() {
+  if (!bubbleWindow || bubbleWindow.isDestroyed()) {
+    return;
+  }
+  bubbleWindow.hide();
+}
+
+function createBubbleWindow() {
+  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+    return;
+  }
+
+  const position = computeBubbleWindowPosition() || { x: 0, y: 0 };
+  bubbleWindow = new BrowserWindow({
+    width: bubbleWindowWidth,
+    height: bubbleWindowHeight,
+    x: position.x,
+    y: position.y,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    show: false,
+    focusable: false,
+    hasShadow: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  bubbleWindow.setIgnoreMouseEvents(true, { forward: true });
+
+  loadBubbleRenderer(bubbleWindow).catch((err) => {
+    logToFile(`[BUBBLE WINDOW] load renderer failed: ${String(err)}`);
+  });
+
+  bubbleWindow.on('closed', () => {
+    bubbleWindow = null;
+  });
 }
 
 function getPetWindowBottomRightPosition() {
@@ -574,6 +757,8 @@ function createPetWindow() {
 
   // Re-apply bottom-right placement to avoid OS window policy override.
   placePetWindowBottomRight(petWindow);
+  createBubbleWindow();
+  syncBubbleWindowToPet();
 
   loadPetRenderer(petWindow).catch((err) => {
     logToFile(`[PET WINDOW] load renderer failed: ${String(err)}`);
@@ -601,17 +786,75 @@ function createPetWindow() {
 
   petWindow.once('ready-to-show', () => {
     logToFile('[PET WINDOW] ready-to-show triggered');
-    setPetWindowClickThrough(true);
-    startPetHoverMonitor();
+    setPetWindowClickThrough(false);
     if (!onboardingLocked) {
       logToFile('[PET WINDOW] showing pet window from ready-to-show');
       petWindow.show();
+      syncBubbleWindowToPet();
     } else {
       logToFile('[PET WINDOW] skipping show (onboarding locked)');
     }
   });
 
+  petWindow.on('will-move', (event, newBounds) => {
+    if (!petWindow || petWindow.isDestroyed() || petTopClampApplying) {
+      return;
+    }
+
+    petDragActive = true;
+    clearPetTopCorrectionTimer();
+
+    const nearestDisplay = screen.getDisplayNearestPoint({
+      x: newBounds.x + Math.floor(newBounds.width / 2),
+      y: newBounds.y + Math.floor(newBounds.height / 2),
+    });
+    const minY = nearestDisplay.bounds.y;
+
+    if (newBounds.y >= minY - 96) {
+      return;
+    }
+
+    event.preventDefault();
+    petTopClampApplying = true;
+    try {
+      petWindow.setPosition(newBounds.x, minY, true);
+    } finally {
+      petTopClampApplying = false;
+    }
+  });
+
+  petWindow.on('moved', () => {
+    petDragActive = false;
+    schedulePetTopClamp(40);
+    syncBubbleWindowToPet({ show: bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible() });
+  });
+
+  petWindow.on('move', () => {
+    syncBubbleWindowToPet({ show: bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible() });
+  });
+
+  petWindow.on('show', () => {
+    if (bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible()) {
+      syncBubbleWindowToPet({ show: true });
+    }
+  });
+
+  petWindow.on('hide', () => {
+    hideBubbleWindow();
+  });
+
+  petWindow.on('blur', () => {
+    if (!petDragActive) {
+      schedulePetTopClamp(40);
+    }
+  });
+
   petWindow.on('closed', () => {
+    clearPetTopCorrectionTimer();
+    if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+      bubbleWindow.close();
+      bubbleWindow = null;
+    }
     stopPetHoverMonitor();
     petWindow = null;
     app.quit();
@@ -630,8 +873,7 @@ function resetPetWindow() {
   petWindow.setAlwaysOnTop(true);
   petWindow.setSkipTaskbar(true);
   petWindow.setBounds(getPetBounds(), true);
-  setPetWindowClickThrough(true);
-  startPetHoverMonitor();
+  setPetWindowClickThrough(false);
 }
 
 /**
@@ -1057,6 +1299,16 @@ ipcMain.on('set-pet-click-through', (_event, enabled) => {
   setPetWindowClickThrough(Boolean(enabled));
 });
 
+ipcMain.on('bubble-window-size', (_event, payload) => {
+  const next = clampBubbleSize(payload?.width, payload?.height);
+  if (next.width === bubbleWindowWidth && next.height === bubbleWindowHeight) {
+    return;
+  }
+  bubbleWindowWidth = next.width;
+  bubbleWindowHeight = next.height;
+  syncBubbleWindowToPet({ show: bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible() });
+});
+
 // 窗口最小化
 ipcMain.on('window-minimize', (event) => {
   const target = BrowserWindow.fromWebContents(event.sender);
@@ -1160,6 +1412,11 @@ ipcMain.on('show-bubble', (_event, data) => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('bubble-show', data);
   }
+
+  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+    syncBubbleWindowToPet({ show: true });
+    bubbleWindow.webContents.send('bubble-show', data);
+  }
 });
 
 // 连接活跃状态
@@ -1177,6 +1434,7 @@ ipcMain.handle('startup-state', async () => startupState);
  * 根据配置决定显示启动窗口还是直接创建桌宠窗口
  */
 app.whenReady().then(async () => {
+  registerPetClickThroughShortcut();
   // 自动启动后端服务
   await startBackendServices();
   
@@ -1223,6 +1481,12 @@ app.on('window-all-closed', () => {
 
 // 应用退出前清理定时器
 app.on('before-quit', () => {
+  clearPetTopCorrectionTimer();
+  if (bubbleWindow && !bubbleWindow.isDestroyed()) {
+    bubbleWindow.close();
+    bubbleWindow = null;
+  }
+  globalShortcut.unregisterAll();
   if (startupPollTimer) {
     clearInterval(startupPollTimer);
     startupPollTimer = null;

--- a/clawpet-frontend/clawpet/electron/preload.js
+++ b/clawpet-frontend/clawpet/electron/preload.js
@@ -85,6 +85,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * 关闭当前窗口
    */
   closeWindow: () => ipcRenderer.send('window-close'),
+
+  /**
+   * 设置桌宠窗口是否穿透鼠标
+   * @param {boolean} enabled - true 为穿透，false 为可点击
+   */
+  setPetClickThrough: (enabled) => ipcRenderer.send('set-pet-click-through', Boolean(enabled)),
   
   // ==================== 设置窗口 ====================
   
@@ -148,6 +154,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * 发送连接活跃状态（心跳）
    */
   sendConnectionAlive: () => ipcRenderer.send('connection-alive'),
+
+  /**
+   * 上报气泡窗口内容尺寸（用于主进程自适应窗口大小）
+   * @param {{width:number,height:number}} size
+   */
+  reportBubbleWindowSize: (size) => {
+    const width = Number(size?.width) || 0
+    const height = Number(size?.height) || 0
+    ipcRenderer.send('bubble-window-size', { width, height })
+  },
   
   // ==================== 事件监听 ====================
   

--- a/clawpet-frontend/clawpet/next-env.d.ts
+++ b/clawpet-frontend/clawpet/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/clawpet-frontend/clawpet/next-env.d.ts
+++ b/clawpet-frontend/clawpet/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
背景
  桌宠交互存在几个连续问题：
  穿透切换依赖自动 hover，状态不稳定
  贴顶时会有边界不一致/拖拽回弹体验
  窗口缩小到 150x180 后，聊天气泡容易被裁切不可见

主要改动
  快捷键穿透（手动可控）
  在主进程注册 CommandOrControl+Shift+P，用于切换桌宠穿透。
  默认改为非穿透（可点击），避免自动状态干扰。
  退出时 globalShortcut.unregisterAll() 清理快捷键。
  贴顶边界修复（稳定拖拽）
  增加顶部边界处理与拖拽态修正，避免越界和明显回弹。
  贴顶逻辑改为更保守的分阶段处理，减少“甩动后偏移”问题。
  双窗口气泡方案（解决小窗裁切）
  新增独立透明气泡窗口（always-on-top、skipTaskbar、点击穿透、不可聚焦）。
  桌宠窗口与气泡窗口联动：移动/显示/隐藏时同步位置与可见性。
  保留原 bubble-show 发送到桌宠窗口的兼容路径（回退兜底）。
  气泡窗口尺寸自适应
  新增气泡渲染页，使用 ResizeObserver 测量文本气泡尺寸。
  渲染进程通过 IPC 上报气泡宽高，主进程动态调整气泡窗口大小并重定位。
  设置最小/最大宽高阈值，避免极端内容导致窗口异常。
  桌宠视觉微调
  上方两个控制按钮整体下移，缩小后布局更自然。