### PR TITLE
[codex] 添加 pptx  skill

### DIFF
--- a/workspace/skills/pptx/SKILL.md
+++ b/workspace/skills/pptx/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pptx
+description: Use this skill when the user asks to create, edit, review, or repair PowerPoint `.pptx` presentations. It supports both generating decks from scratch and making surgical changes to existing files.
+---
+
+# PPTX
+
+Use this skill when the task is specifically about PowerPoint `.pptx` files.
+
+This workspace install is adapted from Anthropic's `pptx` skill so it works locally inside GoClaw without requiring a global install.
+
+## When To Use It
+
+- Creating a new presentation from scratch
+- Editing slide text, notes, order, or structure
+- Reviewing an existing deck and proposing changes
+- Repairing or inspecting a broken `.pptx`
+- Generating helper artifacts such as thumbnails or unpacked XML
+
+## Core Principles
+
+- Prefer `pptxgenjs` when building a deck from scratch or doing broad layout changes.
+- Prefer unpacking the `.pptx` archive when you need precise edits to an existing presentation.
+- Always keep generated files inside the workspace.
+- After structural edits, create a preview image when possible so the result can be checked quickly.
+
+## Workflow
+
+### 1. Understand The Goal
+
+Clarify whether the user wants one of these:
+
+- Create a new deck
+- Modify an existing deck
+- Review and comment on a deck
+- Repair a broken deck
+
+### 2. Choose An Editing Path
+
+#### Path A: Build Or Rebuild With `pptxgenjs`
+
+Use this when:
+
+- The user wants a new presentation
+- The deck needs large-scale layout changes
+- You do not need pixel-perfect preservation of the original file
+
+Reference: `pptxgenjs.md`
+
+#### Path B: Edit The Existing PPTX Package
+
+Use this when:
+
+- The user wants targeted edits to an existing `.pptx`
+- The current layout should remain mostly intact
+- You need to preserve theme, animations, notes, or embedded assets as much as possible
+
+Reference: `editing.md`
+
+### 3. Validate
+
+After edits:
+
+1. Confirm the `.pptx` opens.
+2. Generate a thumbnail preview if the environment supports it:
+
+```bash
+python workspace/skills/pptx/scripts/thumbnail.py path/to/deck.pptx
+```
+
+3. If you unpacked the file for editing, remove temp folders when done:
+
+```bash
+python workspace/skills/pptx/scripts/clean.py path/to/unpacked-dir
+```
+
+## Helper Commands
+
+Unpack a presentation:
+
+```bash
+python workspace/skills/pptx/scripts/office/unpack.py path/to/deck.pptx
+```
+
+Pack an unpacked folder back into a `.pptx`:
+
+```bash
+python workspace/skills/pptx/scripts/office/pack.py path/to/unpacked-dir path/to/output.pptx
+```
+
+Clone an existing slide as a starting point for a new slide:
+
+```bash
+python workspace/skills/pptx/scripts/add_slide.py path/to/deck.pptx --source-index 1 --output path/to/output.pptx
+```
+
+## Constraints
+
+- Do not overwrite the user's source file unless they explicitly ask for in-place edits.
+- Keep intermediate files in the workspace.
+- Prefer reversible changes and save edited output as a new file when possible.
+- If preview generation is unavailable on the current machine, explain that clearly instead of pretending validation succeeded.

--- a/workspace/skills/pptx/editing.md
+++ b/workspace/skills/pptx/editing.md
@@ -1,0 +1,42 @@
+# Editing Existing PPTX Files
+
+PowerPoint files are ZIP archives that contain Open XML parts.
+
+Use this path when the user wants small or surgical edits while preserving the original look and structure.
+
+## Recommended Flow
+
+1. Unpack the `.pptx` archive.
+2. Inspect the relevant XML parts under `ppt/`.
+3. Make the smallest possible edit.
+4. Repack into a new `.pptx`.
+5. Validate by opening or generating a preview.
+
+## High-Value Locations
+
+- `ppt/slides/slide*.xml`: slide body content
+- `ppt/notesSlides/`: speaker notes
+- `ppt/presentation.xml`: slide order and global deck structure
+- `ppt/_rels/` and `ppt/slides/_rels/`: relationships for linked assets
+- `ppt/media/`: embedded images and media
+
+## Good Uses For XML Editing
+
+- Fixing typo-level text changes
+- Updating notes
+- Swapping or replacing media assets
+- Duplicating or reordering slides carefully
+- Repairing relationship issues in a broken deck
+
+## Things To Be Careful About
+
+- Relationship ids must stay consistent.
+- Slide duplication requires both XML parts and relationship entries.
+- Some formatting is split across theme, master, and layout parts.
+- Repacking with the wrong ZIP layout can make Office reject the file.
+
+## Practical Advice
+
+- Preserve filenames and directory layout exactly.
+- Prefer cloning an existing slide instead of constructing XML from scratch.
+- If a change grows beyond a few XML parts, consider rebuilding the deck with `pptxgenjs` instead.

