### PR TITLE
fix: improve desk pet voice feedback and TTS flow

### DIFF
--- a/clawpet-frontend/clawpet/app/desktop-pet/desktop-pet.css
+++ b/clawpet-frontend/clawpet/app/desktop-pet/desktop-pet.css
@@ -130,6 +130,18 @@
   display: block;
 }
 
+.desktop-pet-bubble--voice {
+  margin-top: -244px;
+  width: auto;
+  min-width: 116px;
+  max-width: 190px;
+  padding: 7px 12px;
+  border-color: #f3b34f;
+  color: #8b5a22;
+  font-weight: 600;
+  box-shadow: 0 10px 24px -18px rgba(168, 110, 38, 0.7);
+}
+
 .desktop-pet-state {
   display: none;
 }

--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -219,6 +219,7 @@ export default function DesktopPetPage() {
   const audioObjectUrlRef = useRef<string | null>(null)
   const bubbleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const runtimeHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const transientStateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const bubbleRef = useRef<HTMLDivElement | null>(null)
   const currentAudioIdRef = useRef<number>(0)
   const baseStateRef = useRef<PetState>("standby")
@@ -229,6 +230,9 @@ export default function DesktopPetPage() {
   const sleepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   currentImageRef.current = currentImage
+  const displayedBubbleText = runtimeHint
+    ? (bubble ? `${bubble}\n\n${runtimeHint}` : runtimeHint)
+    : bubble
 
   const transitionTo = useCallback((newState: PetState) => {
     const prevImage = currentImageRef.current
@@ -243,6 +247,27 @@ export default function DesktopPetPage() {
     setPetState(target)
     setCurrentImage(getPetImage(target, prevImage))
   }, [])
+
+  const clearTransientStateTimer = useCallback(() => {
+    if (transientStateTimerRef.current) {
+      clearTimeout(transientStateTimerRef.current)
+      transientStateTimerRef.current = null
+    }
+  }, [])
+
+  const flashState = useCallback(
+    (state: PetState, durationMs: number) => {
+      clearTransientStateTimer()
+      transitionTo(state)
+      if (durationMs > 0) {
+        transientStateTimerRef.current = setTimeout(() => {
+          applyCurrentState()
+          transientStateTimerRef.current = null
+        }, durationMs)
+      }
+    },
+    [applyCurrentState, clearTransientStateTimer, transitionTo],
+  )
 
   // Set the base state (lowest layer; shown when no overlay is active)
   const setBaseState = useCallback((state: PetState) => {
@@ -513,6 +538,7 @@ export default function DesktopPetPage() {
       if (bubbleTimerRef.current) {
         clearTimeout(bubbleTimerRef.current)
       }
+      clearTransientStateTimer()
       if (audioRef.current) {
         audioRef.current.pause()
       }
@@ -566,49 +592,58 @@ export default function DesktopPetPage() {
         runtimeHintTimerRef.current = null
       }
 
-      if (hint && bubble) {
+      if (hint) {
         setRuntimeHint(hint)
         if (stickyMs > 0) {
           runtimeHintTimerRef.current = setTimeout(() => {
             setRuntimeHint("")
           }, stickyMs)
         }
-      } else if (nextState === "idle" || !bubble) {
+      } else if (nextState === "idle") {
         setRuntimeHint("")
       }
 
       if (nextState === "listening" || nextState === "recognizing") {
+        clearTransientStateTimer()
         setPetState("listen")
         setCurrentImage("/pets/listening.gif")
         return
       }
 
-      if (nextState === "thinking" || nextState === "tool_running") {
-        transitionTo("standby")
+      if (nextState === "thinking") {
+        clearTransientStateTimer()
+        setOverlayState("think", Math.max(stickyMs, 500))
+        return
+      }
+
+      if (nextState === "tool_running") {
+        clearTransientStateTimer()
+        setOverlayState("search", Math.max(stickyMs, 800))
         return
       }
 
       if (nextState === "speaking") {
-        transitionTo("happy")
+        flashState("happy", stickyMs || 1600)
         return
       }
 
       if (nextState === "error") {
-        transitionTo("shakeHead", stickyMs || 2200)
+        flashState("shakeHead", stickyMs || 2200)
         return
       }
 
       if (nextState === "stalled") {
-        transitionTo("stayOut", stickyMs || 2600)
+        flashState("stayOut", stickyMs || 2600)
         return
       }
 
       if (nextState === "done") {
-        transitionTo("happy", stickyMs || 1600)
+        flashState("happy", stickyMs || 1600)
         return
       }
 
       if (!bubble) {
+        clearTransientStateTimer()
         setPetState("standby")
         setCurrentImage(getPetImage("standby", currentImageRef.current))
       }
@@ -622,7 +657,7 @@ export default function DesktopPetPage() {
         clearTimeout(runtimeHintTimerRef.current)
       }
     }
-  }, [bubble, transitionTo])
+  }, [bubble, clearTransientStateTimer, flashState, setOverlayState])
 
   useEffect(() => {
     const handlePointerMove = (event: globalThis.MouseEvent) => {
@@ -730,12 +765,12 @@ export default function DesktopPetPage() {
             <img className="desktop-pet-image" src={currentImage} alt="Pet" />
             <span className="desktop-pet-state">{petState}</span>
           </div>
-          {bubble ? (
+          {(bubble || runtimeHint) ? (
           <div
             ref={bubbleRef}
             className={runtimeHint ? "desktop-pet-bubble desktop-pet-bubble--voice" : "desktop-pet-bubble"}
           >
-            <span>{runtimeHint || bubble}</span>
+            <span>{displayedBubbleText}</span>
           </div>
         ) : null}
         </div>

--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -33,6 +33,24 @@ interface BubbleData {
   popOverlay?: boolean
 }
 
+type PetRuntimeState =
+  | "idle"
+  | "listening"
+  | "recognizing"
+  | "thinking"
+  | "tool_running"
+  | "speaking"
+  | "done"
+  | "error"
+  | "stalled"
+
+interface PetRuntimeStatePayload {
+  state?: PetRuntimeState
+  text?: string
+  source?: "voice" | "chat"
+  sticky_ms?: number
+}
+
 function normalizeAudioMimeType(mime?: string): string | null {
   if (!mime) return null
   const normalized = mime.trim().toLowerCase()
@@ -191,13 +209,16 @@ export default function DesktopPetPage() {
   const [petState, setPetState] = useState<PetState>("standby")
   const [currentImage, setCurrentImage] = useState("/pets/standby1.gif")
   const [bubble, setBubble] = useState("")
+  const [runtimeHint, setRuntimeHint] = useState("")
   const [showControls, setShowControls] = useState(false)
+  const [voicePhase, setVoicePhase] = useState<"idle" | "recording" | "recognizing" | "error">("idle")
   const stackRef = useRef<HTMLDivElement | null>(null)
   const controlsVisibleRef = useRef(false)
   const currentImageRef = useRef(currentImage)
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const audioObjectUrlRef = useRef<string | null>(null)
   const bubbleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const runtimeHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const bubbleRef = useRef<HTMLDivElement | null>(null)
   const currentAudioIdRef = useRef<number>(0)
   const baseStateRef = useRef<PetState>("standby")
@@ -375,9 +396,10 @@ export default function DesktopPetPage() {
           audioUrl = `data:${mimeType};base64,${audioUrl}`
         }
 
-        if (audioRef.current) {
-          audioRef.current.pause()
-          audioRef.current.onended = null
+        const activeAudio = audioRef.current
+        if (activeAudio) {
+          ;(activeAudio as HTMLAudioElement | null)?.pause?.()
+          ;(activeAudio as HTMLAudioElement | null)!.onended = null
         }
         const rawCandidates = Array.from(
           new Set([mimeType, "audio/mpeg", "audio/ogg", "audio/wav"]),
@@ -505,6 +527,104 @@ export default function DesktopPetPage() {
   }, [transitionTo, applyCurrentState, setBaseState, setOverlayState, clearOverlayState, popOverlayState, resetSleepTimer])
 
   useEffect(() => {
+    const unsubscribe = window.electronAPI?.onVoiceInputStateChanged?.((payload) => {
+      const nextPhase =
+        payload?.phase === "recording" ||
+        payload?.phase === "recognizing" ||
+        payload?.phase === "error"
+          ? payload.phase
+          : "idle"
+      setVoicePhase(nextPhase)
+
+      if (nextPhase === "recording" || nextPhase === "recognizing") {
+        setPetState("listen")
+        setCurrentImage("/pets/listening.gif")
+        return
+      }
+
+      if (!bubble) {
+        setPetState("standby")
+        setCurrentImage(getPetImage("standby", currentImageRef.current))
+      }
+    })
+
+    return () => {
+      if (typeof unsubscribe === "function") {
+        unsubscribe()
+      }
+    }
+  }, [bubble])
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onPetRuntimeStateChanged?.((payload: PetRuntimeStatePayload) => {
+      const nextState = payload?.state || "idle"
+      const hint = payload?.text?.trim() || ""
+      const stickyMs = Number(payload?.sticky_ms) || 0
+
+      if (runtimeHintTimerRef.current) {
+        clearTimeout(runtimeHintTimerRef.current)
+        runtimeHintTimerRef.current = null
+      }
+
+      if (hint && bubble) {
+        setRuntimeHint(hint)
+        if (stickyMs > 0) {
+          runtimeHintTimerRef.current = setTimeout(() => {
+            setRuntimeHint("")
+          }, stickyMs)
+        }
+      } else if (nextState === "idle" || !bubble) {
+        setRuntimeHint("")
+      }
+
+      if (nextState === "listening" || nextState === "recognizing") {
+        setPetState("listen")
+        setCurrentImage("/pets/listening.gif")
+        return
+      }
+
+      if (nextState === "thinking" || nextState === "tool_running") {
+        transitionTo("standby")
+        return
+      }
+
+      if (nextState === "speaking") {
+        transitionTo("happy")
+        return
+      }
+
+      if (nextState === "error") {
+        transitionTo("shakeHead", stickyMs || 2200)
+        return
+      }
+
+      if (nextState === "stalled") {
+        transitionTo("stayOut", stickyMs || 2600)
+        return
+      }
+
+      if (nextState === "done") {
+        transitionTo("happy", stickyMs || 1600)
+        return
+      }
+
+      if (!bubble) {
+        setPetState("standby")
+        setCurrentImage(getPetImage("standby", currentImageRef.current))
+      }
+    })
+
+    return () => {
+      if (typeof unsubscribe === "function") {
+        unsubscribe()
+      }
+      if (runtimeHintTimerRef.current) {
+        clearTimeout(runtimeHintTimerRef.current)
+      }
+    }
+  }, [bubble, transitionTo])
+
+  useEffect(() => {
     const handlePointerMove = (event: globalThis.MouseEvent) => {
       const stack = stackRef.current
       if (!stack) {
@@ -613,9 +733,9 @@ export default function DesktopPetPage() {
           {bubble ? (
           <div
             ref={bubbleRef}
-            className="desktop-pet-bubble"
+            className={runtimeHint ? "desktop-pet-bubble desktop-pet-bubble--voice" : "desktop-pet-bubble"}
           >
-            <span>{bubble}</span>
+            <span>{runtimeHint || bubble}</span>
           </div>
         ) : null}
         </div>
@@ -623,3 +743,4 @@ export default function DesktopPetPage() {
     </div>
   )
 }
+

--- a/clawpet-frontend/clawpet/app/layout.tsx
+++ b/clawpet-frontend/clawpet/app/layout.tsx
@@ -1,11 +1,7 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { Toaster } from '@/components/ui/toaster'
 import './globals.css'
-
-const _geist = Geist({ subsets: ["latin"] });
-const _geistMono = Geist_Mono({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: {

--- a/clawpet-frontend/clawpet/components/chat-area.tsx
+++ b/clawpet-frontend/clawpet/components/chat-area.tsx
@@ -180,29 +180,11 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
                       }
                     }
 
-                    const splitBubbles = (text: string): string[] => {
-                      const s = text.replace(/\r\n/g, "\n")
-                      const byDn = s.split(/\n\n+/).filter(Boolean)
-                      if (byDn.length > 1) return byDn
-                      const bySn = s.split(/\n+/).filter(Boolean)
-                      if (bySn.length > 1) return bySn
-                      const sentences = s.split(/(?<=[。！？.!?])/).map(x => x.trim()).filter(Boolean)
-                      if (sentences.length <= 1) return [s]
-                      const groups: string[] = []
-                      for (let i = 0; i < sentences.length; i += 3) {
-                        groups.push(sentences.slice(i, i + 3).join(""))
-                      }
-                      return groups
-                    }
-
                     return messages.flatMap((msg, index) => {
                       const isLastAssistant =
                         msg.role === "assistant" && lastAssistantIndex === index
 
-                      const bubbles =
-                        msg.role === "assistant"
-                          ? splitBubbles(msg.content)
-                          : [msg.content]
+                      const bubbles = [msg.content]
 
                       return bubbles.map((part, i) => {
                         const partId = bubbles.length > 1 ? `${msg.id}-${i}` : msg.id

--- a/clawpet-frontend/clawpet/components/chat-area.tsx
+++ b/clawpet-frontend/clawpet/components/chat-area.tsx
@@ -101,7 +101,6 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
   } = useVoiceInput({
     canRecord: isConnected,
     sessionKey: activeSessionId,
-    onResult: sendMessage,
     onError: (voiceInputError) => {
       console.warn("[petclaw] voice input error", voiceInputError)
     },

--- a/clawpet-frontend/clawpet/components/chat-area.tsx
+++ b/clawpet-frontend/clawpet/components/chat-area.tsx
@@ -252,10 +252,10 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
                     <div className="flex justify-start">
                       <div className="rounded-[1.2rem] border border-white/75 bg-white/82 px-4 py-2 text-sm text-[#6f533a] shadow-sm">
                         {toolStatus === "error"
-                          ? "工具调用失败，正在尝试恢复…"
+                          ? "工具调用失败，正在尝试恢复..."
                           : toolStatus === "done"
-                            ? "工具调用完成，正在整理结果…"
-                            : "我正在调用工具处理你的请求…"}
+                            ? "工具调用完成，正在整理结果..."
+                            : "我正在调用工具处理你的请求..."}
                       </div>
                     </div>
                   )}
@@ -478,7 +478,7 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
                   <div className="text-amber-700">录音中...</div>
                 )}
                 {voicePhase === "recognizing" && (
-                  <div className="text-[#7b5b3f]">语音识别中...</div>
+                  <div className="text-[#7b5b3f]">识别中...</div>
                 )}
                 {voiceError && (
                   <div className="text-rose-700">{voiceError}</div>
@@ -494,3 +494,4 @@ export function ChatArea({ chat, layoutMode = "full" }: ChatAreaProps) {
     </section>
   )
 }
+

--- a/clawpet-frontend/clawpet/electron.d.ts
+++ b/clawpet-frontend/clawpet/electron.d.ts
@@ -1,6 +1,22 @@
 export {}
 
 declare global {
+  interface PetRuntimeStatePayload {
+    state:
+      | "idle"
+      | "listening"
+      | "recognizing"
+      | "thinking"
+      | "tool_running"
+      | "speaking"
+      | "done"
+      | "error"
+      | "stalled"
+    text?: string
+    source?: "voice" | "chat"
+    sticky_ms?: number
+  }
+
   interface BubblePayload {
     text: string | null
     emotion: string
@@ -41,8 +57,16 @@ declare global {
       registerPetClickThroughShortcut?: (data: { enabled: boolean; keys: string; mode?: 'toggle' | 'hold' }) => void
       onVoiceShortcutHeld?: (callback: () => void) => void
       onVoiceShortcutReleased?: (callback: () => void) => void
+      onVoiceInputStateChanged?: (
+        callback: (payload: { phase?: string; isListening?: boolean }) => void,
+      ) => (() => void) | void
+      onPetRuntimeStateChanged?: (
+        callback: (payload: PetRuntimeStatePayload) => void,
+      ) => (() => void) | void
       showErrorNotification?: (data: { level: string; code: string; message: string }) => void
       onErrorNotification?: (callback: (data: { level: string; code: string; message: string }) => void) => void
+      reportVoiceInputState?: (data: { phase?: string; isListening?: boolean }) => void
+      reportPetRuntimeState?: (data: PetRuntimeStatePayload) => void
     }
   }
 }

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -46,6 +46,7 @@ let petTopCorrectionTimer = null;
 let onboardingLocked = false;
 let lastBubbleFingerprint = '';
 let lastBubbleAt = 0;
+let bubbleWindowReady = false;
 
 // 语音输入快捷键
 let voiceInputShortcut = 'CommandOrControl+P';
@@ -1220,6 +1221,7 @@ function createBubbleWindow() {
   });
   attachRendererCrashDiagnostics(bubbleWindow, 'BUBBLE WINDOW');
   blockCtrlPDefault(bubbleWindow);
+  bubbleWindowReady = false;
 
   bubbleWindow.setIgnoreMouseEvents(true, { forward: true });
 
@@ -1227,7 +1229,23 @@ function createBubbleWindow() {
     logToFile(`[BUBBLE WINDOW] load renderer failed: ${String(err)}`);
   });
 
+  bubbleWindow.webContents.on('did-finish-load', () => {
+    bubbleWindowReady = true;
+    logToFile('[BUBBLE WINDOW] did-finish-load');
+  });
+
+  bubbleWindow.webContents.on('did-fail-load', (_event, code, desc, validatedURL) => {
+    bubbleWindowReady = false;
+    logToFile(`[BUBBLE WINDOW] did-fail-load code=${code} desc=${desc} url=${validatedURL}`);
+  });
+
+  bubbleWindow.webContents.on('render-process-gone', (_event, details) => {
+    bubbleWindowReady = false;
+    logToFile(`[BUBBLE WINDOW] marked unavailable after render-process-gone reason=${details?.reason || 'unknown'} exitCode=${details?.exitCode ?? 'n/a'}`);
+  });
+
   bubbleWindow.on('closed', () => {
+    bubbleWindowReady = false;
     bubbleWindow = null;
   });
 }
@@ -2071,7 +2089,10 @@ ipcMain.on('show-bubble', (_event, data) => {
   const isPetOverlay = data?.persist === true || data?.clearOverlay === true || data?.popOverlay === true;
   const fingerprint = `${audio}|${text}|${emotion}|${animation}|${data?.clearOverlay ? '1' : ''}|${data?.popOverlay ? '1' : ''}`;
   const now = Date.now();
-  const hasDetachedBubbleWindow = bubbleWindow && !bubbleWindow.isDestroyed();
+  const hasDetachedBubbleWindow =
+    bubbleWindow &&
+    !bubbleWindow.isDestroyed() &&
+    bubbleWindowReady;
 
   // Pet overlay signals (persist/clearOverlay) always pass through — don't dedup them
   if (!isPetOverlay && fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -1936,6 +1936,18 @@ ipcMain.on('register-voice-shortcut', (_event, data) => {
   registerVoiceInputShortcut(keys, enabled, mode);
 });
 
+ipcMain.on('voice-input-state', (_event, payload) => {
+  if (petWindow && !petWindow.isDestroyed()) {
+    petWindow.webContents.send('voice-input-state-changed', payload || {});
+  }
+});
+
+ipcMain.on('pet-runtime-state', (_event, payload) => {
+  if (petWindow && !petWindow.isDestroyed()) {
+    petWindow.webContents.send('pet-runtime-state-changed', payload || {});
+  }
+});
+
 ipcMain.on('register-pet-click-through-shortcut', (_event, data) => {
   const { enabled, keys, mode } = data || {};
   logToFile(`[IPC] register-pet-click-through-shortcut enabled=${enabled} keys=${keys} mode=${mode}`);
@@ -1987,6 +1999,10 @@ ipcMain.on('window-toggle-maximize', (event) => {
 ipcMain.on('window-close', (event) => {
   const target = BrowserWindow.fromWebContents(event.sender);
   if (target && !target.isDestroyed()) {
+    if (target === settingsWindow) {
+      target.hide();
+      return;
+    }
     target.close();
   }
 });
@@ -2028,7 +2044,7 @@ ipcMain.on('maximize-settings', () => {
 // 设置窗口关闭
 ipcMain.on('close-settings', () => {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
-    settingsWindow.close();
+    settingsWindow.hide();
   }
 });
 

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -15,17 +15,18 @@
  */
 
 const { app, BrowserWindow, ipcMain, screen, globalShortcut } = require('electron');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const net = require('net');
+const { spawn } = require('child_process');
+let logStream = null;
 let uIOhook = null;
 try {
   uIOhook = require('uiohook-napi').uIOhook;
 } catch (e) {
   logToFile(`[UIOHOOK] failed to load uiohook-napi: ${e.message}`);
 }
-const path = require('path');
-const os = require('os');
-const fs = require('fs');
-const net = require('net');
-const { spawn } = require('child_process');
 
 // 全局窗口引用
 let petWindow = null;              // 桌宠窗口
@@ -220,7 +221,7 @@ async function buildChildProcessEnv(extraEnv = {}) {
  * 所有日志输出到 ~/.picoclaw/logs.txt
  */
 const logFilePath = path.join(userDataPath, 'logs.txt');
-const logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
 
 function loadOnboardingState() {
   try {
@@ -328,7 +329,9 @@ function leaveOnboardingMode({ completed } = { completed: false }) {
 function logToFile(message) {
   const timestamp = new Date().toISOString();
   const logLine = `[${timestamp}] ${message}\n`;
-  logStream.write(logLine);
+  if (logStream) {
+    logStream.write(logLine);
+  }
   console.log(logLine);
 }
 
@@ -2087,6 +2090,7 @@ ipcMain.on('show-bubble', (_event, data) => {
   const emotion = typeof data?.emotion === 'string' ? data.emotion.trim() : '';
   const animation = typeof data?.animation === 'string' ? data.animation.trim() : '';
   const isPetOverlay = data?.persist === true || data?.clearOverlay === true || data?.popOverlay === true;
+  const hasBubbleContent = Boolean(text || audio);
   const fingerprint = `${audio}|${text}|${emotion}|${animation}|${data?.clearOverlay ? '1' : ''}|${data?.popOverlay ? '1' : ''}`;
   const now = Date.now();
   const hasDetachedBubbleWindow =
@@ -2094,7 +2098,7 @@ ipcMain.on('show-bubble', (_event, data) => {
     !bubbleWindow.isDestroyed() &&
     bubbleWindowReady;
 
-  // Pet overlay signals (persist/clearOverlay) always pass through — don't dedup them
+  // Pet overlay signals (persist/clearOverlay) always pass through ? don't dedup them
   if (!isPetOverlay && fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {
     logToFile('[IPC] show-bubble dropped duplicated payload');
     return;
@@ -2113,16 +2117,19 @@ ipcMain.on('show-bubble', (_event, data) => {
   }
 
   if (hasDetachedBubbleWindow) {
-    syncBubbleWindowToPet({ show: true });
-    bubbleWindow.webContents.send('bubble-show', data);
-    // 同时通知宠物窗口更新动画，text 置 null 表示只更新动画不显示气泡文字
+    if (hasBubbleContent) {
+      syncBubbleWindowToPet({ show: true });
+      bubbleWindow.webContents.send('bubble-show', data);
+    }
     if (petWindow && !petWindow.isDestroyed()) {
-      petWindow.webContents.send('bubble-show', Object.assign({}, data, { text: null }));
+      const petPayload = hasBubbleContent
+        ? Object.assign({}, data, { text: null })
+        : data;
+      petWindow.webContents.send('bubble-show', petPayload);
     }
   }
 });
 
-// 连接活跃状态
 ipcMain.on('connection-alive', () => {
   if (petWindow && !petWindow.isDestroyed()) {
     petWindow.webContents.send('connection-alive');

--- a/clawpet-frontend/clawpet/electron/preload.js
+++ b/clawpet-frontend/clawpet/electron/preload.js
@@ -273,6 +273,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('voice-shortcut-released', handler);
   },
 
+  onVoiceInputStateChanged: (callback) => {
+    const listener = (_event, payload) => callback(payload);
+    ipcRenderer.on('voice-input-state-changed', listener);
+    return () => ipcRenderer.removeListener('voice-input-state-changed', listener);
+  },
+
+  onPetRuntimeStateChanged: (callback) => {
+    const listener = (_event, payload) => callback(payload);
+    ipcRenderer.on('pet-runtime-state-changed', listener);
+    return () => ipcRenderer.removeListener('pet-runtime-state-changed', listener);
+  },
+
   /**
    * 注册/更新语音输入快捷键
    * @param {object} data - 快捷键配置
@@ -284,20 +296,28 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send('register-voice-shortcut', data);
   },
 
+  reportVoiceInputState: (data) => {
+    ipcRenderer.send('voice-input-state', data);
+  },
+
+  reportPetRuntimeState: (data) => {
+    ipcRenderer.send('pet-runtime-state', data);
+  },
+
   /**
-   * 显示错误通知（广播到所有窗口）
-   * @param {object} data - 错误数据
-   * @param {string} data.level - 错误级别
-   * @param {string} data.code - 错误码
-   * @param {string} data.message - 错误消息
+   * ???????????????
+   * @param {object} data - ????
+   * @param {string} data.level - ????
+   * @param {string} data.code - ???
+   * @param {string} data.message - ????
    */
   showErrorNotification: (data) => {
     ipcRenderer.send('show-error-notification', data);
   },
 
   /**
-   * 监听错误通知
-   * @param {function} callback - 回调函数
+   * ??????
+   * @param {function} callback - ????
    */
   onErrorNotification: (callback) => {
     ipcRenderer.on('error-notification', (_event, data) => callback(data));

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -498,6 +498,8 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     value: "",
     at: 0,
   })
+  const audioBubbleSyncRef = useRef(false)
+  const spokenBubbleTextRef = useRef("")
   const lastBubbleTextRef = useRef<{ text: string; at: number }>({
     text: "",
     at: 0,
@@ -650,12 +652,12 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         const now = Date.now()
         if (
           lastBubbleTextRef.current.text !== bubbleText ||
-          now - lastBubbleTextRef.current.at > 1800
+          now - lastBubbleTextRef.current.at > 400
         ) {
           showBubble(bubbleText)
         }
         pendingBubbleTimerRef.current = null
-      }, 1200)
+      }, 180)
     },
     [clearPendingBubbleTimer, showBubble],
   )
@@ -686,28 +688,19 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         return
       }
       streamingEndedRef.current = true
-
-      // 把未匹配标点的尾句入队（最后一句通常无句号）
-      const remaining = finalText.slice(lastStreamingBubblePosRef.current).trim()
-      if (remaining.length > 0) {
-        sentenceQueueRef.current.push(remaining)
-        hasEnqueuedRef.current = true
+      if (audioBubbleSyncRef.current) {
         lastStreamingBubblePosRef.current = finalText.length
-        if (!displayTimerRef.current) {
-          advanceSentenceDisplay()
+        if (!spokenBubbleTextRef.current) {
+          showBubble(finalText.trim())
         }
         return
       }
-
-      // 队列中有句子 → 等自然排空，最后一句保持不动
-      if (hasEnqueuedRef.current || displayTimerRef.current) {
-        return
-      }
-
-      // 队列从未用过（voice-OFF 流式无完整句子）→ 直接显示全文
-      showBubble(finalText)
+      clearPendingBubbleTimer()
+      clearSentenceDisplay()
+      lastStreamingBubblePosRef.current = finalText.length
+      showBubble(finalText.trim())
     },
-    [showBubble, advanceSentenceDisplay],
+    [clearPendingBubbleTimer, clearSentenceDisplay, showBubble],
   )
 
   const scheduleStreamingBubble = useCallback(
@@ -722,31 +715,18 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         clearSentenceDisplay()
       }
 
-      const newPart = content.slice(lastStreamingBubblePosRef.current)
-      if (!newPart) {
+      const normalized = content.trim()
+      if (!normalized) {
         return
       }
 
-      const sepMatch = newPart.match(/[^。！？.!?]*[。！？.!?]+/g)
-      if (!sepMatch) {
+      lastStreamingBubblePosRef.current = content.length
+      if (audioBubbleSyncRef.current) {
         return
       }
-
-      const matched = sepMatch.join("")
-      const endPos = lastStreamingBubblePosRef.current + matched.length
-      lastStreamingBubblePosRef.current = endPos
-
-      clearPendingBubbleTimer()
-      if (matched.trim().length > 1) {
-        sentenceQueueRef.current.push(matched)
-        hasEnqueuedRef.current = true
-      }
-
-      if (!displayTimerRef.current) {
-        advanceSentenceDisplay()
-      }
+      scheduleAssistantBubble(normalized)
     },
-    [clearPendingBubbleTimer, showBubble, advanceSentenceDisplay, clearSentenceDisplay],
+    [clearSentenceDisplay, scheduleAssistantBubble],
   )
 
   const playAudioBase64 = useCallback(
@@ -778,12 +758,6 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       }
 
       clearPendingBubbleTimer()
-
-      if (window.electronAPI?.showBubble) {
-        // Keep bubble text sync, but always play audio via HTMLAudio to ensure
-        // deterministic ordered playback in chat runtime.
-        showBubble(bubbleText ?? (lastAssistantTextRef.current || null), undefined, durationMs)
-      }
 
       const decoded = decodeBase64Chunk(audioBase64)
       const mimeType = normalizeAudioMimeType(audioMimeHint) || inferAudioMimeType(decoded)
@@ -826,10 +800,21 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         currentAudioRef.current.pause()
       }
 
+      const joinSpokenText = (previous: string, next: string): string => {
+        if (!previous) return next
+        if (!next) return previous
+        if (/[A-Za-z0-9]$/.test(previous) && /^[A-Za-z0-9]/.test(next)) {
+          return `${previous} ${next}`
+        }
+        return `${previous}${next}`
+      }
+
       let settled = false
       const settleOnce = () => {
         if (!settled) {
           settled = true
+          audioBubbleSyncRef.current = false
+          spokenBubbleTextRef.current = ""
           if (typeof seq === "number" && Number.isFinite(seq)) {
             wsRef.current.sendAudioDone(seq, streamId)
           }
@@ -857,6 +842,17 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         currentAudioUrlRef.current = audioUrl
         const audio = new Audio(audioUrl)
         currentAudioRef.current = audio
+
+        const segmentText = (bubbleText || "").trim()
+        if (segmentText) {
+          audioBubbleSyncRef.current = true
+          spokenBubbleTextRef.current = joinSpokenText(spokenBubbleTextRef.current, segmentText)
+          showBubble(
+            spokenBubbleTextRef.current,
+            undefined,
+            typeof durationMs === "number" && durationMs > 0 ? durationMs : undefined,
+          )
+        }
 
         audio.onended = () => {
           if (currentAudioUrlRef.current) {
@@ -915,6 +911,8 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     audioSeenSeqRef.current = new Set()
     audioIsPlayingRef.current = false
     lastQueuedSegmentRef.current = { chatId: null, seq: null }
+    audioBubbleSyncRef.current = false
+    spokenBubbleTextRef.current = ""
   }, [clearAudioAdvanceTimer])
 
   const drainAudioQueue = useCallback(() => {
@@ -956,9 +954,6 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         audioExpectedSeqRef.current = nextSegment.seq + 1
 
         // 通知后端此段音频已播完，允许立即推送下一段
-        const ws = wsRef.current
-        ws.sendPetRequest("audio_done", { seq: nextSegment.seq })
-
         drainAudioQueue()
       },
     )
@@ -1044,6 +1039,17 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       window.electronAPI?.showBubble?.({ text: null, emotion: '', ...data } as BubblePayload)
     }
 
+    const reportPetRuntimeState = (payload: {
+      state: "idle" | "listening" | "recognizing" | "thinking" | "tool_running" | "speaking" | "done" | "error" | "stalled"
+      text?: string
+      sticky_ms?: number
+    }) => {
+      window.electronAPI?.reportPetRuntimeState?.({
+        source: "chat",
+        ...payload,
+      })
+    }
+
     const endAssistantTurn = () => {
       assistantTurnActiveRef.current = false
       isToolBusyRef.current = false
@@ -1051,6 +1057,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       setIsTurnActive(false)
       setToolStatus("idle")
       sendPetOverlay({ clearOverlay: true })
+      reportPetRuntimeState({ state: "idle" })
     }
 
     const beginOrKeepAssistantTurn = () => {
@@ -1243,6 +1250,11 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
               if (!isToolBusyRef.current) {
                 sendPetOverlay({ animation: "think", persist: true })
               }
+              reportPetRuntimeState({
+                state: "thinking",
+                text: "小猫正在思考，请耐心等待...",
+                sticky_ms: 2600,
+              })
             } else {
               finalizeStreamingAssistantMessages()
               endAssistantTurn()
@@ -1258,21 +1270,25 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
             sendPetOverlay({ animation: "search", persist: true })
             beginOrKeepAssistantTurn()
             setToolStatus(status)
+            reportPetRuntimeState({
+              state: "tool_running",
+              text: data.text?.trim() || "正在调用工具...",
+              sticky_ms: 2600,
+            })
           } else if (status === "done" || status === "error") {
             isToolBusyRef.current = false
             // Tool finished; LLM is still processing — revert to think
             sendPetOverlay({ animation: "think", persist: true })
             beginOrKeepAssistantTurn()
             setToolStatus(status)
-          }
-          if (status === "busy") {
-            window.electronAPI?.showBubble?.({
-              text: null,
-              animation: "search",
-              duration_ms: 30000,
+            reportPetRuntimeState({
+              state: status === "error" ? "error" : "thinking",
+              text:
+                status === "error"
+                  ? "工具调用失败，正在尝试恢复..."
+                  : "工具完成，正在整理结果...",
+              sticky_ms: status === "error" ? 2600 : 1800,
             })
-          } else if (status === "done" || status === "error") {
-            window.electronAPI?.showBubble?.({ text: null })
           }
           break
         }
@@ -1309,7 +1325,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
             }
             const anim = emotionAnimMap[event.data.trim()]
             if (anim) {
-              window.electronAPI?.showBubble?.({ text: null, animation: anim })
+              window.electronAPI?.showBubble?.({ text: null, emotion: '', animation: anim } as BubblePayload)
             }
           }
           break
@@ -1341,11 +1357,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         case "action_trigger":
           if (typeof event.data === "string" && event.data.trim()) {
             lastActionRef.current = event.data.trim()
-            window.electronAPI?.showBubble?.({
-              text: null,
-              animation: event.data.trim(),
-              duration_ms: 5000,
-            })
+            window.electronAPI?.showBubble?.({ text: null, emotion: '', animation: event.data.trim() } as BubblePayload)
           }
           break
 
@@ -1459,7 +1471,6 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         window.electronAPI?.showBubble?.({ text: null, emotion: '', animation: 'think', persist: true } as BubblePayload)
 
         wsRef.current.send(outbound, activeSessionIdRef.current)
-        window.electronAPI?.showBubble?.({ text: null, animation: "think" })
       } catch (err) {
         window.electronAPI?.showBubble?.({ text: null, emotion: '', clearOverlay: true } as BubblePayload)
         assistantTurnActiveRef.current = false

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -473,6 +473,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     storedSessions?.sessions || [createSessionState(initialSessionIdRef.current)],
   )
   const activeSessionIdRef = useRef(activeSessionId)
+  const asrEventSeqRef = useRef(0)
   const audioQueueRef = useRef<AudioSegmentItem[]>([])
   const audioExpectedSeqRef = useRef<number | null>(null)
   const audioArrivalSeqRef = useRef(0)
@@ -754,6 +755,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       bubbleText?: string | null,
       audioMimeHint?: string,
       seq?: number,
+      streamId?: string | null,
       durationMs?: number,
       onSettled?: () => void,
     ) => {
@@ -829,7 +831,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         if (!settled) {
           settled = true
           if (typeof seq === "number" && Number.isFinite(seq)) {
-            wsRef.current.sendAudioDone(seq, nextSegment.streamId)
+            wsRef.current.sendAudioDone(seq, streamId)
           }
           onSettled?.()
         }
@@ -947,6 +949,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       nextSegment.text || null,
       nextSegment.audioMime,
       nextSegment.seq,
+      nextSegment.streamId,
       nextSegment.durationMs,
       () => {
         audioIsPlayingRef.current = false
@@ -1091,6 +1094,41 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
           }
           break
 
+        case "asr": {
+          if (typeof event.data === "object" && event.data) {
+            const data = event.data as { text?: string; chat_id?: string | number }
+            const content = data.text?.trim() || ""
+            if (!content) {
+              break
+            }
+
+            finalizeStreamingAssistantMessages()
+            endAssistantTurn()
+            wsRef.current.resetAssistantStreamState()
+
+            const timestamp = Date.now()
+            const rawChatId = data.chat_id
+            const asrSeq = ++asrEventSeqRef.current
+            const messageId =
+              rawChatId !== undefined && rawChatId !== null
+                ? `asr-user-${String(rawChatId)}-${asrSeq}`
+                : `asr-user-${timestamp}-${asrSeq}`
+            const message: ChatMessage = {
+              id: messageId,
+              role: "user",
+              content,
+              timestamp,
+            }
+
+            updateSessionMessages(activeSessionIdRef.current, (prev) => [
+              ...prev,
+              message,
+            ])
+            optionsRef.current.onMessage?.(message)
+          }
+          break
+        }
+
         case "audio": {
           const data = event.data as AudioPushData | undefined
           if (!data) {
@@ -1190,6 +1228,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
           if (data.is_final) {
             finalizeStreamingAssistantMessages()
             endAssistantTurn()
+            wsRef.current.resetAssistantStreamState()
           }
 
           break

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -79,6 +79,7 @@ interface AudioPushData {
   audio_mime?: string
   duration?: number
   seq?: number
+  stream_id?: string
   error?: string
   is_final?: boolean
 }
@@ -86,6 +87,7 @@ interface AudioPushData {
 interface AudioSegmentItem {
   chatId: number | null
   seq: number
+  streamId: string | null
   text: string
   audioBase64: string
   audioMime?: string
@@ -475,6 +477,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
   const audioExpectedSeqRef = useRef<number | null>(null)
   const audioArrivalSeqRef = useRef(0)
   const audioActiveChatIdRef = useRef<number | null>(null)
+  const audioActiveStreamIdRef = useRef<string | null>(null)
   const audioIsPlayingRef = useRef(false)
   const audioSeenSeqRef = useRef<Set<string>>(new Set())
   const currentAudioRef = useRef<HTMLAudioElement | null>(null)
@@ -825,6 +828,9 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       const settleOnce = () => {
         if (!settled) {
           settled = true
+          if (typeof seq === "number" && Number.isFinite(seq)) {
+            wsRef.current.sendAudioDone(seq, nextSegment.streamId)
+          }
           onSettled?.()
         }
       }
@@ -903,6 +909,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
     audioExpectedSeqRef.current = null
     audioArrivalSeqRef.current = 0
     audioActiveChatIdRef.current = null
+    audioActiveStreamIdRef.current = null
     audioSeenSeqRef.current = new Set()
     audioIsPlayingRef.current = false
     lastQueuedSegmentRef.current = { chatId: null, seq: null }
@@ -957,7 +964,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
   const enqueueAudioSegment = useCallback(
     (segment: AudioSegmentItem) => {
       const audioFingerprint = segment.audioBase64.slice(0, 24)
-      const seqKey = `${segment.chatId ?? "na"}:${segment.seq}:${audioFingerprint}`
+      const seqKey = `${segment.streamId ?? segment.chatId ?? "na"}:${segment.seq}:${audioFingerprint}`
       if (audioSeenSeqRef.current.has(seqKey)) {
         return
       }
@@ -1097,6 +1104,10 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
 
           const parsedChatId = Number(data.chat_id)
           const incomingChatId = Number.isFinite(parsedChatId) ? parsedChatId : null
+          const incomingStreamId =
+            typeof data.stream_id === "string" && data.stream_id.trim()
+              ? data.stream_id.trim()
+              : null
 
           if (
             incomingChatId !== null &&
@@ -1109,6 +1120,26 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
             audioActiveChatIdRef.current = incomingChatId
           }
 
+          if (
+            incomingStreamId &&
+            audioActiveStreamIdRef.current &&
+            incomingStreamId !== audioActiveStreamIdRef.current
+          ) {
+            if (currentAudioRef.current) {
+              currentAudioRef.current.pause()
+              currentAudioRef.current = null
+            }
+            if (currentAudioUrlRef.current) {
+              URL.revokeObjectURL(currentAudioUrlRef.current)
+              currentAudioUrlRef.current = null
+            }
+            resetAudioQueue()
+            lastPlayedAudioRef.current = { value: "", at: 0 }
+          }
+          if (incomingStreamId) {
+            audioActiveStreamIdRef.current = incomingStreamId
+          }
+
           const audioChunkPayload = resolveAudioChunkPayload(data)
           const parsedSeq = Number(data.seq)
           const seq = Number.isFinite(parsedSeq)
@@ -1117,10 +1148,28 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
           const parsedDuration = Number(data.duration)
           const durationMs = Number.isFinite(parsedDuration) ? parsedDuration : 0
 
+          // Pet channel audio pushes do not currently include chat_id, so the
+          // sequence resetting to 1 is our best signal that a new spoken turn
+          // has started. Reset dedupe/queue state here so later turns do not
+          // get dropped as "duplicates" because they share the same seq=1 and
+          // MP3 header prefix as the first successful reply.
+          if (seq === 1 && incomingChatId === null && !incomingStreamId) {
+            if (currentAudioRef.current) {
+              currentAudioRef.current.pause()
+              currentAudioRef.current = null
+            }
+            if (currentAudioUrlRef.current) {
+              URL.revokeObjectURL(currentAudioUrlRef.current)
+              currentAudioUrlRef.current = null
+            }
+            resetAudioQueue()
+            lastPlayedAudioRef.current = { value: "", at: 0 }
+          }
           if (audioChunkPayload) {
             enqueueAudioSegment({
               chatId: incomingChatId,
               seq,
+              streamId: incomingStreamId,
               text: typeof data.text === "string" ? data.text : "",
               audioBase64: audioChunkPayload.audioBase64,
               audioMime: audioChunkPayload.audioMime,

--- a/clawpet-frontend/clawpet/hooks/use-voice-input.ts
+++ b/clawpet-frontend/clawpet/hooks/use-voice-input.ts
@@ -9,9 +9,33 @@ interface UseVoiceInputOptions {
   onError?: (error: string) => void
   canRecord?: boolean
   sessionKey?: string
+  onRecognizingText?: (text: string) => void
 }
 
 type VoicePhase = "idle" | "recording" | "recognizing" | "error"
+
+type PetRuntimeState =
+  | "idle"
+  | "listening"
+  | "recognizing"
+  | "thinking"
+  | "tool_running"
+  | "speaking"
+  | "done"
+  | "error"
+  | "stalled"
+
+interface PetRuntimeStatePayload {
+  state: PetRuntimeState
+  text?: string
+  source?: "voice" | "chat"
+  sticky_ms?: number
+}
+
+interface VoiceBubbleOptions {
+  animation?: string
+  durationMs?: number
+}
 
 const TARGET_SAMPLE_RATE = 16000
 const FRAME_SIZE = 2048
@@ -103,7 +127,13 @@ function downsampleTo16k(input: Float32Array, sourceSampleRate: number): Float32
 }
 
 export function useVoiceInput(options: UseVoiceInputOptions = {}) {
-  const { onResult, onError, canRecord = true, sessionKey = "" } = options
+  const {
+    onResult,
+    onError,
+    onRecognizingText,
+    canRecord = true,
+    sessionKey = "",
+  } = options
   const [isListening, _setIsListening] = useState(false)
   const isListeningRef = useRef(false)
   const setIsListening = useCallback((v: boolean) => {
@@ -167,6 +197,27 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}) {
   const stoppingRef = useRef(false)
   const holdStartedAtRef = useRef(0)
   const holdActiveRef = useRef(false)
+
+  const reportPetRuntimeState = useCallback((payload: PetRuntimeStatePayload) => {
+    window.electronAPI?.reportPetRuntimeState?.({
+      source: "voice",
+      ...payload,
+    })
+  }, [])
+
+  const showVoiceBubble = useCallback((text: string, options: VoiceBubbleOptions = {}) => {
+    const normalized = text.trim()
+    if (!normalized || !window.electronAPI?.showBubble) {
+      return
+    }
+
+    window.electronAPI.showBubble({
+      text: normalized,
+      emotion: "neutral",
+      animation: options.animation,
+      duration_ms: options.durationMs,
+    })
+  }, [])
 
   const debugLog = useCallback((message: string, data?: Record<string, unknown>) => {
     if (!DEBUG_VOICE) {
@@ -884,14 +935,6 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}) {
       return
     }
 
-    if (window.electronAPI?.ensureSettingsForeground) {
-      const focused = await window.electronAPI.ensureSettingsForeground()
-      if (!focused?.ok) {
-        failStart("无法激活主设置窗口，请切回主窗口后重试。")
-        return
-      }
-    }
-
     // 移除失焦保护，允许后台录音
     // if (document.visibilityState !== "visible") {
     //   failStart("当前窗口不可见，无法开始语音输入，请切回主设置窗口。")
@@ -1363,6 +1406,57 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}) {
   useEffect(() => {
     startListeningRef.current = startListening
   }, [startListening])
+
+  useEffect(() => {
+    isListeningRef.current = isListening
+  }, [isListening])
+
+  useEffect(() => {
+    window.electronAPI?.reportVoiceInputState?.({
+      phase,
+      isListening,
+    })
+  }, [isListening, phase])
+
+  useEffect(() => {
+    if (phase === "recording") {
+      showVoiceBubble("正在录音，再按一次结束", {
+        animation: "listen",
+        durationMs: 30000,
+      })
+      reportPetRuntimeState({
+        state: "listening",
+        text: "正在录音，再按一次结束",
+      })
+      return
+    }
+    if (phase === "recognizing") {
+      showVoiceBubble("正在识别语音，请稍候...", {
+        animation: "listen",
+        durationMs: 20000,
+      })
+      reportPetRuntimeState({
+        state: "recognizing",
+        text: "正在识别语音，请稍候...",
+      })
+      return
+    }
+    if (phase === "error" && error) {
+      showVoiceBubble(error, {
+        animation: "shake-head",
+        durationMs: 2800,
+      })
+      reportPetRuntimeState({
+        state: "error",
+        text: error,
+        sticky_ms: 2800,
+      })
+      return
+    }
+    if (phase === "idle") {
+      reportPetRuntimeState({ state: "idle" })
+    }
+  }, [error, phase, reportPetRuntimeState, showVoiceBubble])
 
   const toggleListening = useCallback(() => {
     try {

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -189,6 +189,7 @@ export class PicoClawWebSocket {
   private activeAssistantContent = ""
   private activeAssistantTimestamp = 0
   private activeAssistantLastChatId: number | null = null
+  private activeAudioStreamId: string | null = null
   private openHandlers: {
     settle: () => void
     fail: (err: Error) => void
@@ -257,6 +258,7 @@ export class PicoClawWebSocket {
     this.activeAssistantContent = ""
     this.activeAssistantTimestamp = 0
     this.activeAssistantLastChatId = null
+    this.activeAudioStreamId = null
   }
 
   private async resolveTokenAndPath(): Promise<{
@@ -701,6 +703,24 @@ export class PicoClawWebSocket {
     }
 
     const payload = { ...((data || {}) as Record<string, unknown>) }
+    const parsedSeq = Number(payload.seq)
+    const seq = Number.isFinite(parsedSeq) ? parsedSeq : null
+    const incomingStreamId =
+      typeof payload.stream_id === "string" && payload.stream_id.trim()
+        ? payload.stream_id.trim()
+        : null
+
+    if (
+      (seq === 1 && this.activeAssistantMessageId) ||
+      (incomingStreamId &&
+        this.activeAudioStreamId &&
+        incomingStreamId !== this.activeAudioStreamId)
+    ) {
+      this.resetAssistantState()
+    }
+    if (incomingStreamId) {
+      this.activeAudioStreamId = incomingStreamId
+    }
 
     if (payload.type === "error" && typeof payload.text === "string") {
       this.emit({

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -1044,6 +1044,10 @@ export class PicoClawWebSocket {
     this.reconnectAttempts = 0
   }
 
+  resetAssistantStreamState(): void {
+    this.resetAssistantState()
+  }
+
   send(content: string, sessionKey?: string): void {
     this.resetAssistantState()
     const resolvedSessionKey = sessionKey?.trim() || this.generateSessionId()

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -1110,7 +1110,7 @@ export class PicoClawWebSocket {
     return true
   }
 
-  sendAudioDone(sequence: number): boolean {
+  sendAudioDone(sequence: number, streamId?: string | null): boolean {
     if (!Number.isFinite(sequence) || sequence <= 0) {
       return false
     }
@@ -1121,7 +1121,13 @@ export class PicoClawWebSocket {
 
     this.sendRaw({
       action: AUDIO_DONE_ACTION,
-      data: { seq: sequence },
+      data: {
+        seq: sequence,
+        stream_id:
+          typeof streamId === "string" && streamId.trim()
+            ? streamId.trim()
+            : undefined,
+      },
       request_id: `req-${++this.msgIdCounter}-${Date.now()}`,
     })
     return true

--- a/clawpet-frontend/clawpet/lib/api/websocket.ts
+++ b/clawpet-frontend/clawpet/lib/api/websocket.ts
@@ -10,6 +10,7 @@ import {
 
 const CHAT_ACTION = "chat"
 const AUDIO_FRAME_ACTION = "audio_frame"
+const AUDIO_DONE_ACTION = "audio_done"
 const DEBUG_WS = process.env.NODE_ENV !== "production"
 
 const PUSH_TYPE_AI_CHAT = "ai_chat"
@@ -1106,6 +1107,23 @@ export class PicoClawWebSocket {
       },
       { queueIfDisconnected: false },
     )
+    return true
+  }
+
+  sendAudioDone(sequence: number): boolean {
+    if (!Number.isFinite(sequence) || sequence <= 0) {
+      return false
+    }
+
+    if (this.wsMode !== "pet" || this.ws?.readyState !== WebSocket.OPEN) {
+      return false
+    }
+
+    this.sendRaw({
+      action: AUDIO_DONE_ACTION,
+      data: { seq: sequence },
+      request_id: `req-${++this.msgIdCounter}-${Date.now()}`,
+    })
     return true
   }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1442,6 +1442,17 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 			})
 	}
 
+	if len(opts.ForcedSkills) == 0 {
+		if inferred := inferImplicitSkills(agent, opts.UserMessage); len(inferred) > 0 {
+			opts.ForcedSkills = append(opts.ForcedSkills, inferred...)
+			logger.InfoCF("agent", "Applying implicit skill hint",
+				map[string]any{
+					"session_key": opts.SessionKey,
+					"skills":      strings.Join(inferred, ","),
+				})
+		}
+	}
+
 	return al.runAgentLoop(ctx, agent, opts)
 }
 
@@ -3239,6 +3250,66 @@ func activeSkillNames(agent *AgentInstance, opts processOptions) []string {
 	}
 
 	return resolved
+}
+
+func inferImplicitSkills(agent *AgentInstance, userMessage string) []string {
+	if agent == nil || agent.ContextBuilder == nil {
+		return nil
+	}
+
+	text := strings.ToLower(strings.TrimSpace(userMessage))
+	if text == "" {
+		return nil
+	}
+
+	var inferred []string
+	if hasPPTSkillIntent(text) {
+		if skillName, ok := agent.ContextBuilder.ResolveSkillName("pptx"); ok {
+			inferred = append(inferred, skillName)
+		}
+	}
+
+	if len(inferred) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(inferred))
+	result := make([]string, 0, len(inferred))
+	for _, name := range inferred {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, name)
+	}
+	return result
+}
+
+func hasPPTSkillIntent(text string) bool {
+	if text == "" {
+		return false
+	}
+
+	triggers := []string{
+		"ppt",
+		"pptx",
+		"powerpoint",
+		"presentation",
+		"幻灯片",
+		"演示文稿",
+		"演示稿",
+		"做课件",
+	}
+	for _, trigger := range triggers {
+		if strings.Contains(text, trigger) {
+			return true
+		}
+	}
+	return false
 }
 
 func initPPTExecutionState(agent *AgentInstance, opts processOptions) pptExecutionState {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -407,6 +407,32 @@ func TestApplyExplicitSkillCommand_InlineMessageMutatesOptions(t *testing.T) {
 	}
 }
 
+func TestInferImplicitSkills_PPTMessageActivatesPPTXSkill(t *testing.T) {
+	al, cfg, _, _, cleanup := newTestAgentLoop(t)
+	defer cleanup()
+
+	if err := os.MkdirAll(filepath.Join(cfg.Agents.Defaults.Workspace, "skills", "pptx"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(skill) error = %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(cfg.Agents.Defaults.Workspace, "skills", "pptx", "SKILL.md"),
+		[]byte("# PPTX\n\nUse this skill for PowerPoint work.\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("WriteFile(SKILL.md) error = %v", err)
+	}
+
+	agent := al.GetRegistry().GetDefaultAgent()
+	if agent == nil {
+		t.Fatal("expected default agent")
+	}
+
+	got := inferImplicitSkills(agent, "帮我做个PPT吧")
+	if len(got) != 1 || got[0] != "PPTX" {
+		t.Fatalf("inferImplicitSkills() = %#v, want [PPTX]", got)
+	}
+}
+
 func TestRecordLastChannel(t *testing.T) {
 	al, cfg, msgBus, provider, cleanup := newTestAgentLoop(t)
 	defer cleanup()

--- a/pkg/channels/pet/audio_done_state.go
+++ b/pkg/channels/pet/audio_done_state.go
@@ -1,0 +1,39 @@
+package pet
+
+import "sync"
+
+var (
+	activeStreamersMu sync.RWMutex
+	activeStreamers   = make(map[string]*petStreamer)
+)
+
+func setActivePetStreamer(sessionID string, streamer *petStreamer) {
+	if sessionID == "" || streamer == nil {
+		return
+	}
+	activeStreamersMu.Lock()
+	activeStreamers[sessionID] = streamer
+	activeStreamersMu.Unlock()
+}
+
+func getActivePetStreamer(sessionID string) *petStreamer {
+	if sessionID == "" {
+		return nil
+	}
+	activeStreamersMu.RLock()
+	streamer := activeStreamers[sessionID]
+	activeStreamersMu.RUnlock()
+	return streamer
+}
+
+func clearActivePetStreamer(sessionID string, streamer *petStreamer) {
+	if sessionID == "" || streamer == nil {
+		return
+	}
+	activeStreamersMu.Lock()
+	current := activeStreamers[sessionID]
+	if current == streamer {
+		delete(activeStreamers, sessionID)
+	}
+	activeStreamersMu.Unlock()
+}

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -27,7 +27,7 @@ import (
 // 队列和超时配置默认值（当配置缺失时使用）
 const (
 	defaultAudioQueueSize   = 100             // 默认队列容量
-	defaultAudioWaitTimeout = 500 * time.Millisecond // 默认等待超时（兜底，前端应发 audio_done 替代）
+	defaultAudioWaitTimeout = 3 * time.Second // 默认等待超时（兜底）
 )
 
 // 语音分段符
@@ -48,29 +48,6 @@ func parsePureText(raw string) string {
 		}
 	}
 	return sb.String()
-}
-
-// splitSentences 按分隔符将文本分割成句子
-func splitSentences(text string) []string {
-	var sentences []string
-	runes := []rune(text)
-	start := 0
-	for i, r := range runes {
-		if strings.ContainsRune(voiceSegmentSeps, r) {
-			if i > start {
-				s := string(runes[start:i]) + string(r)
-				sentences = append(sentences, s)
-			}
-			start = i + 1
-		}
-	}
-	if start < len(runes) {
-		sentences = append(sentences, string(runes[start:]))
-	}
-	if len(sentences) == 0 {
-		sentences = append(sentences, text)
-	}
-	return sentences
 }
 
 func inferAudioMimeFromBytes(raw []byte) string {
@@ -128,7 +105,6 @@ type PetChannel struct {
 	cancel                context.CancelFunc  // 取消函数
 	service               *pet.PetService     // 桌宠服务
 	voiceSynthesizer      *voice.Synthesizer  // 语音合成器
-	activeStreamers       sync.Map            // sessionID → *petStreamer
 }
 
 // petConn 表示一个WebSocket连接
@@ -391,7 +367,7 @@ func (c *PetChannel) sendToClient(sessionID, content string) {
 		logger.Infof("pet: checking connection conn_id=%s, sessionID=%s", connID, pc.sessionID)
 		if pc.sessionID == sessionID || sessionID == "broadcast" {
 			logger.Infof("pet: matched! sending to conn_id=%s", connID)
-			data, _ := json.Marshal(map[string]string{"text": content})
+			data, _ := json.Marshal(content)
 			pc.writeJSON(Response{
 				Status: pet.StatusOK,
 				Action: pet.ActionChat,
@@ -591,13 +567,37 @@ func (c *PetChannel) readLoop(pc *petConn) {
 
 // handleRequest 处理客户端请求
 func (c *PetChannel) handleRequest(pc *petConn, req Request) {
-	// 音频播放完成确认走快速路径，不经过 service
 	if req.Action == pet.ActionAudioDone {
-		c.handleAudioDone(pc.sessionID, req)
+		c.handleAudioDoneRequest(pc, req)
 		return
 	}
 	logger.Infof("pet: handleRequest called, action=%s, conn_id=%s", req.Action, pc.id)
 	c.service.HandleRequest(pc.id, req)
+}
+
+func (c *PetChannel) handleAudioDoneRequest(pc *petConn, req Request) {
+	var data pet.AudioDoneRequest
+	if err := json.Unmarshal(req.Data, &data); err != nil || data.Seq <= 0 {
+		_ = pc.writeJSON(Response{
+			Status:    pet.StatusError,
+			Action:    req.Action,
+			Error:     "invalid audio_done data",
+			RequestID: req.RequestID,
+		})
+		return
+	}
+
+	streamer := getActivePetStreamer(pc.sessionID)
+	if streamer != nil {
+		streamer.HandleAudioDone(data.Seq)
+	}
+
+	_ = pc.writeJSON(Response{
+		Status:    pet.StatusOK,
+		Action:    req.Action,
+		Data:      mustMarshal(map[string]any{"received": streamer != nil, "seq": data.Seq}),
+		RequestID: req.RequestID,
+	})
 }
 
 // writeJSON 发送JSON到客户端
@@ -696,8 +696,7 @@ func (c *PetChannel) BeginStream(ctx context.Context, sessionID string) (channel
 
 	// 启动音频播放控制 goroutine
 	go streamer.audioPlayLoop()
-
-	c.activeStreamers.Store(sessionID, streamer)
+	setActivePetStreamer(sessionID, streamer)
 
 	return streamer, nil
 }
@@ -758,6 +757,9 @@ func (s *petStreamer) Update(ctx context.Context, content string) error {
 // 注意：不再发送重复文本，只发送情绪状态汇总
 // 流式结束后等待剩余音频发送完毕
 func (s *petStreamer) Finalize(ctx context.Context, content string) error {
+	if s != nil && s.channel != nil {
+		defer clearActivePetStreamer(s.sessionID, s)
+	}
 
 	logger.DebugCF("pet", "Finalize called", map[string]any{
 		"content": content,
@@ -807,9 +809,6 @@ func (s *petStreamer) Finalize(ctx context.Context, content string) error {
 	s.chatID++
 	s.channel.sendStreamChunk(s.sessionID, s.chatID, "final", "", true)
 
-	// 从活跃流式映射中移除
-	s.channel.activeStreamers.Delete(s.sessionID)
-
 	return nil
 }
 
@@ -826,6 +825,7 @@ func (s *petStreamer) Cancel(ctx context.Context) {
 	if s.audioQueue != nil {
 		s.audioQueue.Clear()
 	}
+	clearActivePetStreamer(s.sessionID, s)
 }
 
 // findSegment 查找第一个完整的段落（以换行或句号结尾）
@@ -1323,6 +1323,7 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 			"seq":  seg.Seq,
 			"text": seg.Text,
 		})
+		s.HandleAudioDone(seg.Seq)
 		return
 	}
 
@@ -1338,6 +1339,7 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 			"seq":  seg.Seq,
 			"text": seg.Text,
 		})
+		s.HandleAudioDone(seg.Seq)
 		return
 	}
 	encoded := base64.StdEncoding.EncodeToString(seg.AudioData)
@@ -1392,26 +1394,6 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 		s.waitTimer.Reset(defaultAudioWaitTimeout)
 	}
 	s.waitMu.Unlock()
-}
-
-// handleAudioDone 处理前端发起的 audio_done 请求
-func (c *PetChannel) handleAudioDone(sessionID string, req Request) {
-	var body struct {
-		Seq int64 `json:"seq"`
-	}
-	if req.Data != nil {
-		_ = json.Unmarshal(req.Data, &body)
-	}
-	val, ok := c.activeStreamers.Load(sessionID)
-	if !ok {
-		logger.DebugCF("pet", "handleAudioDone: no active streamer for session", map[string]any{
-			"session": sessionID,
-			"seq":     body.Seq,
-		})
-		return
-	}
-	streamer := val.(*petStreamer)
-	streamer.HandleAudioDone(body.Seq)
 }
 
 // HandleAudioDone 处理前端音频播放完毕的通知

--- a/pkg/channels/pet/channel.go
+++ b/pkg/channels/pet/channel.go
@@ -588,14 +588,18 @@ func (c *PetChannel) handleAudioDoneRequest(pc *petConn, req Request) {
 	}
 
 	streamer := getActivePetStreamer(pc.sessionID)
-	if streamer != nil {
+	if streamer != nil && (data.StreamID == "" || data.StreamID == streamer.streamID) {
 		streamer.HandleAudioDone(data.Seq)
 	}
 
 	_ = pc.writeJSON(Response{
 		Status:    pet.StatusOK,
 		Action:    req.Action,
-		Data:      mustMarshal(map[string]any{"received": streamer != nil, "seq": data.Seq}),
+		Data: mustMarshal(map[string]any{
+		"received":  streamer != nil && (data.StreamID == "" || data.StreamID == streamer.streamID),
+		"seq":       data.Seq,
+		"stream_id": data.StreamID,
+	}),
 		RequestID: req.RequestID,
 	})
 }
@@ -642,6 +646,7 @@ func mustMarshal(v interface{}) json.RawMessage {
 type petStreamer struct {
 	channel          *PetChannel
 	sessionID        string
+	streamID         string
 	lastLen          int
 	buffer           string
 	chatID           int64
@@ -668,6 +673,7 @@ type petStreamer struct {
 	streamingEnded     bool              // 流式是否已结束
 	hasSentFirst       bool              // 是否已发送第一个音频
 	hasReadyAudioCount int               // 等待发送的音频数量
+	waitingAudioSeq    int64
 	audioPlayDone      chan struct{}     // audioPlayLoop 结束信号
 	voiceEnabled       bool              // 当前语音开关状态
 	audioDone          chan int64        // audio_done 通知 channel
@@ -681,6 +687,7 @@ func (c *PetChannel) BeginStream(ctx context.Context, sessionID string) (channel
 	streamer := &petStreamer{
 		channel:          c,
 		sessionID:        sessionID,
+		streamID:         fmt.Sprintf("stream-%d", time.Now().UnixNano()),
 		chatID:           0,
 		voiceSynthesizer: c.voiceSynthesizer,
 		// 语音优先队列初始化
@@ -1364,6 +1371,7 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 
 	data := map[string]any{
 		"seq":        seg.Seq,
+		"stream_id":  s.streamID,
 		"text":       seg.Text,
 		"audio":      encoded,
 		"audio_mime": mimeType,
@@ -1398,6 +1406,12 @@ func (s *petStreamer) sendAudioSegmentAsync(seg *voice.AudioSegment, isFinal boo
 
 // HandleAudioDone 处理前端音频播放完毕的通知
 func (s *petStreamer) HandleAudioDone(seq int64) {
+	s.waitMu.Lock()
+	waitingSeq := s.waitingAudioSeq
+	s.waitMu.Unlock()
+	if waitingSeq > 0 && seq != waitingSeq {
+		return
+	}
 	select {
 	case s.audioDone <- seq:
 	default:

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -759,7 +759,6 @@ func (s *PetService) handleChat(sessionID string, req Request) error {
 		logger.WarnCF("pet", "PetService: handleChat invalid chat data", map[string]any{
 			"session_id": sessionID,
 			"request_id": req.RequestID,
-			"raw_data":   string(req.Data),
 			"error":      err.Error(),
 		})
 		return s.sendError(sessionID, req.Action, "invalid chat data")
@@ -769,7 +768,6 @@ func (s *PetService) handleChat(sessionID string, req Request) error {
 		"request_id":       req.RequestID,
 		"session_key":      chatReq.SessionKey,
 		"text_len":         len(chatReq.Text),
-		"text_preview":     chatReq.Text,
 		"text_is_empty":    chatReq.Text == "",
 		"session_key_empty": chatReq.SessionKey == "",
 	})
@@ -808,7 +806,6 @@ func (s *PetService) handleChat(sessionID string, req Request) error {
 		"session_key":  chatReq.SessionKey,
 		"peer_kind":    char.ID,
 		"content_len":  len(chatReq.Text),
-		"content_text": chatReq.Text,
 	})
 
 	if err := s.msgBus.PublishInbound(context.Background(), inbound); err != nil {

--- a/pkg/pet/service.go
+++ b/pkg/pet/service.go
@@ -480,6 +480,12 @@ func (s *PetService) PushToolEnd(tool string, data json.RawMessage) {
 func (s *PetService) RegisterSession(connID, sessionID string) {
 	s.mu.Lock()
 	s.connSessions[connID] = sessionID
+	if sessionID != "" && s.activeSessionID == "" {
+		s.activeSessionID = sessionID
+		if s.charManager != nil {
+			s.activeCharacterID = s.charManager.GetCurrentID()
+		}
+	}
 	s.mu.Unlock()
 }
 
@@ -750,16 +756,36 @@ func (s *PetService) HandleRequest(connID string, req Request) error {
 func (s *PetService) handleChat(sessionID string, req Request) error {
 	var chatReq ChatRequest
 	if err := json.Unmarshal(req.Data, &chatReq); err != nil {
+		logger.WarnCF("pet", "PetService: handleChat invalid chat data", map[string]any{
+			"session_id": sessionID,
+			"request_id": req.RequestID,
+			"raw_data":   string(req.Data),
+			"error":      err.Error(),
+		})
 		return s.sendError(sessionID, req.Action, "invalid chat data")
 	}
+	logger.InfoCF("pet", "PetService: handleChat received", map[string]any{
+		"session_id":       sessionID,
+		"request_id":       req.RequestID,
+		"session_key":      chatReq.SessionKey,
+		"text_len":         len(chatReq.Text),
+		"text_preview":     chatReq.Text,
+		"text_is_empty":    chatReq.Text == "",
+		"session_key_empty": chatReq.SessionKey == "",
+	})
 
 	char := s.charManager.GetCurrent()
 	if char == nil {
+		logger.WarnCF("pet", "PetService: handleChat no active character", map[string]any{
+			"session_id": sessionID,
+			"request_id": req.RequestID,
+		})
 		return s.sendError(sessionID, req.Action, "no active character")
 	}
 
 	// 用户一说话，就顺手记一笔活动记录，
 	// 同时触发一次主动性“即时评估”。
+	s.markSessionInteraction(sessionID)
 	s.recordUserActivity(sessionID, chatReq.Text)
 	if s.proactiveManager != nil {
 		s.proactiveManager.Trigger("user_message")
@@ -776,10 +802,29 @@ func (s *PetService) handleChat(sessionID string, req Request) error {
 		Content:  chatReq.Text,
 		Metadata: map[string]string{"type": "chat", "conn_id": req.RequestID},
 	}
+	logger.InfoCF("pet", "PetService: handleChat publishing inbound", map[string]any{
+		"session_id":   sessionID,
+		"request_id":   req.RequestID,
+		"session_key":  chatReq.SessionKey,
+		"peer_kind":    char.ID,
+		"content_len":  len(chatReq.Text),
+		"content_text": chatReq.Text,
+	})
 
 	if err := s.msgBus.PublishInbound(context.Background(), inbound); err != nil {
+		logger.WarnCF("pet", "PetService: handleChat publish inbound failed", map[string]any{
+			"session_id":  sessionID,
+			"request_id":  req.RequestID,
+			"session_key": chatReq.SessionKey,
+			"error":       err.Error(),
+		})
 		return s.sendError(sessionID, req.Action, err.Error())
 	}
+	logger.InfoCF("pet", "PetService: handleChat publish inbound succeeded", map[string]any{
+		"session_id":  sessionID,
+		"request_id":  req.RequestID,
+		"session_key": chatReq.SessionKey,
+	})
 
 	return s.sendResponse(sessionID, req.Action, map[string]string{"session_key": chatReq.SessionKey})
 }

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -113,7 +113,8 @@ type Response struct {
 }
 
 type AudioDoneRequest struct {
-	Seq int64 `json:"seq"`
+	Seq      int64  `json:"seq"`
+	StreamID string `json:"stream_id,omitempty"`
 }
 // Push 推送消息结构
 type Push struct {

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -37,7 +37,6 @@ const (
 	ActionModelDelete          = "model_delete"            // 删除模型
 	ActionModelSetDefault      = "model_set_default"       // 设置默认模型
 	ActionCronAdd              = "cron_add"                // 添加定时任务
-	ActionCronUpdate           = "cron_update"             // 更新定时任务
 	ActionCronList             = "cron_list"               // 列出定时任务
 	ActionCronRemove           = "cron_remove"             // 删除定时任务
 	ActionCronEnable           = "cron_enable"             // 启用定时任务
@@ -65,7 +64,7 @@ const (
 	ActionAudioFrame           = "audio_frame"             // 音频帧（语音输入）
 	ActionVoiceConfigGet       = "voice_config_get"        // 获取 voice 配置（model_name）
 	ActionVoiceConfigUpdate    = "voice_config_update"     // 更新 voice 配置（model_name）
-	ActionAudioDone            = "audio_done"              // 音频播放完成确认
+	ActionAudioDone            = "audio_done"              // ????????
 	PushTypeWeeklyReport  = "weekly_report_ready"
 	PushTypeProgressNudge = "progress_nudge"
 )
@@ -113,6 +112,9 @@ type Response struct {
 	RequestID string          `json:"request_id,omitempty"` // 对应的请求ID
 }
 
+type AudioDoneRequest struct {
+	Seq int64 `json:"seq"`
+}
 // Push 推送消息结构
 type Push struct {
 	Type      string          `json:"type"`      // 固定为 "push"
@@ -271,18 +273,11 @@ type ConversationListResponse struct {
 
 // CronAddRequest 添加定时任务请求数据
 type CronAddRequest struct {
-	Name         string  `json:"name"`                     // 任务名称
-	Description  string  `json:"description,omitempty"`    // 任务描述（展示用）
-	Message      string  `json:"message"`                  // 触发时发送的消息
-	ScheduleType string  `json:"schedule_type,omitempty"`  // 调度类型说明
-	EverySeconds int64   `json:"every_seconds,omitempty"`  // 周期性任务间隔（秒）
-	CronExpr     string  `json:"cron_expr,omitempty"`      // Cron 表达式
-	AtSeconds    int64   `json:"at_seconds,omitempty"`     // 一次性任务延迟（秒，从现在起）
-	AtMS         *int64  `json:"at_ms,omitempty"`          // 一次性任务绝对触发时间（毫秒）
-	Command      string  `json:"command,omitempty"`        // 命令（不为空时执行命令而非发送消息）
-	Enabled      *bool   `json:"enabled,omitempty"`        // 创建后是否启用（默认 true）
-	Channel      string  `json:"channel,omitempty"`        // 目标渠道
-	To           string  `json:"to,omitempty"`             // 目标接收者
+	Name         string `json:"name"`                    // 任务名称
+	Message      string `json:"message"`                 // 触发时发送的消息
+	EverySeconds int64  `json:"every_seconds,omitempty"` // 周期性任务间隔（秒）
+	CronExpr     string `json:"cron_expr,omitempty"`     // Cron 表达式
+	AtSeconds    int64  `json:"at_seconds,omitempty"`    // 一次性任务延迟（秒，从现在起）
 }
 
 // CronListRequest 列出定时任务请求数据
@@ -305,25 +300,18 @@ type CronEnableRequest struct {
 type CronJobInfo struct {
 	ID           string `json:"id"`                       // 任务ID
 	Name         string `json:"name"`                     // 任务名称
-	Description  string `json:"description,omitempty"`    // 任务描述
 	Enabled      bool   `json:"enabled"`                  // 是否启用
-	ScheduleType string `json:"schedule_type,omitempty"`  // 统一调度类型说明
 	ScheduleKind string `json:"schedule_kind"`            // 调度类型: at, every, cron
-	Schedule     string `json:"schedule,omitempty"`       // 统一计划展示
 	EveryMS      *int64 `json:"every_ms,omitempty"`       // 周期（毫秒）
-	EverySeconds *int64 `json:"every_seconds,omitempty"`  // 周期（秒，展示用）
 	CronExpr     string `json:"cron_expr,omitempty"`      // Cron 表达式
 	AtMS         *int64 `json:"at_ms,omitempty"`          // 一次性触发时间戳
 	Message      string `json:"message"`                  // 触发时发送的消息
-	Command      string `json:"command,omitempty"`        // 命令内容
 	Channel      string `json:"channel"`                  // 目标渠道
 	To           string `json:"to"`                       // 目标接收者
 	NextRunAtMS  *int64 `json:"next_run_at_ms,omitempty"` // 下次触发时间戳
 	LastRunAtMS  *int64 `json:"last_run_at_ms,omitempty"` // 上次触发时间戳
 	LastStatus   string `json:"last_status,omitempty"`    // 上次执行状态
-	LastError    string `json:"last_error,omitempty"`     // 上次错误信息
 	CreatedAtMS  int64  `json:"created_at_ms"`            // 创建时间戳
-	UpdatedAtMS  int64  `json:"updated_at_ms,omitempty"`  // 更新时间戳
 }
 
 // CronListResponse 定时任务列表响应
@@ -331,17 +319,10 @@ type CronListResponse struct {
 	Jobs []CronJobInfo `json:"jobs"` // 任务列表
 }
 
-// CronUpdateRequest 更新定时任务请求数据
-type CronUpdateRequest struct {
-	JobID string `json:"job_id"` // 要更新的任务 ID
-	CronAddRequest
-}
-
 // CronAddResponse 添加定时任务响应
 type CronAddResponse struct {
-	JobID string      `json:"job_id"` // 新创建的任务ID
-	Name  string      `json:"name"`   // 任务名称
-	Job   *CronJobInfo `json:"job,omitempty"` // 完整任务信息
+	JobID string `json:"job_id"` // 新创建的任务ID
+	Name  string `json:"name"`   // 任务名称
 }
 
 // =============================================================================

--- a/pkg/pet/types.go
+++ b/pkg/pet/types.go
@@ -37,6 +37,7 @@ const (
 	ActionModelDelete          = "model_delete"            // 删除模型
 	ActionModelSetDefault      = "model_set_default"       // 设置默认模型
 	ActionCronAdd              = "cron_add"                // 添加定时任务
+	ActionCronUpdate           = "cron_update"             // 更新定时任务
 	ActionCronList             = "cron_list"               // 列出定时任务
 	ActionCronRemove           = "cron_remove"             // 删除定时任务
 	ActionCronEnable           = "cron_enable"             // 启用定时任务
@@ -64,7 +65,7 @@ const (
 	ActionAudioFrame           = "audio_frame"             // 音频帧（语音输入）
 	ActionVoiceConfigGet       = "voice_config_get"        // 获取 voice 配置（model_name）
 	ActionVoiceConfigUpdate    = "voice_config_update"     // 更新 voice 配置（model_name）
-	ActionAudioDone            = "audio_done"              // ????????
+	ActionAudioDone            = "audio_done"              // 音频播放完成确认
 	PushTypeWeeklyReport  = "weekly_report_ready"
 	PushTypeProgressNudge = "progress_nudge"
 )
@@ -275,10 +276,17 @@ type ConversationListResponse struct {
 // CronAddRequest 添加定时任务请求数据
 type CronAddRequest struct {
 	Name         string `json:"name"`                    // 任务名称
+	Description  string `json:"description,omitempty"`   // 任务描述（展示用）
 	Message      string `json:"message"`                 // 触发时发送的消息
+	ScheduleType string `json:"schedule_type,omitempty"` // 调度类型说明
 	EverySeconds int64  `json:"every_seconds,omitempty"` // 周期性任务间隔（秒）
 	CronExpr     string `json:"cron_expr,omitempty"`     // Cron 表达式
 	AtSeconds    int64  `json:"at_seconds,omitempty"`    // 一次性任务延迟（秒，从现在起）
+	AtMS         *int64 `json:"at_ms,omitempty"`         // 一次性任务绝对触发时间（毫秒）
+	Command      string `json:"command,omitempty"`       // 命令（不为空时执行命令而非发送消息）
+	Enabled      *bool  `json:"enabled,omitempty"`       // 创建后是否启用（默认 true）
+	Channel      string `json:"channel,omitempty"`       // 目标渠道
+	To           string `json:"to,omitempty"`            // 目标接收者
 }
 
 // CronListRequest 列出定时任务请求数据
@@ -301,18 +309,25 @@ type CronEnableRequest struct {
 type CronJobInfo struct {
 	ID           string `json:"id"`                       // 任务ID
 	Name         string `json:"name"`                     // 任务名称
+	Description  string `json:"description,omitempty"`    // 任务描述
 	Enabled      bool   `json:"enabled"`                  // 是否启用
+	ScheduleType string `json:"schedule_type,omitempty"`  // 统一调度类型说明
 	ScheduleKind string `json:"schedule_kind"`            // 调度类型: at, every, cron
+	Schedule     string `json:"schedule,omitempty"`       // 统一计划展示
 	EveryMS      *int64 `json:"every_ms,omitempty"`       // 周期（毫秒）
+	EverySeconds *int64 `json:"every_seconds,omitempty"`  // 周期（秒，展示用）
 	CronExpr     string `json:"cron_expr,omitempty"`      // Cron 表达式
 	AtMS         *int64 `json:"at_ms,omitempty"`          // 一次性触发时间戳
 	Message      string `json:"message"`                  // 触发时发送的消息
+	Command      string `json:"command,omitempty"`        // 命令内容
 	Channel      string `json:"channel"`                  // 目标渠道
 	To           string `json:"to"`                       // 目标接收者
 	NextRunAtMS  *int64 `json:"next_run_at_ms,omitempty"` // 下次触发时间戳
 	LastRunAtMS  *int64 `json:"last_run_at_ms,omitempty"` // 上次触发时间戳
 	LastStatus   string `json:"last_status,omitempty"`    // 上次执行状态
+	LastError    string `json:"last_error,omitempty"`     // 上次错误信息
 	CreatedAtMS  int64  `json:"created_at_ms"`            // 创建时间戳
+	UpdatedAtMS  int64  `json:"updated_at_ms,omitempty"`  // 更新时间戳
 }
 
 // CronListResponse 定时任务列表响应
@@ -320,10 +335,17 @@ type CronListResponse struct {
 	Jobs []CronJobInfo `json:"jobs"` // 任务列表
 }
 
+// CronUpdateRequest 更新定时任务请求数据
+type CronUpdateRequest struct {
+	JobID string `json:"job_id"` // 要更新的任务 ID
+	CronAddRequest
+}
+
 // CronAddResponse 添加定时任务响应
 type CronAddResponse struct {
-	JobID string `json:"job_id"` // 新创建的任务ID
-	Name  string `json:"name"`   // 任务名称
+	JobID string       `json:"job_id"`       // 新创建的任务ID
+	Name  string       `json:"name"`         // 任务名称
+	Job   *CronJobInfo `json:"job,omitempty"` // 完整任务信息
 }
 
 // =============================================================================


### PR DESCRIPTION

## 背景
本次 PR 聚焦解决 #267、#268 两个问题，从虚拟桌宠交互层面整体优化语音交互体验。

在本次修复之前，部分关键状态仅在聊天面板展示；当用户主要查看桌宠窗口时，会产生**桌宠状态迷惑、无响应**的感知问题：
- 语音快捷键的**录音/停止/识别**状态，无法在桌宠气泡上直观展示
- 用户无法清晰判断语音输入是否已结束、桌宠是否已进入思考回复状态
- 隐藏聊天面板后，TTS 语音播报功能稳定性变差
- 首轮语音回复可以正常播放，但多轮对话后续回复会出现静音；原因是**前端音频去重状态未按每轮对话正确重置**

## 本次 PR 修复内容
- 复用现有桌宠气泡承载语音运行状态反馈，不再依赖聊天面板展示。
  现已完整覆盖以下状态提示：
  - 麦克风准备中
  - 已开始录音 / 再次按键停止录音
  - 语音识别中
  - 模型思考/等待回复中
  - 异常错误反馈
- 隐藏聊天面板、设置面板时，**保留完整语音交互链路**，让桌宠主界面可独立作为核心交互入口。
- 新增桌宠通道音频播放完成回执事件（`audio_done`），让语音流程在播放事件结束后可更可靠地向下流转。
- 每轮新语音对话开始时，**重置前端音频去重状态**，修复首轮TTS正常、后续轮次静音的问题。
- 优化 Electron 多窗口之间的运行时状态透传，让前台可见的桌宠界面，成为语音/任务运行状态的可信展示源。

## 修复的根本原因
- 原有语音状态流转链路，与当前展示的桌宠气泡界面未完全对齐。
- TTS 播报流程缺少可靠的前端播放完成回执机制。
- 当序列号 `seq` 从1重新开始、且后端推送未提供稳定 `chat_id` 时，前端音频去重逻辑会误将后续轮次的首段音频判定为重复音频，导致静默。

## 评审后续优化
代码评审后追加了迭代改动，进一步提升逻辑严谨性与用户隐私保护：
- `audio_done` 回执改为**按单个语音流维度匹配**，避免旧轮次延迟的播放回执错误推进新语音流流程。
- 新增的日志诊断逻辑，不再在日志中留存用户原始聊天内容，保护隐私。

## 测试说明
- 编译命令：`go build ./pkg/channels/pet ./pkg/pet`
- 执行构建测试脚本：`powershell -ExecutionPolicy Bypass -File .\\build-and-test.ps1`
- 客户端打包包手动验证项：
  - 桌宠气泡展示语音快捷键启停状态提示
  - ASR 识别完成后思考状态正常可见
  - 多轮对话下 TTS 语音回复可连续正常播放
- 调试阶段直连 MiniMax 接口做对照验证，区分**配置/服务商问题**与**前端播放逻辑问题**，完成问题定位。
