### PR TITLE
Feat/pet tool approval

### DIFF
--- a/docs/PET_CHANNEL_API.md
+++ b/docs/PET_CHANNEL_API.md
@@ -1,6 +1,6 @@
 # Pet Channel API 接口文档
 
-> 版本：v2.10  
+> 版本：v2.11  
 > 日期：2026-05-08  
 > 协议：WebSocket + JSON
 
@@ -506,6 +506,89 @@ if (msg.push_type === 'error') {
             // 其他错误
             showToast(`服务错误: ${data.message}`);
     }
+}
+```
+
+### 3.9 tool_approval - 工具审批请求
+
+当 LLM 调用高风险工具（如 `exec`、`write_file` 等）时，后端主动推送给客户端请求用户审批。
+
+**推送格式**：
+
+```json
+{
+  "type": "push",
+  "push_type": "tool_approval",
+  "data": {
+    "request_id": "tool_approval_1714896000123456789",
+    "tool": "exec",
+    "arguments": {
+      "command": "ipconfig"
+    }
+  },
+  "timestamp": 1714896000
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| request_id | string | 审批请求ID，客户端回复时必须使用相同ID |
+| tool | string | 需要审批的工具名称 |
+| arguments | object | 工具参数（如命令、文件路径等） |
+
+**需要审批的工具列表**：
+
+| 工具 | 说明 |
+|------|------|
+| exec | 执行 Shell 命令 |
+| write_file | 写入文件 |
+| edit_file | 编辑文件 |
+| append_file | 追加文件 |
+| subagent | 启动子代理 |
+| spawn | 启动子任务 |
+
+**客户端回复格式**（通过同一条 WebSocket 连接发送）：
+
+```json
+{
+  "action": "tool_approval_response",
+  "data": {
+    "request_id": "tool_approval_1714896000123456789",
+    "approved": true
+  }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| action | string | 是 | 固定为 `tool_approval_response` |
+| data.request_id | string | 是 | 推送中的 `request_id`，原样返回 |
+| data.approved | bool | 是 | `true` 允许执行 / `false` 拒绝执行 |
+
+**超时处理**：如果用户 60 秒内未回复，系统自动拒绝该工具调用。
+
+**前端处理逻辑**：
+
+```javascript
+// 接收 tool_approval 推送
+if (msg.push_type === 'tool_approval') {
+    const { request_id, tool, arguments } = msg.data;
+    
+    // 弹出确认框让用户选择
+    const approved = confirm(`允许执行工具 "${tool}" 吗？\n\n参数: ${JSON.stringify(arguments)}`);
+    
+    // 通过同一条连接回复
+    ws.send(JSON.stringify({
+        action: "tool_approval_response",
+        data: {
+            request_id: request_id,
+            approved: approved
+        }
+    }));
 }
 ```
 
@@ -2812,6 +2895,7 @@ async def send_chat(ws, text):
 | text_and_audio | 语音流式合成 | 流式推送语音音频片段，按顺序播放 |
 | heartbeat | 每 30 秒 | 保活检测 |
 | error | 运行时错误 | 推送 TTS/LLM/供应商等运行时错误 |
+| tool_approval | 工具调用时 | 推送工具审批请求，需要用户确认 |
 
 ---
 

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -183,6 +183,7 @@ func NewPetChannel(cfg config.PetConfig, msgBus *bus.MessageBus, workspacePath s
 
 	perr.SetPushHandler(pc.handleErrorPush)
 
+	pc.service.SetSessionPush(pc.sendPushToSession)
 	pc.service.Start()
 
 	// 初始化语音合成器
@@ -216,6 +217,21 @@ func (c *PetChannel) handleServicePush(push any) {
 		}
 		if err := pc.writeJSON(push); err != nil {
 			logger.Warnf("pet: failed to push to conn_id=%s: %v", pc.id, err)
+		}
+	}
+}
+
+// sendPushToSession 发送消息到指定 session 的客户端
+func (c *PetChannel) sendPushToSession(sessionID string, v any) {
+	c.connsMu.RLock()
+	defer c.connsMu.RUnlock()
+
+	for _, pc := range c.connections {
+		if pc.sessionID == sessionID {
+			if err := pc.writeJSON(v); err != nil {
+				logger.Warnf("pet: failed to push to conn_id=%s: %v", pc.id, err)
+			}
+			return
 		}
 	}
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -198,6 +198,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				svc := pc.Service()
 
 				petHook := pet.NewPetHook(svc.CharManager(), svc.ActionManager(), svc, svc.MemoryStore(), svc.ConversationStore(), svc.UserProfileManager())
+				svc.SetApprovalResolver(petHook.ResolveApproval)
 				agentLoop.MountHook(agent.NamedHook("pet", petHook))
 				logger.InfoCF("pet", "Pet hook registered", nil)
 			}

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -925,3 +925,117 @@ func parseMemoryTags(content string) []MemoryTag {
 	}
 	return tags
 }
+
+func (h *PetHook) OnEvent(ctx context.Context, evt agent.Event) error {
+	if evt.Kind == agent.EventKindError {
+		if payload, ok := evt.Payload.(agent.ErrorPayload); ok {
+			ctx := make(map[string]any)
+			if evt.Meta.SessionKey != "" {
+				ctx["session_key"] = evt.Meta.SessionKey
+			}
+			if evt.Meta.AgentID != "" {
+				ctx["agent_id"] = evt.Meta.AgentID
+			}
+			if evt.Meta.TurnID != "" {
+				ctx["turn_id"] = evt.Meta.TurnID
+			}
+			if payload.Stage != "" {
+				ctx["stage"] = payload.Stage
+			}
+
+			if payload.Err != nil {
+				code := "agent_error"
+				if fe, ok := payload.Err.(*providers.FailoverError); ok {
+					code = mapFailoverCode(fe.Reason)
+					ctx["provider"] = fe.Provider
+					ctx["model"] = fe.Model
+					if fe.Status > 0 {
+						ctx["status"] = fe.Status
+					}
+					ctx["reason"] = string(fe.Reason)
+				}
+				perr.Add(perr.LevelError, code, payload.Err.Error(), ctx)
+			} else {
+				perr.Add(perr.LevelError, "agent_error", payload.Message, ctx)
+			}
+		}
+	}
+
+	return nil
+}
+
+func mapFailoverCode(reason providers.FailoverReason) string {
+	switch reason {
+	case providers.FailoverRateLimit:
+		return providers.CodeProviderRateLimit
+	case providers.FailoverOverloaded:
+		return providers.CodeProviderOverload
+	case providers.FailoverTimeout:
+		return providers.CodeProviderTimeout
+	case providers.FailoverContextOverflow:
+		return providers.CodeProviderContext
+	case providers.FailoverAuth:
+		return providers.CodeProviderAuth
+	case providers.FailoverFormat:
+		return providers.CodeProviderFormat
+	default:
+		return providers.CodeProviderUnknown
+	}
+}
+
+func (h *PetHook) ApproveTool(ctx context.Context, req *agent.ToolApprovalRequest) (agent.ApprovalDecision, error) {
+	if h.petService == nil {
+		return agent.ApprovalDecision{Approved: true}, nil
+	}
+
+	requestID := fmt.Sprintf("tool_approval_%d", time.Now().UnixNano())
+	push := ToolApprovalPush{
+		RequestID: requestID,
+		Tool:      req.Tool,
+		Arguments: req.Arguments,
+	}
+	rawData, _ := json.Marshal(push)
+	pushMsg := Push{
+		Type:      "push",
+		PushType:  PushTypeToolApproval,
+		Data:      rawData,
+		Timestamp: time.Now().Unix(),
+	}
+
+	if h.petService.sessionPush != nil {
+		h.petService.sessionPush(req.ChatID, pushMsg)
+	} else if h.petService.pushHandler != nil {
+		h.petService.pushHandler(pushMsg)
+	}
+
+	ch := make(chan bool, 1)
+	h.approvalMu.Lock()
+	h.pendingApprovals[requestID] = ch
+	h.approvalMu.Unlock()
+
+	defer func() {
+		h.approvalMu.Lock()
+		delete(h.pendingApprovals, requestID)
+		h.approvalMu.Unlock()
+	}()
+
+	select {
+	case approved := <-ch:
+		return agent.ApprovalDecision{Approved: approved}, nil
+	case <-time.After(60 * time.Second):
+		return agent.ApprovalDecision{Approved: false, Reason: "审批超时，已自动拒绝"}, nil
+	case <-ctx.Done():
+		return agent.ApprovalDecision{Approved: false, Reason: "上下文已取消"}, nil
+	}
+}
+
+func (h *PetHook) ResolveApproval(requestID string, approved bool) {
+	h.approvalMu.Lock()
+	ch, ok := h.pendingApprovals[requestID]
+	delete(h.pendingApprovals, requestID)
+	h.approvalMu.Unlock()
+
+	if ok {
+		ch <- approved
+	}
+}

--- a/pkg/pet/hooks.go
+++ b/pkg/pet/hooks.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/sipeed/picoclaw/pkg/agent"
 	"github.com/sipeed/picoclaw/pkg/logger"
@@ -49,6 +51,9 @@ type PetHook struct {
 	conversationStore *compression.ConversationStore // 会话存储
 	userProfileMgr    *userprofile.Manager           // 用户画像管理器
 	lastUserMessage   string                         // 最后一条用户消息，用于记录对话
+
+	approvalMu       sync.Mutex
+	pendingApprovals map[string]chan bool
 }
 
 // NewPetHook 创建PetHook实例
@@ -66,6 +71,7 @@ func NewPetHook(charManager *characters.Manager, actionManager *action.ActionMan
 		memoryStore:       memoryStore,
 		conversationStore: conversationStore,
 		userProfileMgr:    userProfileMgr,
+		pendingApprovals:  make(map[string]chan bool),
 	}
 }
 
@@ -918,61 +924,4 @@ func parseMemoryTags(content string) []MemoryTag {
 		tags = append(tags, MemoryTag{Type: m[1], Weight: weight, Summary: m[3]})
 	}
 	return tags
-}
-
-func (h *PetHook) OnEvent(ctx context.Context, evt agent.Event) error {
-	if evt.Kind == agent.EventKindError {
-		if payload, ok := evt.Payload.(agent.ErrorPayload); ok {
-			ctx := make(map[string]any)
-			if evt.Meta.SessionKey != "" {
-				ctx["session_key"] = evt.Meta.SessionKey
-			}
-			if evt.Meta.AgentID != "" {
-				ctx["agent_id"] = evt.Meta.AgentID
-			}
-			if evt.Meta.TurnID != "" {
-				ctx["turn_id"] = evt.Meta.TurnID
-			}
-			if payload.Stage != "" {
-				ctx["stage"] = payload.Stage
-			}
-
-			if payload.Err != nil {
-				code := "agent_error"
-				if fe, ok := payload.Err.(*providers.FailoverError); ok {
-					code = mapFailoverCode(fe.Reason)
-					ctx["provider"] = fe.Provider
-					ctx["model"] = fe.Model
-					if fe.Status > 0 {
-						ctx["status"] = fe.Status
-					}
-					ctx["reason"] = string(fe.Reason)
-				}
-				perr.Add(perr.LevelError, code, payload.Err.Error(), ctx)
-			} else {
-				perr.Add(perr.LevelError, "agent_error", payload.Message, ctx)
-			}
-		}
-	}
-
-	return nil
-}
-
-func mapFailoverCode(reason providers.FailoverReason) string {
-	switch reason {
-	case providers.FailoverRateLimit:
-		return providers.CodeProviderRateLimit
-	case providers.FailoverOverloaded:
-		return providers.CodeProviderOverload
-	case providers.FailoverTimeout:
-		return providers.CodeProviderTimeout
-	case providers.FailoverContextOverflow:
-		return providers.CodeProviderContext
-	case providers.FailoverAuth:
-		return providers.CodeProviderAuth
-	case providers.FailoverFormat:
-		return providers.CodeProviderFormat
-	default:
-		return providers.CodeProviderUnknown
-	}
 }

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -37,6 +37,7 @@ type PetService struct {
 	msgBus      *bus.MessageBus
 	config      PetServiceConfig
 	pushHandler PushHandler
+	sessionPush func(sessionID string, v any)
 	provider    providers.LLMProvider
 
 	configManager      *petconfig.Manager
@@ -58,6 +59,8 @@ type PetService struct {
 	activeSessionID     string
 	activeCharacterID   string
 	lastSessionActiveAt time.Time
+
+	resolveApproval func(requestID string, approved bool)
 
 	mu sync.RWMutex
 
@@ -742,6 +745,8 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 		return s.handleVoiceConfigGet(sessionID, req)
 	case ActionVoiceConfigUpdate:
 		return s.handleVoiceConfigUpdate(sessionID, req)
+	case ActionToolApprovalResponse:
+		return s.handleToolApprovalResponse(sessionID, req)
 	default:
 		return s.sendError(sessionID, req.Action, fmt.Sprintf("unknown action: %s", req.Action))
 	}
@@ -1127,6 +1132,25 @@ func (s *PetService) sendResponse(sessionID, action string, data interface{}) er
 		return nil
 	}
 	s.pushHandler(resp)
+	return nil
+}
+
+func (s *PetService) SetSessionPush(push func(sessionID string, v any)) {
+	s.sessionPush = push
+}
+
+func (s *PetService) SetApprovalResolver(resolver func(requestID string, approved bool)) {
+	s.resolveApproval = resolver
+}
+
+func (s *PetService) handleToolApprovalResponse(sessionID string, req Request) error {
+	var data ToolApprovalResponse
+	if err := json.Unmarshal(req.Data, &data); err != nil {
+		return s.sendError(sessionID, req.Action, "invalid tool approval response data")
+	}
+	if s.resolveApproval != nil {
+		s.resolveApproval(data.RequestID, data.Approved)
+	}
 	return nil
 }
 

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -65,6 +65,7 @@ const (
 	ActionAudioFrame           = "audio_frame"             // 音频帧（语音输入）
 	ActionVoiceConfigGet       = "voice_config_get"        // 获取 voice 配置（model_name）
 	ActionVoiceConfigUpdate    = "voice_config_update"     // 更新 voice 配置（model_name）
+	ActionToolApprovalResponse = "tool_approval_response"  // 工具审批响应
 	PushTypeWeeklyReport  = "weekly_report_ready"
 	PushTypeProgressNudge = "progress_nudge"
 )
@@ -86,6 +87,7 @@ const (
 	PushTypeAudio           = "audio"            // 音频播放
 	PushTypeTextAndAudio    = "text_and_audio"   // 文本和音频同时推送
 	PushTypeError           = "error"            // 错误推送
+	PushTypeToolApproval    = "tool_approval"    // 工具审批请求
 )
 
 // =============================================================================
@@ -511,4 +513,17 @@ type AudioFrameRequest struct {
 	Sequence   uint64 `json:"sequence"`    // 帧序号
 	Timestamp  uint32 `json:"timestamp"`   // 时间戳（毫秒）
 	SessionKey string `json:"session_key"` // 会话隔离标识，和文本聊天一样
+}
+
+// ToolApprovalPush 工具审批推送数据
+type ToolApprovalPush struct {
+	RequestID string         `json:"request_id"` // 请求ID
+	Tool      string         `json:"tool"`       // 工具名称
+	Arguments map[string]any `json:"arguments"`  // 工具参数
+}
+
+// ToolApprovalResponse 工具审批响应数据
+type ToolApprovalResponse struct {
+	RequestID string `json:"request_id"` // 请求ID
+	Approved  bool   `json:"approved"`   // 是否允许
 }


### PR DESCRIPTION
# PR: Pet 通道工具审批机制

> Related Issue: [#255](https://github.com/1024XEngineer/ClawPet/issues/255)

## 背景

当前 pet 通道的 LLM 可以调用工具箱中的高风险工具（如 `exec`、`write_file`、`subagent` 等），虽然有 deny 黑名单和 workspace 限制，但没有用户显式确认机制。用户无法在工具执行前进行审批，存在安全隐患。

## 目标

实现 `ToolApprover` hook，让 pet 通道的客户端可以审批/拒绝高风险工具的执行。

## 实现方案

### 1. 新增类型和常量 (`pkg/pet/types.go`)

- `PushTypeToolApproval = "tool_approval"` — 推送类型
- `ActionToolApprovalResponse = "tool_approval_response"` — 客户端响应 Action
- `ToolApprovalPush` — 推送给客户端的审批请求
- `ToolApprovalResponse` — 客户端返回的审批结果

### 2. PetHook 实现 ToolApprover (`pkg/pet/hooks.go`)

- 新增 `pendingApprovals` 映射，存储等待审批的请求
- `ApproveTool()`：推送审批请求给客户端 → 等待用户响应（60s 超时）→ 返回审批结果
- `ResolveApproval()`：由 PetService 在收到客户端响应时调用，结束等待

### 3. PetService 新增审批支持 (`pkg/pet/service.go`)

- `sessionPush` 回调：定向推送给指定 session 的客户端
- `resolveApproval` 回调：将客户端审批结果转发给 PetHook
- `handleToolApprovalResponse()`：处理 `tool_approval_response` 请求

### 4. PetChannel 新增定向推送 (`pkg/channels/pet/channel.go`)

- `sendPushToSession()`：只推送给匹配 `sessionID` 的 WebSocket 连接

### 5. 审批推送流程

```
LLM 调用 exec("ipconfig")
    ↓
AgentLoop → PetHook.ApproveTool()
    ↓
发送 tool_approval push（只发给当前会话）
    ↓
客户端弹出确认框
    ↓
用户选择 → 发回 tool_approval_response
    ↓
PetService.handleToolApprovalResponse()
    ↓
PetHook.ResolveApproval() → 返回审批结果
    ↓
AgentLoop 执行或跳过工具
```

### 6. 客户端交互格式

**服务端推送**：
```json
{
  "type": "push",
  "push_type": "tool_approval",
  "data": {
    "request_id": "tool_approval_1714896000123456789",
    "tool": "exec",
    "arguments": { "command": "ipconfig" }
  },
  "timestamp": 1714896000
}
```

**客户端回复**（同一条 WebSocket 连接）：
```json
{
  "action": "tool_approval_response",
  "data": {
    "request_id": "tool_approval_1714896000123456789",
    "approved": true
  }
}
```

### 7. 后续待改进

- [ ] 配置化：支持自定义哪些工具需要审批（`tool_approval.require_approval` 配置项）
- [ ] 记忆化：同一会话内同命令可记住用户选择，减少重复审批
- [ ] session 校验：回复审批时校验 sessionID 是否匹配发起方

## 文件变更

### 修改文件

| 文件 | 变更说明 |
|------|----------|
| `pkg/pet/types.go` | 新增审批相关类型和常量 |
| `pkg/pet/hooks.go` | PetHook 实现 ToolApprover 接口 |
| `pkg/pet/service.go` | 新增会话推送和审批响应处理 |
| `pkg/channels/pet/channel.go` | 新增定向推送方法 |
| `pkg/gateway/gateway.go` | 注册审批回调 |
| `docs/PET_CHANNEL_API.md` | 新增 tool_approval API 文档 |

## 提交记录

```
53b21d22 docs(pet): add tool approval push documentation to API docs
76843076 feat(pet): PetHook implements ToolApprover interface for user approval
83d30fd4 feat(pet): add tool approval push types and action constants
```
