### PR TITLE
fix: sync embedded clawpet backends before packaging

### DIFF
--- a/clawpet-frontend/clawpet/electron/before-pack.js
+++ b/clawpet-frontend/clawpet/electron/before-pack.js
@@ -1,0 +1,127 @@
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+function statSafe(targetPath) {
+  try {
+    return fs.statSync(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+function latestMtimeMs(targetPath) {
+  const stat = statSafe(targetPath);
+  if (!stat) {
+    return 0;
+  }
+
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let latest = stat.mtimeMs;
+  for (const entry of fs.readdirSync(targetPath, { withFileTypes: true })) {
+    latest = Math.max(latest, latestMtimeMs(path.join(targetPath, entry.name)));
+  }
+  return latest;
+}
+
+function ensureDir(targetPath) {
+  fs.mkdirSync(targetPath, { recursive: true });
+}
+
+function copyIfDifferent(fromPath, toPath) {
+  const fromStat = statSafe(fromPath);
+  if (!fromStat) {
+    throw new Error(`missing source binary: ${fromPath}`);
+  }
+
+  const toStat = statSafe(toPath);
+  if (
+    toStat &&
+    toStat.size === fromStat.size &&
+    Math.abs(toStat.mtimeMs - fromStat.mtimeMs) < 1
+  ) {
+    return false;
+  }
+
+  ensureDir(path.dirname(toPath));
+  fs.copyFileSync(fromPath, toPath);
+  fs.utimesSync(toPath, fromStat.atime, fromStat.mtime);
+  return true;
+}
+
+function buildBinary(repoRoot, outputPath, target) {
+  ensureDir(path.dirname(outputPath));
+  execFileSync(
+    "go",
+    ["build", "-tags", "goolm,stdjson", "-o", outputPath, target],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+    },
+  );
+}
+
+module.exports = async function beforePack() {
+  if (process.platform !== "win32") {
+    console.log("[beforePack] skipping embedded backend sync on non-Windows host");
+    return;
+  }
+
+  const projectDir = path.resolve(__dirname, "..");
+  const repoRoot = path.resolve(projectDir, "..", "..");
+  const distDir = path.join(repoRoot, "dist");
+
+  const sharedSourceMtime = Math.max(
+    latestMtimeMs(path.join(repoRoot, "pkg")),
+    latestMtimeMs(path.join(repoRoot, "go.mod")),
+    latestMtimeMs(path.join(repoRoot, "go.sum")),
+  );
+
+  const binaries = [
+    {
+      label: "gateway",
+      outputName: "picoclaw.exe",
+      buildTarget: "./cmd/picoclaw",
+      sourceMtime: Math.max(
+        sharedSourceMtime,
+        latestMtimeMs(path.join(repoRoot, "cmd", "picoclaw")),
+      ),
+    },
+    {
+      label: "launcher",
+      outputName: "picoclaw-web.exe",
+      buildTarget: "./web/backend",
+      sourceMtime: Math.max(
+        sharedSourceMtime,
+        latestMtimeMs(path.join(repoRoot, "web", "backend")),
+      ),
+    },
+  ];
+
+  for (const binary of binaries) {
+    const distBinaryPath = path.join(distDir, binary.outputName);
+    const embeddedBinaryPath = path.join(projectDir, binary.outputName);
+
+    const distStat = statSafe(distBinaryPath);
+    const embeddedStat = statSafe(embeddedBinaryPath);
+    const newestBuiltMtime = Math.max(
+      distStat?.mtimeMs || 0,
+      embeddedStat?.mtimeMs || 0,
+    );
+
+    if (newestBuiltMtime < binary.sourceMtime) {
+      console.log(`[beforePack] rebuilding ${binary.label}: ${binary.outputName}`);
+      buildBinary(repoRoot, distBinaryPath, binary.buildTarget);
+    }
+
+    const copied = copyIfDifferent(distBinaryPath, embeddedBinaryPath);
+    if (copied) {
+      console.log(`[beforePack] synced ${binary.outputName} into Electron resources`);
+    } else {
+      console.log(`[beforePack] ${binary.outputName} already up to date`);
+    }
+  }
+};

--- a/clawpet-frontend/clawpet/package.json
+++ b/clawpet-frontend/clawpet/package.json
@@ -14,6 +14,7 @@
   "build": {
     "appId": "com.goclaw.clawpet",
     "productName": "ClawPet",
+    "beforePack": "electron/before-pack.js",
     "directories": {
       "output": "dist"
     },


### PR DESCRIPTION
做ppt的时候因为要长时间的工作，前端长时间没收到回复以为结束了。更新了一下打包的规则，如果后端的二进制文件与当下不匹配则重新编译