### PR TITLE
fix: 对齐 ClawPet 发布链路、.picoclaw 存储与 PPT skill 路由

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build-linux-macos-freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.goos == 'darwin' && 'macos-latest' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -199,11 +199,58 @@ jobs:
           chmod +x "${BIN}-gateway"
           tar -czf "${BASE}.tar.gz" "${BIN}" "${LAUNCHER_BIN}" "${BIN}-gateway"
 
+      - name: Package macOS Electron App
+        if: matrix.goos == 'darwin'
+        shell: bash
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          set -euo pipefail
+          
+          # Copy Go binaries to Electron project
+          cp dist/${APP_NAME} clawpet-frontend/clawpet/picoclaw
+          cp dist/${APP_NAME}-web clawpet-frontend/clawpet/picoclaw-web
+          
+          # Build Electron app for macOS
+          cd clawpet-frontend/clawpet
+          
+          # Install dependencies
+          npm install
+          
+          # Build Next.js
+          npm run build
+          
+          # Package with electron-builder
+          if [[ "${{ matrix.goarch }}" == "arm64" ]]; then
+            npx electron-builder --mac --arm64 --publish never
+          elif [[ "${{ matrix.goarch }}" == "amd64" ]]; then
+            npx electron-builder --mac --x64 --publish never
+          else
+            npx electron-builder --mac --publish never
+          fi
+          
+          # Copy Electron app zip to release directory (as the main package)
+          cd dist
+          
+          # Find Electron builder output
+          electronZip=$(ls -t ClawPet*.zip 2>/dev/null | head -1)
+          if [[ -n "$electronZip" ]]; then
+            repoDist="../../../dist"
+            mkdir -p "$repoDist"
+            # Use standard naming for the complete package
+            cp "$electronZip" "${repoDist}/${APP_NAME}_${{ matrix.file_os }}_${{ matrix.file_arch }}.zip"
+            echo "✅ Main package (Electron + Backend): $electronZip"
+          else
+            echo "️  No Electron zip found"
+          fi
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-arm{0}', matrix.goarm) || '' }}
-          path: dist/*.tar.gz
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
           if-no-files-found: error
 
   build-windows:
@@ -348,11 +395,6 @@ jobs:
           exit /b %EXIT_CODE%
           '@ | Out-File -FilePath "${{ env.APP_NAME }}-gateway.bat" -Encoding ASCII
 
-          # Standard package using PowerShell Compress-Archive
-          $zipFiles = @($WIN_BIN, $WIN_LAUNCHER_BIN, "${{ env.APP_NAME }}-gateway.bat")
-          Compress-Archive -Path $zipFiles -DestinationPath "${BASE}.zip" -Force
-          Write-Host "✅ Standard package created: ${BASE}.zip"
-
           # Copy Go binaries to Electron project
           Copy-Item -Path $WIN_BIN -Destination "../clawpet-frontend/clawpet/picoclaw.exe" -Force
           Copy-Item -Path $WIN_LAUNCHER_BIN -Destination "../clawpet-frontend/clawpet/picoclaw-web.exe" -Force
@@ -368,17 +410,21 @@ jobs:
             npx electron-builder --win --publish never
           }
           
-          # Copy built zip to release directory
+          # Copy Electron app zip to release directory (as the main package)
           Set-Location dist
           Get-ChildItem
           
-          # Copy zip archive
-          $zipFile = Get-ChildItem -Filter "*.zip" | Select-Object -First 1
-          if ($zipFile) {
+          # Find Electron builder output
+          $electronZip = Get-ChildItem -Filter "ClawPet*.zip" | Select-Object -First 1
+          if ($electronZip) {
             $repoDist = "../../../dist"
             New-Item -ItemType Directory -Force -Path $repoDist | Out-Null
-            Copy-Item -Path $zipFile.FullName -Destination "${repoDist}/${{ env.APP_NAME }}_${{ matrix.file_os }}_${{ matrix.file_arch }}.zip" -Force
-            Write-Host "✅ Zip archive: $($zipFile.Name)"
+            # Use standard naming for the complete package
+            $mainDest = "${repoDist}/${{ env.APP_NAME }}_${{ matrix.file_os }}_${{ matrix.file_arch }}.zip"
+            Copy-Item -Path $electronZip.FullName -Destination $mainDest -Force
+            Write-Host "✅ Main package (Electron + Backend): $($electronZip.Name)"
+          } else {
+            Write-Host "⚠️  No Electron zip found" -ForegroundColor Yellow
           }
           
           # Copy win-unpacked directory for debugging

--- a/clawpet-frontend/clawpet/BUILD_GUIDE.md
+++ b/clawpet-frontend/clawpet/BUILD_GUIDE.md
@@ -144,7 +144,7 @@ cd clawpet-frontend\clawpet
 ### 查看日志
 
 ```powershell
-Get-Content "$env:USERPROFILE\.goclaw\logs.txt" -Tail 30
+Get-Content "$env:USERPROFILE\.picoclaw\logs.txt" -Tail 30
 ```
 
 成功启动的日志应包含：
@@ -323,6 +323,6 @@ git push origin v0.1.0
 
 如遇到问题：
 
-1. 查看日志文件：`$env:USERPROFILE\.goclaw\logs.txt`
+1. 查看日志文件：`$env:USERPROFILE\.picoclaw\logs.txt`
 2. 检查进程是否运行：`Get-Process -Name "ClawPet,picoclaw" -ErrorAction SilentlyContinue`
 3. 检查端口占用：`netstat -ano | findstr :18790` 和 `netstat -ano | findstr :18800`

--- a/clawpet-frontend/clawpet/build-and-test.ps1
+++ b/clawpet-frontend/clawpet/build-and-test.ps1
@@ -95,5 +95,5 @@ Write-Host "  # Method 2: Run portable version" -ForegroundColor Gray
 Write-Host "  & \"$ClawpetDir\dist\ClawPet 0.1.0.exe\"" -ForegroundColor White
 Write-Host ""
 Write-Host "View logs:" -ForegroundColor Yellow
-Write-Host "  Get-Content \"$env:USERPROFILE\.goclaw\logs.txt\" -Tail 30" -ForegroundColor White
+Write-Host "  Get-Content \"$env:USERPROFILE\.picoclaw\logs.txt\" -Tail 30" -ForegroundColor White
 Write-Host ""

--- a/clawpet-frontend/clawpet/diagnose-backend.ps1
+++ b/clawpet-frontend/clawpet/diagnose-backend.ps1
@@ -4,7 +4,7 @@
 Write-Host "`n=== ClawPet 后端服务诊断 ===" -ForegroundColor Cyan
 
 # 检查配置文件
-$configPath = "$env:USERPROFILE\.goclaw-runtime\config.json"
+$configPath = "$env:USERPROFILE\.picoclaw\config.json"
 Write-Host "`n[1] 检查配置文件: $configPath" -ForegroundColor Yellow
 
 if (Test-Path $configPath) {
@@ -112,7 +112,7 @@ try {
 # 检查日志文件
 Write-Host "`n[4] 检查日志文件" -ForegroundColor Yellow
 
-$logPath = "$env:USERPROFILE\.goclaw\logs.txt"
+$logPath = "$env:USERPROFILE\.picoclaw\logs.txt"
 if (Test-Path $logPath) {
     Write-Host "  ✓ 日志文件存在: $logPath" -ForegroundColor Green
     
@@ -136,6 +136,6 @@ Write-Host "`n=== 诊断完成 ===" -ForegroundColor Cyan
 Write-Host "`n提示：" -ForegroundColor Yellow
 Write-Host "1. 如果 Gateway 或 Launcher 未运行，请重启 ClawPet 应用" -ForegroundColor White
 Write-Host "2. 如果二进制文件缺失，请重新打包应用" -ForegroundColor White
-Write-Host "3. 如果配置有问题，请检查 ~/.goclaw-runtime/config.json" -ForegroundColor White
-Write-Host "4. 查看详细日志: Get-Content `$env:USERPROFILE\.goclaw\logs.txt -Tail 50" -ForegroundColor White
+Write-Host "3. 如果配置有问题，请检查 ~/.picoclaw/config.json" -ForegroundColor White
+Write-Host "4. 查看详细日志: Get-Content `$env:USERPROFILE\.picoclaw\logs.txt -Tail 50" -ForegroundColor White
 Write-Host ""

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -18,6 +18,7 @@ const { app, BrowserWindow, ipcMain, screen, globalShortcut } = require('electro
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
+const net = require('net');
 const { spawn } = require('child_process');
 
 // 全局窗口引用
@@ -90,7 +91,83 @@ function isLoopbackProxyValue(value) {
   }
 }
 
-function buildChildProcessEnv(extraEnv = {}) {
+function getLoopbackProxyTarget(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const defaultPorts = {
+    'http:': 80,
+    'https:': 443,
+    'socks5:': 1080,
+    'socks5h:': 1080,
+  };
+
+  try {
+    const parsed = new URL(trimmed);
+    const hostname = parsed.hostname;
+    if (hostname !== '127.0.0.1' && hostname !== 'localhost' && hostname !== '::1') {
+      return null;
+    }
+
+    const parsedPort = Number(parsed.port || defaultPorts[parsed.protocol] || 0);
+    if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+      return null;
+    }
+
+    return {
+      host: hostname === '::1' ? '127.0.0.1' : hostname,
+      port: parsedPort,
+      cacheKey: `${hostname}:${parsedPort}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const loopbackProxyReachabilityCache = new Map();
+
+function canConnectToLoopbackProxy(target, timeoutMs = 250) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: target.host, port: target.port });
+
+    const finalize = (reachable) => {
+      socket.removeAllListeners();
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+      resolve(reachable);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finalize(true));
+    socket.once('timeout', () => finalize(false));
+    socket.once('error', () => finalize(false));
+  });
+}
+
+async function shouldKeepLoopbackProxy(value) {
+  const target = getLoopbackProxyTarget(value);
+  if (!target) {
+    return false;
+  }
+
+  const cached = loopbackProxyReachabilityCache.get(target.cacheKey);
+  if (typeof cached === 'boolean') {
+    return cached;
+  }
+
+  const reachable = await canConnectToLoopbackProxy(target);
+  loopbackProxyReachabilityCache.set(target.cacheKey, reachable);
+  return reachable;
+}
+
+async function buildChildProcessEnv(extraEnv = {}) {
   const childEnv = { ...process.env };
   const proxyKeys = [
     'HTTP_PROXY',
@@ -102,7 +179,17 @@ function buildChildProcessEnv(extraEnv = {}) {
   ];
 
   for (const key of proxyKeys) {
-    if (isLoopbackProxyValue(childEnv[key])) {
+    if (!isLoopbackProxyValue(childEnv[key])) {
+      continue;
+    }
+
+    // Keep valid loopback proxies such as Clash/mitmproxy when they are
+    // actually reachable. We only strip stale loopback proxy env vars when
+    // the local proxy endpoint is no longer accepting connections, because
+    // that breaks packaged child processes while preserving intentional proxy
+    // setups and required egress controls.
+    const keepProxy = await shouldKeepLoopbackProxy(childEnv[key]);
+    if (!keepProxy) {
       delete childEnv[key];
     }
   }
@@ -279,7 +366,7 @@ const isProduction = app.isPackaged;
 let effectiveDashboardBaseUrl = dashboardBaseUrl;
 let nextServerProcess = null;
 
-function startNextServer() {
+async function startNextServer() {
   if (!isProduction) {
     return;
   }
@@ -308,18 +395,20 @@ function startNextServer() {
 
   logToFile(`[NEXT] Starting Next.js from ${appDir}`);
 
+  const childEnv = await buildChildProcessEnv({
+    ELECTRON_RUN_AS_NODE: '1',
+    NODE_ENV: 'production',
+    PORT: '3000',
+    NEXT_PUBLIC_PICOCLAW_API_URL: 'http://127.0.0.1:18800',
+    NEXT_PUBLIC_PICOCLAW_WS_URL: 'ws://127.0.0.1:18800',
+    NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL: 'http://127.0.0.1:18790',
+  });
+
   nextServerProcess = spawn(process.execPath, [nextCliPath, 'start', '-p', '3000'], {
     cwd: appDir,
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    env: buildChildProcessEnv({
-      ELECTRON_RUN_AS_NODE: '1',
-      NODE_ENV: 'production',
-      PORT: '3000',
-      NEXT_PUBLIC_PICOCLAW_API_URL: 'http://127.0.0.1:18800',
-      NEXT_PUBLIC_PICOCLAW_WS_URL: 'ws://127.0.0.1:18800',
-      NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL: 'http://127.0.0.1:18790',
-    }),
+    env: childEnv,
   });
 
   nextServerProcess.stdout.on('data', (data) => {
@@ -1577,7 +1666,7 @@ async function startBackendServices() {
   logToFile('[BACKEND] Starting embedded backend services...');
   if (isProduction) {
     try {
-      startNextServer();
+      await startNextServer();
     } catch (error) {
       logToFile(`[BACKEND] Failed to start Next.js: ${error.message}`);
     }
@@ -1607,21 +1696,28 @@ async function startBackendServices() {
 /**
  * 启动 Launcher 服务
  */