--- a/workspace/skills/pptx/pptxgenjs.md
+++ b/workspace/skills/pptx/pptxgenjs.md
@@ -1,0 +1,31 @@
+# PptxGenJS Notes
+
+Use `PptxGenJS` when you need to generate a new PowerPoint deck or substantially restructure an old one.
+
+## Best For
+
+- New presentations
+- Multi-slide rewrites
+- Template-based generation
+- Programmatic charts, tables, and repeated layouts
+
+## Recommended Approach
+
+1. Build a clear slide outline first.
+2. Define a small theme: fonts, colors, margins, title style.
+3. Create slides with consistent spacing and hierarchy.
+4. Render to a new `.pptx`.
+5. Validate the output with a preview image when possible.
+
+## Design Guidance
+
+- Keep each slide focused on one job.
+- Use strong visual hierarchy.
+- Prefer fewer bullets with larger type.
+- Keep speaker notes separate from visible body text.
+
+## When Not To Use It
+
+- When the user needs exact preservation of a manually designed deck
+- When the task is a small edit to an existing slide
+- When you must preserve animations or niche Office-only features

--- a/workspace/skills/pptx/scripts/add_slide.py
+++ b/workspace/skills/pptx/scripts/add_slide.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from office.pack import main as pack_main  # type: ignore
+from office.unpack import main as unpack_main  # type: ignore
+
+
+NS = {
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+    "rel": "http://schemas.openxmlformats.org/package/2006/relationships",
+}
+
+
+def next_numeric_suffix(paths: list[Path], prefix: str, suffix: str) -> int:
+    nums: list[int] = []
+    for path in paths:
+        name = path.name
+        if name.startswith(prefix) and name.endswith(suffix):
+            middle = name[len(prefix) : -len(suffix)]
+            if middle.isdigit():
+                nums.append(int(middle))
+    return (max(nums) + 1) if nums else 1
+
+
+def clone_slide(workdir: Path, source_index: int) -> None:
+    slides_dir = workdir / "ppt" / "slides"
+    rels_dir = slides_dir / "_rels"
+    presentation_xml = workdir / "ppt" / "presentation.xml"
+    presentation_rels = workdir / "ppt" / "_rels" / "presentation.xml.rels"
+
+    slides = sorted(slides_dir.glob("slide*.xml"))
+    if source_index < 1 or source_index > len(slides):
+        raise SystemExit(f"source slide index out of range: {source_index}")
+
+    source_slide = slides[source_index - 1]
+    source_rel = rels_dir / f"{source_slide.name}.rels"
+
+    next_index = next_numeric_suffix(slides, "slide", ".xml")
+    new_slide = slides_dir / f"slide{next_index}.xml"
+    new_rel = rels_dir / f"{new_slide.name}.rels"
+
+    shutil.copy2(source_slide, new_slide)
+    if source_rel.exists():
+        shutil.copy2(source_rel, new_rel)
+
+    pres_tree = ET.parse(presentation_xml)
+    pres_root = pres_tree.getroot()
+    sld_id_lst = pres_root.find("p:sldIdLst", NS)
+    if sld_id_lst is None:
+        raise SystemExit("presentation.xml missing p:sldIdLst")
+
+    existing_ids = [int(node.attrib["id"]) for node in sld_id_lst.findall("p:sldId", NS)]
+    new_id = max(existing_ids) + 1 if existing_ids else 256
+
+    rel_tree = ET.parse(presentation_rels)
+    rel_root = rel_tree.getroot()
+    existing_rids = []
+    for rel in rel_root.findall("rel:Relationship", NS):
+        rid = rel.attrib.get("Id", "")
+        if rid.startswith("rId") and rid[3:].isdigit():
+            existing_rids.append(int(rid[3:]))
+    new_rid = f"rId{(max(existing_rids) + 1) if existing_rids else 1}"
+
+    ET.SubElement(
+        rel_root,
+        "{http://schemas.openxmlformats.org/package/2006/relationships}Relationship",
+        {
+            "Id": new_rid,
+            "Type": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+            "Target": f"slides/{new_slide.name}",
+        },
+    )
+
+    ET.SubElement(
+        sld_id_lst,
+        "{http://schemas.openxmlformats.org/presentationml/2006/main}sldId",
+        {
+            "id": str(new_id),
+            "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id": new_rid,
+        },
+    )
+
+    pres_tree.write(presentation_xml, encoding="utf-8", xml_declaration=True)
+    rel_tree.write(presentation_rels, encoding="utf-8", xml_declaration=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Clone an existing slide in a PPTX file.")
+    parser.add_argument("pptx", help="Source PPTX file")
+    parser.add_argument("--source-index", type=int, default=1, help="1-based slide index to clone")
+    parser.add_argument("--output", required=True, help="Output PPTX file")
+    args = parser.parse_args()
+
+    src = Path(args.pptx).expanduser().resolve()
+    if not src.is_file():
+        raise SystemExit(f"Source PPTX not found: {src}")
+
+    output = Path(args.output).expanduser().resolve()
+    with tempfile.TemporaryDirectory(prefix="pptx-clone-") as temp_dir:
+        workdir = Path(temp_dir) / "deck"
+        unpack_cmd = ["", str(src), "--output", str(workdir)]
+        pack_cmd = ["", str(workdir), str(output)]
+
+        import sys
+
+        old_argv = sys.argv[:]
+        try:
+            sys.argv = unpack_cmd
+            unpack_main()
+            clone_slide(workdir, args.source_index)
+            sys.argv = pack_cmd
+            pack_main()
+        finally:
+            sys.argv = old_argv
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace/skills/pptx/scripts/clean.py
+++ b/workspace/skills/pptx/scripts/clean.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Remove an unpacked PPTX working directory.")
+    parser.add_argument("path", help="Directory to remove")
+    args = parser.parse_args()
+
+    target = Path(args.path).expanduser().resolve()
+    if not target.exists():
+        print(f"Nothing to clean: {target}")
+        return 0
+    if not target.is_dir():
+        raise SystemExit(f"Not a directory: {target}")
+
+    shutil.rmtree(target)
+    print(f"Removed {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace/skills/pptx/scripts/office/__init__.py
+++ b/workspace/skills/pptx/scripts/office/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for local PPTX helper scripts.

--- a/workspace/skills/pptx/scripts/office/pack.py
+++ b/workspace/skills/pptx/scripts/office/pack.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import argparse
+import zipfile
+from pathlib import Path
+
+
+def iter_files(root: Path):
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pack an unpacked PPTX directory into a PPTX file.")
+    parser.add_argument("input_dir", help="Unpacked PPTX directory")
+    parser.add_argument("output", help="Output PPTX file")
+    args = parser.parse_args()
+
+    src = Path(args.input_dir).expanduser().resolve()
+    if not src.is_dir():
+        raise SystemExit(f"Input directory not found: {src}")
+
+    output = Path(args.output).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    content_types = src / "[Content_Types].xml"
+    if not content_types.exists():
+        raise SystemExit(f"Missing [Content_Types].xml in {src}")
+
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in iter_files(src):
+            zf.write(path, path.relative_to(src).as_posix())
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace/skills/pptx/scripts/office/unpack.py
+++ b/workspace/skills/pptx/scripts/office/unpack.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import zipfile
+from pathlib import Path
+
+
+def default_output(src: Path) -> Path:
+    return src.parent / f"{src.stem}_unpacked"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unpack a PPTX file into a working directory.")
+    parser.add_argument("pptx", help="Source PPTX file")
+    parser.add_argument("--output", help="Destination directory")
+    parser.add_argument("--force", action="store_true", help="Replace existing output directory")
+    args = parser.parse_args()
+
+    src = Path(args.pptx).expanduser().resolve()
+    if not src.is_file():
+        raise SystemExit(f"Source PPTX not found: {src}")
+
+    output = Path(args.output).expanduser().resolve() if args.output else default_output(src)
+    if output.exists():
+        if not args.force:
+            raise SystemExit(f"Output already exists: {output}. Use --force to replace it.")
+        shutil.rmtree(output)
+    output.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(src, "r") as zf:
+        zf.extractall(output)
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace/skills/pptx/scripts/thumbnail.py
+++ b/workspace/skills/pptx/scripts/thumbnail.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=True, text=True, capture_output=True)
+
+
+def make_with_qlmanage(src: Path, output: Path) -> bool:
+    if not shutil.which("qlmanage"):
+        return False
+    with tempfile.TemporaryDirectory(prefix="pptx-thumb-") as temp_dir:
+        run(["qlmanage", "-t", "-s", "2000", "-o", temp_dir, str(src)])
+        generated = Path(temp_dir) / f"{src.name}.png"
+        if not generated.exists():
+            return False
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(generated, output)
+        return True
+
+
+def make_with_libreoffice(src: Path, output: Path) -> bool:
+    soffice = shutil.which("soffice") or shutil.which("libreoffice")
+    if not soffice:
+        return False
+
+    converter = shutil.which("pdftoppm") or shutil.which("magick")
+    if not converter:
+        return False
+
+    with tempfile.TemporaryDirectory(prefix="pptx-pdf-") as temp_dir:
+        temp_path = Path(temp_dir)
+        run([soffice, "--headless", "--convert-to", "pdf", "--outdir", str(temp_path), str(src)])
+        pdf = temp_path / f"{src.stem}.pdf"
+        if not pdf.exists():
+            return False
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if Path(converter).name == "pdftoppm":
+            prefix = temp_path / "slide"
+            run(["pdftoppm", "-png", "-f", "1", "-singlefile", str(pdf), str(prefix)])
+            generated = temp_path / "slide.png"
+            if not generated.exists():
+                return False
+            shutil.copy2(generated, output)
+            return True
+
+        run(["magick", f"{pdf}[0]", str(output)])
+        return output.exists()
+
+
+def default_output(src: Path) -> Path:
+    return src.with_suffix(".png")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a preview PNG for a PPTX file.")
+    parser.add_argument("pptx", help="Source PPTX file")
+    parser.add_argument("--output", help="Output PNG path")
+    args = parser.parse_args()
+
+    src = Path(args.pptx).expanduser().resolve()
+    if not src.is_file():
+        raise SystemExit(f"Source PPTX not found: {src}")
+
+    output = Path(args.output).expanduser().resolve() if args.output else default_output(src)
+
+    if make_with_qlmanage(src, output) or make_with_libreoffice(src, output):
+        print(output)
+        return 0
+
+    raise SystemExit(
+        "Could not generate thumbnail. Install `qlmanage` (macOS Quick Look), "
+        "`soffice` plus `pdftoppm`, or `ImageMagick`."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更内容

- 在 `workspace/skills/pptx` 下新增一个工作区级 `pptx` skill
- 补充了用于创建、编辑、评审和修复 `.pptx` 文件的使用说明
- 增加了辅助脚本，用于解包、回包、克隆幻灯片、清理临时目录以及生成缩略图

## 变更原因

这次改动为 GoClaw 增加了一套可复用的 PowerPoint 工作流。这样在处理演示文稿相关任务时，可以直接使用专门的本地 skill，而不需要每次临时拼接说明。

## 影响

- 用户现在可以通过专门的 `pptx` skill 处理演示文稿生成和编辑任务
- 这个 skill 同时支持“整体重建”式工作流和“精细 XML/包结构编辑”式工作流
- 配套脚本让工作区内常见的 `.pptx` 操作更容易自动化

## 验证方式

- 已确认新增文件仅位于 `workspace/skills/pptx`
- 已对脚本做基础冒烟检查，执行了以下命令：
  - `python3 workspace/skills/pptx/scripts/office/unpack.py --help`
  - `python3 workspace/skills/pptx/scripts/office/pack.py --help`
  - `python3 workspace/skills/pptx/scripts/thumbnail.py --help`
  - `python3 workspace/skills/pptx/scripts/add_slide.py --help`

## 备注

本次 PR 有意不包含本地对 `workspace/skills/student-ppt-pet` 的删除改动。
