### PR TITLE
feat:  新增 move/search/sleep/think    四个动画及优先级状态控制器

### DIFF
--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -30,6 +30,7 @@ interface BubbleData {
   duration_ms?: number
   persist?: boolean
   clearOverlay?: boolean
+  popOverlay?: boolean
 }
 
 function normalizeAudioMimeType(mime?: string): string | null {
@@ -201,6 +202,7 @@ export default function DesktopPetPage() {
   const currentAudioIdRef = useRef<number>(0)
   const baseStateRef = useRef<PetState>("standby")
   const overlayStateRef = useRef<PetState | null>(null)
+  const prevOverlayStateRef = useRef<PetState | null>(null)
   const overlayLockedUntilRef = useRef<number>(0)
   const isDraggingRef = useRef<boolean>(false)
   const sleepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -231,13 +233,18 @@ export default function DesktopPetPage() {
     }
   }, [])
 
-  // Set an overlay state with priority enforcement and optional minimum hold duration
+  // Set an overlay state with priority enforcement and optional minimum hold duration.
+  // When "move" displaces an existing overlay, the displaced overlay is saved so drag-end
+  // can restore it via popOverlayState() instead of falling all the way back to base.
   const setOverlayState = useCallback((state: PetState, minMs = 0) => {
     const now = Date.now()
     const current = overlayStateRef.current
     const currentPrio = current !== null ? (STATE_PRIORITY[current] ?? 0) : -1
     const newPrio = STATE_PRIORITY[state] ?? 0
     if (current === null || newPrio >= currentPrio || now >= overlayLockedUntilRef.current) {
+      if (state === "move" && current !== null) {
+        prevOverlayStateRef.current = current
+      }
       overlayStateRef.current = state
       overlayLockedUntilRef.current = minMs > 0 ? now + minMs : 0
       const prevImage = currentImageRef.current
@@ -246,13 +253,27 @@ export default function DesktopPetPage() {
     }
   }, [])
 
-  // Clear current overlay and restore the base state
+  // Clear ALL overlays and restore the base state (used when a turn fully ends)
   const clearOverlayState = useCallback(() => {
     overlayStateRef.current = null
+    prevOverlayStateRef.current = null
     overlayLockedUntilRef.current = 0
     isDraggingRef.current = false
     applyCurrentState()
   }, [applyCurrentState])
+
+  // Pop only the topmost overlay (used when drag ends: restores think/search if active)
+  const popOverlayState = useCallback(() => {
+    const restored = prevOverlayStateRef.current
+    prevOverlayStateRef.current = null
+    overlayStateRef.current = restored
+    overlayLockedUntilRef.current = 0
+    isDraggingRef.current = false
+    const target = restored ?? baseStateRef.current
+    const prevImage = currentImageRef.current
+    setPetState(target)
+    setCurrentImage(getPetImage(target, prevImage))
+  }, [])
 
   const resetSleepTimer = useCallback(() => {
     if (sleepTimerRef.current) clearTimeout(sleepTimerRef.current)
@@ -288,7 +309,13 @@ export default function DesktopPetPage() {
         timestamp: Date.now()
       })
 
-      // clearOverlay: restore base state, don't start bubble
+      // popOverlay: drag ended — restore previous overlay (think/search) if any
+      if (data.popOverlay) {
+        popOverlayState()
+        return
+      }
+
+      // clearOverlay: turn fully ended — clear all overlays, restore base
       if (data.clearOverlay) {
         if (data.text !== null) setBubble(data.text || "")
         clearOverlayState()
@@ -475,7 +502,7 @@ export default function DesktopPetPage() {
         clearTimeout(sleepTimerRef.current)
       }
     }
-  }, [transitionTo, applyCurrentState, setBaseState, setOverlayState, clearOverlayState, resetSleepTimer])
+  }, [transitionTo, applyCurrentState, setBaseState, setOverlayState, clearOverlayState, popOverlayState, resetSleepTimer])
 
   useEffect(() => {
     const handlePointerMove = (event: globalThis.MouseEvent) => {

--- a/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
+++ b/clawpet-frontend/clawpet/app/desktop-pet/page.tsx
@@ -16,6 +16,8 @@ type PetState =
   | "stayOut"
   | "think"
   | "search"
+  | "sleep"
+  | "move"
 
 interface BubbleData {
   text: string | null
@@ -26,6 +28,8 @@ interface BubbleData {
   audio?: string
   audio_mime?: string
   duration_ms?: number
+  persist?: boolean
+  clearOverlay?: boolean
 }
 
 function normalizeAudioMimeType(mime?: string): string | null {
@@ -64,7 +68,17 @@ function decodeBase64Audio(value: string): Uint8Array | null {
 }
 
 const happyImages = ["/pets/happy1.gif", "/pets/happy2.gif"]
-const standbyImages = ["/pets/standby1.gif", "/pets/standby2.gif", "/pets/standby3.gif", "/pets/sleep.gif", "/pets/move.gif"]
+const standbyImages = ["/pets/standby1.gif", "/pets/standby2.gif", "/pets/standby3.gif"]
+
+// Overlay states have explicit priority; base states (standby/sleep/idle) are the fallback
+const STATE_PRIORITY: Record<string, number> = {
+  sleep: 0, idle: 1, standby: 2,
+  sad: 3, happy: 3, listen: 3, celebrate: 3, shakeHead: 3, stayOut: 3,
+  think: 4, search: 5, move: 6,
+}
+const OVERLAY_STATES: ReadonlySet<string> = new Set(["think", "search", "move"])
+const BASE_STATES: ReadonlySet<string> = new Set(["standby", "sleep", "idle"])
+const SLEEP_TIMEOUT_MS = 5 * 60 * 1000
 
 const getPetImage = (state: PetState, prevImage?: string): string => {
   switch (state) {
@@ -86,6 +100,10 @@ const getPetImage = (state: PetState, prevImage?: string): string => {
       return "/pets/think.gif"
     case "search":
       return "/pets/search.gif"
+    case "sleep":
+      return "/pets/sleep.gif"
+    case "move":
+      return "/pets/move.gif"
     case "standby": {
       let img = standbyImages[Math.floor(Math.random() * standbyImages.length)]
       if (prevImage && standbyImages.includes(prevImage) && standbyImages.length > 1) {
@@ -129,6 +147,8 @@ const animationToPetState: Record<string, PetState> = {
   "init.png": "idle",
   think: "think",
   search: "search",
+  sleep: "sleep",
+  move: "move",
 }
 
 const resolvePetState = (data: BubbleData): PetState => {
@@ -155,7 +175,9 @@ const resolvePetState = (data: BubbleData): PetState => {
       candidate === "shakeHead" ||
       candidate === "stayOut" ||
       candidate === "think" ||
-      candidate === "search"
+      candidate === "search" ||
+      candidate === "sleep" ||
+      candidate === "move"
     ) {
       return candidate
     }
@@ -177,20 +199,69 @@ export default function DesktopPetPage() {
   const bubbleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const bubbleRef = useRef<HTMLDivElement | null>(null)
   const currentAudioIdRef = useRef<number>(0)
+  const baseStateRef = useRef<PetState>("standby")
+  const overlayStateRef = useRef<PetState | null>(null)
+  const overlayLockedUntilRef = useRef<number>(0)
+  const isDraggingRef = useRef<boolean>(false)
+  const sleepTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   currentImageRef.current = currentImage
 
-  const transitionTo = useCallback((newState: PetState, delay?: number) => {
+  const transitionTo = useCallback((newState: PetState) => {
     const prevImage = currentImageRef.current
     setPetState(newState)
     setCurrentImage(getPetImage(newState, prevImage))
-    if (delay) {
-      setTimeout(() => {
-        setPetState("standby")
-        setCurrentImage(getPetImage("standby", currentImageRef.current))
-      }, delay)
+  }, [])
+
+  // Restore whatever state is currently correct (overlay if active, else base)
+  const applyCurrentState = useCallback(() => {
+    const target = overlayStateRef.current ?? baseStateRef.current
+    const prevImage = currentImageRef.current
+    setPetState(target)
+    setCurrentImage(getPetImage(target, prevImage))
+  }, [])
+
+  // Set the base state (lowest layer; shown when no overlay is active)
+  const setBaseState = useCallback((state: PetState) => {
+    baseStateRef.current = state
+    if (!overlayStateRef.current) {
+      const prevImage = currentImageRef.current
+      setPetState(state)
+      setCurrentImage(getPetImage(state, prevImage))
     }
   }, [])
+
+  // Set an overlay state with priority enforcement and optional minimum hold duration
+  const setOverlayState = useCallback((state: PetState, minMs = 0) => {
+    const now = Date.now()
+    const current = overlayStateRef.current
+    const currentPrio = current !== null ? (STATE_PRIORITY[current] ?? 0) : -1
+    const newPrio = STATE_PRIORITY[state] ?? 0
+    if (current === null || newPrio >= currentPrio || now >= overlayLockedUntilRef.current) {
+      overlayStateRef.current = state
+      overlayLockedUntilRef.current = minMs > 0 ? now + minMs : 0
+      const prevImage = currentImageRef.current
+      setPetState(state)
+      setCurrentImage(getPetImage(state, prevImage))
+    }
+  }, [])
+
+  // Clear current overlay and restore the base state
+  const clearOverlayState = useCallback(() => {
+    overlayStateRef.current = null
+    overlayLockedUntilRef.current = 0
+    isDraggingRef.current = false
+    applyCurrentState()
+  }, [applyCurrentState])
+
+  const resetSleepTimer = useCallback(() => {
+    if (sleepTimerRef.current) clearTimeout(sleepTimerRef.current)
+    sleepTimerRef.current = setTimeout(() => {
+      if (!isDraggingRef.current && !overlayStateRef.current) {
+        setBaseState("sleep")
+      }
+    }, SLEEP_TIMEOUT_MS)
+  }, [setBaseState])
 
   useEffect(() => {
     const handleBubbleShow = (data: BubbleData) => {
@@ -205,18 +276,46 @@ export default function DesktopPetPage() {
         audioRef.current = null
       }
 
+      resetSleepTimer()
+
       console.log('[petclaw] handleBubbleShow:', {
         bubbleId,
         text: data.text,
         hasAudio: !!data.audio,
+        persist: data.persist,
+        clearOverlay: data.clearOverlay,
+        animation: data.animation,
         timestamp: Date.now()
       })
+
+      // clearOverlay: restore base state, don't start bubble
+      if (data.clearOverlay) {
+        if (data.text !== null) setBubble(data.text || "")
+        clearOverlayState()
+        return
+      }
 
       if (data.text !== null) {
         setBubble(data.text || "")
       }
 
-      transitionTo(resolvePetState(data))
+      const resolvedState = resolvePetState(data)
+
+      // persist: set as permanent overlay, no auto-revert timer
+      if (data.persist) {
+        const minMs = resolvedState === "search" ? 800 : resolvedState === "think" ? 500 : 0
+        if (resolvedState === "move") isDraggingRef.current = true
+        setOverlayState(resolvedState, minMs)
+        return
+      }
+
+      // Normal bubble: update visual directly (don't touch overlayStateRef)
+      // On completion, applyCurrentState() restores the overlay or base
+      if (BASE_STATES.has(resolvedState)) {
+        setBaseState(resolvedState)
+      } else {
+        transitionTo(resolvedState)
+      }
 
       if (data.audio) {
         const rawAudio = data.audio.trim()
@@ -240,7 +339,7 @@ export default function DesktopPetPage() {
           })
           if (bubbleId === currentAudioIdRef.current) {
             setBubble("")
-            transitionTo("standby")
+            applyCurrentState()
           }
           return
         }
@@ -275,7 +374,7 @@ export default function DesktopPetPage() {
             })
             if (bubbleId === currentAudioIdRef.current) {
               setBubble("")
-              transitionTo("standby")
+              applyCurrentState()
             }
             return
           }
@@ -293,7 +392,7 @@ export default function DesktopPetPage() {
             })
             if (bubbleId === currentAudioIdRef.current) {
               setBubble("")
-              transitionTo("standby")
+              applyCurrentState()
             }
           }
           audio.onerror = (errorEvent) => {
@@ -343,11 +442,11 @@ export default function DesktopPetPage() {
         bubbleTimerRef.current = setTimeout(() => {
           if (bubbleId === currentAudioIdRef.current) {
             setBubble("")
-            transitionTo("standby")
+            applyCurrentState()
           }
         }, fallbackMs)
       }
-}
+    }
 
     window.electronAPI?.onBubbleShow?.(handleBubbleShow)
     window.electronAPI?.onSettingsUpdate?.(() => {})
@@ -372,8 +471,11 @@ export default function DesktopPetPage() {
         URL.revokeObjectURL(audioObjectUrlRef.current)
         audioObjectUrlRef.current = null
       }
-}
-  }, [transitionTo])
+      if (sleepTimerRef.current) {
+        clearTimeout(sleepTimerRef.current)
+      }
+    }
+  }, [transitionTo, applyCurrentState, setBaseState, setOverlayState, clearOverlayState, resetSleepTimer])
 
   useEffect(() => {
     const handlePointerMove = (event: globalThis.MouseEvent) => {
@@ -409,6 +511,11 @@ export default function DesktopPetPage() {
       window.removeEventListener("mouseleave", handleWindowLeave as EventListener)
     }
   }, [])
+
+  // Start sleep timer on mount
+  useEffect(() => {
+    resetSleepTimer()
+  }, [resetSleepTimer])
 
   const openChatPanel = () => {
     try {

--- a/clawpet-frontend/clawpet/electron.d.ts
+++ b/clawpet-frontend/clawpet/electron.d.ts
@@ -10,7 +10,8 @@ declare global {
     audio?: string
     duration_ms?: number
     persist?: boolean      // set animation as overlay, no auto-revert
-    clearOverlay?: boolean // clear current overlay, restore base state
+    clearOverlay?: boolean // clear ALL overlays, restore base state
+    popOverlay?: boolean   // pop top overlay only (e.g. drag ended, restore previous overlay)
   }
 
   interface Window {

--- a/clawpet-frontend/clawpet/electron.d.ts
+++ b/clawpet-frontend/clawpet/electron.d.ts
@@ -9,6 +9,8 @@ declare global {
     animationHints?: string[]
     audio?: string
     duration_ms?: number
+    persist?: boolean      // set animation as overlay, no auto-revert
+    clearOverlay?: boolean // clear current overlay, restore base state
   }
 
   interface Window {

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -1395,9 +1395,9 @@ function createPetWindow() {
     petDragActive = false;
     schedulePetTopClamp(40);
     syncBubbleWindowToPet({ show: bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible() });
-    // Restore whatever state was active before dragging started
+    // Restore previous overlay (think/search) if one was active before drag started
     if (petWindow && !petWindow.isDestroyed()) {
-      petWindow.webContents.send('bubble-show', { text: null, emotion: '', clearOverlay: true });
+      petWindow.webContents.send('bubble-show', { text: null, emotion: '', popOverlay: true });
     }
   });
 
@@ -2052,8 +2052,8 @@ ipcMain.on('show-bubble', (_event, data) => {
   const text = typeof data?.text === 'string' ? data.text.trim() : '';
   const emotion = typeof data?.emotion === 'string' ? data.emotion.trim() : '';
   const animation = typeof data?.animation === 'string' ? data.animation.trim() : '';
-  const isPetOverlay = data?.persist === true || data?.clearOverlay === true;
-  const fingerprint = `${audio}|${text}|${emotion}|${animation}|${data?.clearOverlay ? '1' : ''}`;
+  const isPetOverlay = data?.persist === true || data?.clearOverlay === true || data?.popOverlay === true;
+  const fingerprint = `${audio}|${text}|${emotion}|${animation}|${data?.clearOverlay ? '1' : ''}|${data?.popOverlay ? '1' : ''}`;
   const now = Date.now();
   const hasDetachedBubbleWindow = bubbleWindow && !bubbleWindow.isDestroyed();
 

--- a/clawpet-frontend/clawpet/electron/main.js
+++ b/clawpet-frontend/clawpet/electron/main.js
@@ -1365,6 +1365,10 @@ function createPetWindow() {
       return;
     }
 
+    if (!petDragActive) {
+      // Send move animation directly to pet window, bypassing show-bubble dedup
+      petWindow.webContents.send('bubble-show', { text: null, animation: 'move', emotion: '', persist: true });
+    }
     petDragActive = true;
     clearPetTopCorrectionTimer();
 
@@ -1391,6 +1395,10 @@ function createPetWindow() {
     petDragActive = false;
     schedulePetTopClamp(40);
     syncBubbleWindowToPet({ show: bubbleWindow && !bubbleWindow.isDestroyed() && bubbleWindow.isVisible() });
+    // Restore whatever state was active before dragging started
+    if (petWindow && !petWindow.isDestroyed()) {
+      petWindow.webContents.send('bubble-show', { text: null, emotion: '', clearOverlay: true });
+    }
   });
 
   petWindow.on('move', () => {
@@ -2044,19 +2052,26 @@ ipcMain.on('show-bubble', (_event, data) => {
   const text = typeof data?.text === 'string' ? data.text.trim() : '';
   const emotion = typeof data?.emotion === 'string' ? data.emotion.trim() : '';
   const animation = typeof data?.animation === 'string' ? data.animation.trim() : '';
-  const fingerprint = `${audio}|${text}|${emotion}|${animation}`;
+  const isPetOverlay = data?.persist === true || data?.clearOverlay === true;
+  const fingerprint = `${audio}|${text}|${emotion}|${animation}|${data?.clearOverlay ? '1' : ''}`;
   const now = Date.now();
   const hasDetachedBubbleWindow = bubbleWindow && !bubbleWindow.isDestroyed();
 
-  if (fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {
+  // Pet overlay signals (persist/clearOverlay) always pass through — don't dedup them
+  if (!isPetOverlay && fingerprint && fingerprint === lastBubbleFingerprint && now - lastBubbleAt < 2500) {
     logToFile('[IPC] show-bubble dropped duplicated payload');
     return;
+  }
+
+  if (isPetOverlay) {
+    logToFile(`[IPC] show-bubble pet-overlay: animation=${animation} persist=${data?.persist} clearOverlay=${data?.clearOverlay}`);
   }
 
   lastBubbleFingerprint = fingerprint;
   lastBubbleAt = now;
 
   if (!hasDetachedBubbleWindow && petWindow && !petWindow.isDestroyed()) {
+    logToFile(`[IPC] forwarding bubble-show to petWindow: animation=${animation} persist=${data?.persist}`);
     petWindow.webContents.send('bubble-show', data);
   }
 

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -1373,7 +1373,9 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         wsRef.current.send(outbound, activeSessionIdRef.current)
         window.electronAPI?.showBubble?.({ text: null, animation: "think" })
       } catch (err) {
+        window.electronAPI?.showBubble?.({ text: null, emotion: '', clearOverlay: true } as BubblePayload)
         assistantTurnActiveRef.current = false
+        isToolBusyRef.current = false
         setIsTyping(false)
         setIsTurnActive(false)
         setToolStatus("idle")

--- a/clawpet-frontend/clawpet/hooks/use-chat.ts
+++ b/clawpet-frontend/clawpet/hooks/use-chat.ts
@@ -487,6 +487,7 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
   })
   const lastAssistantTextRef = useRef("")
   const assistantTurnActiveRef = useRef(false)
+  const isToolBusyRef = useRef(false)
   const lastEmotionRef = useRef("neutral")
   const lastActionRef = useRef("")
   const lastPlayedAudioRef = useRef<{ value: string; at: number }>({
@@ -1028,11 +1029,18 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
       })
     }
 
+    const sendPetOverlay = (data: { animation?: string; persist?: boolean; clearOverlay?: boolean }) => {
+      console.log('[petclaw:sendPetOverlay]', data)
+      window.electronAPI?.showBubble?.({ text: null, emotion: '', ...data } as BubblePayload)
+    }
+
     const endAssistantTurn = () => {
       assistantTurnActiveRef.current = false
+      isToolBusyRef.current = false
       setIsTyping(false)
       setIsTurnActive(false)
       setToolStatus("idle")
+      sendPetOverlay({ clearOverlay: true })
     }
 
     const beginOrKeepAssistantTurn = () => {
@@ -1144,7 +1152,9 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
               typeof event.data === "string" ? event.data === "true" : true
             if (typing) {
               beginOrKeepAssistantTurn()
-              window.electronAPI?.showBubble?.({ text: null, animation: "think" })
+              if (!isToolBusyRef.current) {
+                sendPetOverlay({ animation: "think", persist: true })
+              }
             } else {
               finalizeStreamingAssistantMessages()
               endAssistantTurn()
@@ -1155,7 +1165,15 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         case "tool_status": {
           const data = (event.data || {}) as ToolStatusEventData
           const status = data.status || "busy"
-          if (status === "busy" || status === "done" || status === "error") {
+          if (status === "busy") {
+            isToolBusyRef.current = true
+            sendPetOverlay({ animation: "search", persist: true })
+            beginOrKeepAssistantTurn()
+            setToolStatus(status)
+          } else if (status === "done" || status === "error") {
+            isToolBusyRef.current = false
+            // Tool finished; LLM is still processing — revert to think
+            sendPetOverlay({ animation: "think", persist: true })
             beginOrKeepAssistantTurn()
             setToolStatus(status)
           }
@@ -1348,6 +1366,9 @@ export function useChat(options: UseChatOptions = {}): UseChatResult {
         setIsTurnActive(true)
         setToolStatus("idle")
         setError(null)
+
+        // Trigger think animation in sync with the blinking dot
+        window.electronAPI?.showBubble?.({ text: null, emotion: '', animation: 'think', persist: true } as BubblePayload)
 
         wsRef.current.send(outbound, activeSessionIdRef.current)
         window.electronAPI?.showBubble?.({ text: null, animation: "think" })


### PR DESCRIPTION
## 功能概述

  为桌宠添加 4 个新动画，并重构动画状态系统，解决原有实现中多个动画并发时相互抢占、无法正确回退的问题。

  ---

  ## 新增动画

  | 动画文件 | 状态名 | 触发时机 |
  |---|---|---|
  | `think.gif` | `think` | 用户发送消息后、等待大模型回复期间（与对话框闪烁点同步） |
  | `search.gif` | `search` | 大模型调用工具（tool call）执行期间 |
  | `move.gif` | `move` | 用户拖动桌宠窗口时 |
  | `sleep.gif` | `sleep` | 连续 5 分钟无任何交互时自动进入 |

  所有 GIF 文件存放于 `clawpet-frontend/clawpet/public/pets/`。

  ---

  ## 改动文件

  ### 1. `public/pets/`（新增 4 个 GIF）
  `think.gif`、`search.gif`、`move.gif`、`sleep.gif`

  ### 2. `electron.d.ts`
  `BubblePayload` 接口新增两个字段：
  - `persist?: boolean` — 设为 overlay（持久覆盖层），不自动回退
  - `clearOverlay?: boolean` — 清除当前 overlay，恢复基础状态

  ### 3. `app/desktop-pet/page.tsx`（核心重构）

  **引入 base/overlay 双层状态模型：**
  - `baseState`（基础层）：standby、sleep — 无交互时的默认状态
  - `overlayState`（覆盖层）：think、search、move — 有优先级的临时状态

  **优先级顺序（高覆盖低）：**
  move(6) > search(5) > think(4) > 情绪动画(3) > standby(2) > sleep(0)

  **修复旧问题：** 原来 `audio.onended` 和 fallback timer 硬编码回 `standby`，会把 think/search 等过程态打断。现改为
  `applyCurrentState()`，正确恢复到当前 overlay 或 base。

  ### 4. `hooks/use-chat.ts`

  - `sendMessage`：发送消息时立即触发 `think` overlay，与对话框闪烁点同步
  - `tool_status=busy`：工具调用开始时覆盖为 `search`（优先级高于 think）
  - `tool_status=done/error`：工具完成后恢复 `think`（大模型仍在处理）
  - `endAssistantTurn()`：收到完整回复时发送 `clearOverlay`，清除所有过程态

  ### 5. `electron/main.js`

  - `will-move` 事件：拖动开始时发送 `move` overlay 到桌宠窗口
  - `moved` 事件：拖动结束后发送 `clearOverlay`，恢复拖动前状态
  - `show-bubble` 去重逻辑修复：`persist/clearOverlay` 信号绕过 2500ms 去重窗口

  ---

  ## 测试方式

  | 场景 | 预期动画 |
  |---|---|
  | 发送一条消息，等待回复 | 立即播放 think.gif，收到回复后停止 |
  | 发送触发工具调用的消息 | think → search（执行中）→ think（整理结果）→ 停止 |
  | 发送一条消息，等待回复 | 立即播放 think.gif，收到回复后停止 |
  | 发送触发工具调用的消息 | think → search（执行中）→ think（整理结果）→ 停止 |
  | 按住桌宠拖动 | 播放 move.gif，松手后恢复 |
  | 5 分钟不操作 | 自动切到 sleep.gif |