-function startLauncher(exePath, workDir) {
-  return new Promise((resolve, reject) => {
-    const configDir = path.join(os.homedir(), '.picoclaw');
-    if (!fs.existsSync(configDir)) {
-      fs.mkdirSync(configDir, { recursive: true });
-    }
-    
-    const configPath = path.join(configDir, 'config.json');
-    
-    if (!launcherToken) {
-      launcherToken = embeddedLauncherTokenDefault;
-    }
-    process.env.GOCLAW_LAUNCHER_TOKEN = launcherToken;
-    process.env.PICOCLAW_LAUNCHER_TOKEN = launcherToken;
+async function startLauncher(exePath, workDir) {
+  const configDir = path.join(os.homedir(), '.picoclaw');
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  
+  const configPath = path.join(configDir, 'config.json');
+  
+  if (!launcherToken) {
+    launcherToken = embeddedLauncherTokenDefault;
+  }
+  process.env.GOCLAW_LAUNCHER_TOKEN = launcherToken;
+  process.env.PICOCLAW_LAUNCHER_TOKEN = launcherToken;
 
+  const childEnv = await buildChildProcessEnv({
+    PICOCLAW_LAUNCHER_TOKEN: launcherToken,
+    GOCLAW_LAUNCHER_TOKEN: launcherToken,
+    PICOCLAW_HOME: configDir,
+    PICOCLAW_CONFIG: configPath
+  });
+
+  return new Promise((resolve, reject) => {
     launcherProcess = spawn(exePath, [
       '-port', '18800',
       '-no-browser',
@@ -1630,12 +1726,7 @@ function startLauncher(exePath, workDir) {
       cwd: workDir,
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: buildChildProcessEnv({
-        PICOCLAW_LAUNCHER_TOKEN: launcherToken,
-        GOCLAW_LAUNCHER_TOKEN: launcherToken,
-        PICOCLAW_HOME: configDir,
-        PICOCLAW_CONFIG: configPath
-      }),
+      env: childEnv,
     });
     
     launcherProcess.stdout.on('data', (data) => {
@@ -1679,10 +1770,16 @@ function startLauncher(exePath, workDir) {
 /**
  * 启动 Gateway 服务
  */
-function startGateway(exePath, workDir) {
+async function startGateway(exePath, workDir) {
+  const configDir = path.join(os.homedir(), '.picoclaw');
+  const configPath = path.join(configDir, 'config.json');
+
+  const childEnv = await buildChildProcessEnv({
+    PICOCLAW_HOME: configDir,
+    PICOCLAW_CONFIG: configPath
+  });
+
   return new Promise((resolve, reject) => {
-    const configDir = path.join(os.homedir(), '.picoclaw');
-    const configPath = path.join(configDir, 'config.json');
     
     logToFile(`[GATEWAY] Config dir: ${configDir}`);
     logToFile(`[GATEWAY] Config path: ${configPath}`);
@@ -1714,10 +1811,7 @@ function startGateway(exePath, workDir) {
       cwd: workDir,
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: buildChildProcessEnv({
-        PICOCLAW_HOME: configDir,
-        PICOCLAW_CONFIG: configPath
-      }),
+      env: childEnv,
     });
     
     gatewayProcess.stdout.on('data', (data) => {

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -62,9 +62,9 @@ let bubbleWindowHeight = BUBBLE_WINDOW_DEFAULT_HEIGHT;
 
 /**
  * 设置 Electron 用户数据目录
- * 使用 .goclaw 目录存储日志等数据
+ * 使用 .picoclaw 目录存储日志等数据
  */
-const userDataPath = path.join(os.homedir(), '.goclaw');
+const userDataPath = path.join(os.homedir(), '.picoclaw');
 app.setPath('userData', userDataPath);
 const onboardingStatePath = path.join(userDataPath, 'onboarding-state.json');
 
@@ -72,9 +72,50 @@ if (!fs.existsSync(userDataPath)) {
   fs.mkdirSync(userDataPath, { recursive: true });
 }
 
+function isLoopbackProxyValue(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost' || parsed.hostname === '::1';
+  } catch {
+    return /^(https?|socks5h?):\/\/(127\.0\.0\.1|localhost|\[::1\])(?::\d+)?$/i.test(trimmed);
+  }
+}
+
+function buildChildProcessEnv(extraEnv = {}) {
+  const childEnv = { ...process.env };
+  const proxyKeys = [
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'ALL_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'all_proxy',
+  ];
+
+  for (const key of proxyKeys) {
+    if (isLoopbackProxyValue(childEnv[key])) {
+      delete childEnv[key];
+    }
+  }
+
+  return {
+    ...childEnv,
+    ...extraEnv,
+  };
+}
+
 /**
  * 日志系统配置
- * 所有日志输出到 ~/.goclaw/logs.txt
+ * 所有日志输出到 ~/.picoclaw/logs.txt
  */
 const logFilePath = path.join(userDataPath, 'logs.txt');
 const logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
@@ -271,15 +312,14 @@ function startNextServer() {
     cwd: appDir,
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    env: {
-      ...process.env,
+    env: buildChildProcessEnv({
       ELECTRON_RUN_AS_NODE: '1',
       NODE_ENV: 'production',
       PORT: '3000',
       NEXT_PUBLIC_PICOCLAW_API_URL: 'http://127.0.0.1:18800',
       NEXT_PUBLIC_PICOCLAW_WS_URL: 'ws://127.0.0.1:18800',
       NEXT_PUBLIC_PICOCLAW_DIRECT_GATEWAY_URL: 'http://127.0.0.1:18790',
-    },
+    }),
   });
 
   nextServerProcess.stdout.on('data', (data) => {
@@ -1569,7 +1609,7 @@ async function startBackendServices() {
  */
 function startLauncher(exePath, workDir) {
   return new Promise((resolve, reject) => {
-    const configDir = path.join(os.homedir(), '.goclaw-runtime');
+    const configDir = path.join(os.homedir(), '.picoclaw');
     if (!fs.existsSync(configDir)) {
       fs.mkdirSync(configDir, { recursive: true });
     }
@@ -1590,13 +1630,12 @@ function startLauncher(exePath, workDir) {
       cwd: workDir,
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
+      env: buildChildProcessEnv({
         PICOCLAW_LAUNCHER_TOKEN: launcherToken,
         GOCLAW_LAUNCHER_TOKEN: launcherToken,
         PICOCLAW_HOME: configDir,
         PICOCLAW_CONFIG: configPath
-      }
+      }),
     });
     
     launcherProcess.stdout.on('data', (data) => {
@@ -1642,7 +1681,7 @@ function startLauncher(exePath, workDir) {
  */
 function startGateway(exePath, workDir) {
   return new Promise((resolve, reject) => {
-    const configDir = path.join(os.homedir(), '.goclaw-runtime');
+    const configDir = path.join(os.homedir(), '.picoclaw');
     const configPath = path.join(configDir, 'config.json');
     
     logToFile(`[GATEWAY] Config dir: ${configDir}`);
@@ -1675,11 +1714,10 @@ function startGateway(exePath, workDir) {
       cwd: workDir,
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
+      env: buildChildProcessEnv({
         PICOCLAW_HOME: configDir,
         PICOCLAW_CONFIG: configPath
-      }
+      }),
     });
     
     gatewayProcess.stdout.on('data', (data) => {

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -15,8 +15,6 @@ import {
 
 const SESSIONS_STORAGE_KEY = "petclaw_sessions"
 const ACTIVE_SESSION_KEY = "petclaw_active_session"
-const PPT_SKILL_NAME = "student-ppt-pet"
-const PPT_TRIGGER_RE = /(\bppt\b|PPT|幻灯片|答辩|汇报|开题|课件)/i
 
 export interface UseChatOptions {
   onMessage?: (message: ChatMessage) => void
@@ -206,14 +204,7 @@ function mergeMessage(
 }
 
 function buildOutgoingMessage(raw: string): string {
-  const text = raw.trim()
-  if (text.startsWith("/")) {
-    return text
-  }
-  if (!PPT_TRIGGER_RE.test(text)) {
-    return text
-  }
-  return `/use ${PPT_SKILL_NAME} ${text}`
+  return raw.trim()
 }
 
 function decodeBase64Chunk(value: string): Uint8Array | null {

--- a/clawpet-frontend/clawpet/package.json
+++ b/clawpet-frontend/clawpet/package.json
@@ -49,6 +49,14 @@
         }
       ],
       "signAndEditExecutable": false
+    },
+    "mac": {
+      "target": [
+        {
+          "target": "zip"
+        }
+      ],
+      "category": "public.app-category.entertainment"
     }
   },
   "dependencies": {

--- a/clawpet-frontend/clawpet/reset-onboarding.ps1
+++ b/clawpet-frontend/clawpet/reset-onboarding.ps1
@@ -44,9 +44,9 @@ if ($confirm -ne "y" -and $confirm -ne "Y") {
 }
 
 # 定义路径
-$goclawDir = "$env:USERPROFILE\.goclaw"
-$onboardingStateFile = "$goclawDir\onboarding-state.json"
-$logFile = "$goclawDir\logs.txt"
+$picoclawDir = "$env:USERPROFILE\.picoclaw"
+$onboardingStateFile = "$picoclawDir\onboarding-state.json"
+$logFile = "$picoclawDir\logs.txt"
 $clawpetExe = "D:\study part\GoClawPet\clawpet-frontend\clawpet\dist\win-unpacked\ClawPet.exe"
 
 # 步骤1：停止所有相关进程

--- a/clawpet-frontend/clawpet/run-packaged.ps1
+++ b/clawpet-frontend/clawpet/run-packaged.ps1
@@ -26,5 +26,5 @@ Write-Host "Tips:" -ForegroundColor Yellow
 Write-Host "  - Startup progress window will appear first" -ForegroundColor Gray
 Write-Host "  - Backend services will auto-start (Gateway + Launcher)" -ForegroundColor Gray
 Write-Host "  - Check logs if needed:" -ForegroundColor Gray
-Write-Host "    Get-Content `"$env:USERPROFILE\.goclaw\logs.txt`" -Tail 30" -ForegroundColor White
+Write-Host "    Get-Content `"$env:USERPROFILE\.picoclaw\logs.txt`" -Tail 30" -ForegroundColor White
 Write-Host ""

--- a/clawpet-frontend/clawpet/test-app.ps1
+++ b/clawpet-frontend/clawpet/test-app.ps1
@@ -87,5 +87,5 @@ Write-Host ""
 Write-Host "Tips:" -ForegroundColor Yellow
 Write-Host "  - The app will show startup progress window first" -ForegroundColor Gray
 Write-Host "  - Gateway (18790) and Launcher (18800) will auto-start" -ForegroundColor Gray
-Write-Host "  - View logs: Get-Content \"$env:USERPROFILE\.goclaw\logs.txt\" -Tail 30" -ForegroundColor Gray
+Write-Host "  - View logs: Get-Content \"$env:USERPROFILE\.picoclaw\logs.txt\" -Tail 30" -ForegroundColor Gray
 Write-Host ""

--- a/clawpet-frontend/clawpet/verify-services.ps1
+++ b/clawpet-frontend/clawpet/verify-services.ps1
@@ -72,7 +72,7 @@ try {
 
 # 检查最新日志
 Write-Host "`n[4] 最新日志（最近 10 行）" -ForegroundColor Yellow
-$logPath = "$env:USERPROFILE\.goclaw\logs.txt"
+$logPath = "$env:USERPROFILE\.picoclaw\logs.txt"
 if (Test-Path $logPath) {
     Get-Content $logPath -Tail 10 | ForEach-Object {
         if ($_ -match "ERROR|Failed|error") {
@@ -90,5 +90,5 @@ if (Test-Path $logPath) {
 Write-Host "`n=== 验证完成 ===" -ForegroundColor Cyan
 Write-Host "`n提示：" -ForegroundColor Yellow
 Write-Host "- 如果所有检查都通过，WebSocket 连接应该正常工作" -ForegroundColor White
-Write-Host "- 如果仍有问题，请查看完整日志: Get-Content `$env:USERPROFILE\.goclaw\logs.txt -Tail 50" -ForegroundColor White
+Write-Host "- 如果仍有问题，请查看完整日志: Get-Content `$env:USERPROFILE\.picoclaw\logs.txt -Tail 50" -ForegroundColor White
 Write-Host ""


### PR DESCRIPTION
关联 Issue: #223

## 变更说明
这个 PR 主要围绕 ClawPet 的“可发布、可运行、可排查”三件事做了一次收敛，包含以下几部分：

1. 运行时目录统一到 `.picoclaw`
- 修正打包运行时仍写入 `.goclaw` / `.goclaw-runtime` 的问题
- 让 ClawPet 的数据目录与 PicoClaw 主体保持一致，减少配置、日志、workspace 分裂

2. 去掉前端对 PPT skill 的硬编码路由
- 删除前端把 PPT 相关聊天请求强制改写成 `/use student-ppt-pet` 的逻辑
- 恢复为由后端模型根据已安装 skill 自行判断是否使用 `pptx` 等能力

3. 优化打包版代理继承策略
- 保留健康可用的本地 loopback 代理（如 Clash、mitmproxy）
- 仅在 loopback 代理配置存在但本地端口已不可达时，才自动剥离代理环境变量
- 避免“残留死代理”导致模型请求失败，同时不破坏用户有意配置的本地代理链路

4. 对齐发布工作流与配套脚本
- 对齐上游 release workflow 与 fork 中已验证通过的发布链路
- 补齐 macOS Electron 打包配置
- 同步本地打包、运行、诊断、重置、验证脚本，以及相关文档中的 `.picoclaw` 路径

## 验证
- `node --check clawpet-frontend/clawpet/electron/main.js`
- `npm run build`（目录：`clawpet-frontend/clawpet`）
- 在 fork 中已验证最新 release workflow 可成功完成：
  - Windows 打包
  - macOS Darwin x86_64 打包
  - macOS Darwin arm64 打包

## 影响范围
- ClawPet 打包运行时
- 技能路由行为（PPT 相关请求）
- 发布工作流与本地排障脚本